### PR TITLE
Custom control over survplot and table font separately

### DIFF
--- a/R/ggsurvplot_core.R
+++ b/R/ggsurvplot_core.R
@@ -23,6 +23,8 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
                             tables.y.text.col = TRUE,
                             risk.table = FALSE, risk.table.pos = c("out", "in"), risk.table.title = NULL,
                             risk.table.col = tables.col, risk.table.fontsize = fontsize,
+                            risk.table.font.x =  NULL, risk.table.font.y =  NULL,
+                            risk.table.font.tickslab = NULL,
                             risk.table.y.text = tables.y.text,
                             risk.table.y.text.col = tables.y.text.col,
                             risk.table.height = tables.height, surv.plot.height = 0.75,
@@ -152,6 +154,12 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
   pms$cumevents.title <- cumevents.title
   pms$cumcensor.title <- cumcensor.title
   pms$fontsize <- fontsize
+  pms$font.x <- risk.table.font.x
+  if( ("font.x" %in% names(extra.params)) & is.null(risk.table.font.x)) pms$font.x <- extra.params[["font.x"]]
+  pms$font.y <- risk.table.font.y
+  if( ("font.y" %in% names(extra.params)) & is.null(risk.table.font.y)) pms$font.y <- extra.params[["font.y"]]
+  pms$font.tickslab <- risk.table.font.tickslab
+  if( ("font.tickslab" %in% names(extra.params)) & is.null(risk.table.font.tickslab)) pms$font.tickslab <- extra.params[["font.tickslab"]]
   pms$ggtheme <- ggtheme
   pms$ylab <- pms$legend.title
   pms$tables.theme <- tables.theme

--- a/R/ggsurvtable.R
+++ b/R/ggsurvtable.R
@@ -296,6 +296,8 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
     coord_cartesian(xlim = xlim) +
     labs(title = title, x = xlab, y = ylab, color = legend.title, shape = legend.title)
 
+  p <- p + tables.theme
+
   if (survtable == "risk.table")
     p <- .set_risktable_gpar(p, ...) # For backward compatibility
 
@@ -308,7 +310,7 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
   else p <- p + ggplot2::scale_x_continuous(breaks = times,
                                             trans = "log10", labels = xticklabels)
 
-  p <- p + tables.theme
+
 
   if(!y.text) {
     p <- .set_large_dash_as_ytext(p)


### PR DESCRIPTION
Allow font.x, font.y, and font.tickslab to control the survplot and table and introduce risk.table.font.x, risk.table.font.y, and risk.table.font.tickslab to specify alternative values