### PR TITLE
typo in the formula for weightened log-rank test

### DIFF
--- a/vignettes/Specifiying_weights_in_log-rank_comparisons.Rmd
+++ b/vignettes/Specifiying_weights_in_log-rank_comparisons.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Specifiyng weights in Log-rank comparisons
 author: Marcin Kosinski
-date: "29-01-2017"
+date: "created 29-01-2017, revised 22-08-2018"
 output:
   html_document:
     mathjax:  default
@@ -43,7 +43,7 @@ As it is stated in the literature, the Log-rank test for comparing survival (est
 
 $$LR = \frac{U^2}{V} \sim \chi(1),$$
 
-where $$U = \sum_{i=1}^{T}w_{t_i}(o_{t_i}^A-e_{t_i}^A), \ \ \ \ \ \ \ \ V = Var(U) = \sum_{i=1}^{T}(w_{t_i}^2\frac{n_{t_i}^An_{t_i}^Bd_i(n_{t_i}-o_{t_i})}{n_{t_i}^2(n_{t_i}-1)})$$
+where $$U = \sum_{i=1}^{T}w_{t_i}(o_{t_i}^A-e_{t_i}^A), \ \ \ \ \ \ \ \ V = Var(U) = \sum_{i=1}^{T}(w_{t_i}^2\frac{n_{t_i}^An_{t_i}^Bo_{t_i}(n_{t_i}-o_{t_i})}{n_{t_i}^2(n_{t_i}-1)})$$
 and 
 
 - $t_i$ for $i=1, \dots, T$ are possible event times, 


### PR DESCRIPTION
@kassambara I got an e-mail from 

Thomas B. Heiberg-Iürgensen
Tlf +45 61 77 62 04

Learn2Ski
Medstifter, Learn2Ski
Email info@learn2ski.dk

Knowledge Cube
Student Developer, Knowledge Cube
Email tbh@knowledgecube.net

The IT-University of Copenhagen
Assistant Teacher, The IT-University of Copenhagen
Email thbh@itu.dk

asking about
![whatisdi 1](https://user-images.githubusercontent.com/6773454/44468027-985c0100-a624-11e8-898e-fd7cd56929a9.png)
in the formula at this article https://t.co/apWVJu5f1L

I have figure out this was a typo and updated the formula. Thanks for merging.
