### PR TITLE
make panel.labs tibble compatible

### DIFF
--- a/R/ggsurvplot_facet.R
+++ b/R/ggsurvplot_facet.R
@@ -94,9 +94,9 @@ ggsurvplot_facet <- function(fit, data, facet.by,
   if(!is.null(panel.labs)){
     for(.grouping.var in facet.by){
       if(!is.null(panel.labs[[.grouping.var]])){
-        if(!is.factor(data[, .grouping.var]))
-          data[, .grouping.var] <- as.factor(data[, .grouping.var])
-        levels(data[, .grouping.var]) <- panel.labs[[.grouping.var]]
+        if(!is.factor(data[[.grouping.var]]))
+          data[[.grouping.var]] <- as.factor(data[[.grouping.var]])
+        levels(data[[.grouping.var]]) <- panel.labs[[.grouping.var]]
       }
     }
   }


### PR DESCRIPTION
In case the `data` variable is of class `tbl_df` the syntax `data[, .grouping.var]` always returns a `tbl_df` object. `data[[.grouping.var]]` returns the column vector both for `data.frame`s and `tbl_df`s.