### PR TITLE
Issue/241 ggforest alignment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,13 @@
 Package: survminer
 Type: Package
 Title: Drawing Survival Curves using 'ggplot2'
-Version: 0.4.0.999
+Version: 0.4.0.9999
 Date: 2017-06-07
 Authors@R: c(
     person("Alboukadel", "Kassambara", role = c("aut", "cre"), email = "alboukadel.kassambara@gmail.com"),
     person("Marcin", "Kosinski", role = c("aut"), email = "m.p.kosinski@@gmail.com"),
-    person("Przemyslaw", "Biecek", role = c("ctb"), email = "przemyslaw.biecek@gmail.com")
-    )
+    person("Przemyslaw", "Biecek", role = c("ctb"), email = "przemyslaw.biecek@gmail.com"),
+    person("Scheipl", "Fabian", role = c("ctb"), email = "fabian.scheipl@gmail.com"))
 Description: Contains the function 'ggsurvplot()' for drawing easily beautiful
     and 'ready-to-publish' survival curves with the 'number at risk' table
     and 'censoring count plot'. Other functions are also available to plot 

--- a/man/ggforest.Rd
+++ b/man/ggforest.Rd
@@ -24,7 +24,7 @@ will be extracted from 'fit' object.}
 \item{noDigits}{number of digits for estimates and p-values in the plot.}
 }
 \value{
-return an grid object
+returns a ggplot2 object (invisibly)
 }
 \description{
 Drawing Forest Plot for Cox proportional hazards model. In two panels the model structure is presented.
@@ -35,10 +35,18 @@ model <- coxph( Surv(time, status) ~ sex + rx + adhere,
                 data = colon )
 ggforest(model)
 
-model <- coxph( Surv(time, status) ~ sex+rx, data = colon )
-ggforest(model)
+colon <- within(colon, {
+  sex <- factor(sex, labels = c("female", "male"))
+  differ <- factor(differ, labels = c("well", "moderate", "poor"))
+  extent <- factor(extent, labels = c("submuc.", "muscle", "serosa", "contig."))
+})
+bigmodel <-
+  coxph(Surv(time, status) ~ sex + rx + adhere + differ + extent + node4,
+    data = colon )
+ggforest(bigmodel)
 
 }
 \author{
-Przemyslaw Biecek, \email{przemyslaw.biecek@gmail.com}
+Przemyslaw Biecek (\email{przemyslaw.biecek@gmail.com}),
+  Fabian Scheipl (\email{fabian.scheipl@gmail.com})
 }


### PR DESCRIPTION
Fixes #241 --  `ggforest` no longer tries to bolt a table fulll of text to the coefficient plot, instead the annotations are done via `ggplot2::annotate`, see example below

Thx for the great package

```r
setwd("~/survminer")
library("devtools")
library("survival")

colon <- within(colon, {
  sex <- factor(sex, labels = c("female", "male"))
  differ <- factor(differ, labels = c("well", "moderate", "poor"))
  extent <- factor(extent, labels = c("submuc.", "muscle", "serosa", "contig."))
  })
bigmodel <- coxph( Surv(time, status) ~ sex + rx + adhere + differ + extent + node4,
  data = colon )

# old version:
system("git checkout master")
load_all(".")
ggforest(bigmodel)
```
![image](https://user-images.githubusercontent.com/998541/32795154-2c08795c-c96b-11e7-8cca-3740940d0a22.png)

```r
#new version:
system("git checkout issue/241")
load_all(".")
ggforest(bigmodel)
```
![image](https://user-images.githubusercontent.com/998541/32795173-3a431914-c96b-11e7-8407-3d27e85966b3.png)
