### PR TITLE
Update ggcoxdiagnostics.R, fix for ox.scale = "time" and  non unique eventtimes

### DIFF
--- a/R/ggcoxdiagnostics.R
+++ b/R/ggcoxdiagnostics.R
@@ -69,7 +69,9 @@ ggcoxdiagnostics <- function (fit,
     stop("Can't handle an object of class ", class(fit))
   type <- match.arg(type)
 
-  res <- as.data.frame(resid(fit, type = type))
+  # raw_res needed for eventimes, when ox.scale = time and there are non-unique eventtimes
+  raw_res <- resid(fit, type = type)
+  res <- as.data.frame(raw_res)
   .facet <- FALSE
 
   xlabel <- "The index number of observations"
@@ -89,7 +91,8 @@ ggcoxdiagnostics <- function (fit,
          time = {
            if (!(type %in% c("schoenfeld", "scaledsch")))
              warning("ox.scale='time' works only with type=schoenfeld/scaledsch")
-           xval <- as.numeric(rownames(res))
+           xval <- as.numeric(rownames(raw_res)) # see comment raw_res
+           raw_res <- NULL # no longer needed and potentially large
            xlabel <- "Time"
          },
          {warning("ox.scale should be one of linear.predictions/observation.id/time")})


### PR DESCRIPTION
I hope this is the correct place for this, as this is my first time really using Github. 

Pleasantries first: This is a wonderful package and i'm very thankful for having it.

## The issue 

The following Code produces empty plots:
```
library("survival")
library("survminer")
fit <- coxph(Surv(time, status) ~sex + age, data = lung)
ggcoxdiagnostics(fit, type = "schoenfeld", ox.scale = "time")
```
also it generates the following warning:
```
 Warning messages:
1: In ggcoxdiagnostics(fit, type = "schoenfeld", ox.scale = "time") :`
  NAs introduced by coercion
2: Removed 330 rows containing non-finite values (stat_smooth). 
3: Removed 330 rows containing missing values (geom_point).
```
I could not find an issue for this problem, but it  was also described here:
https://community.rstudio.com/t/ggcoxdiagnostics-warning-message/51867

## My understanding of the problem and my solution

The introduction of NAs by Coercion happens in current line 92
```
xval <- as.numeric(rownames(res))
```

with res being defined by

```
res <- as.data.frame(resid(fit, type = type))
```

While `resid(fit, type = type)` returns an object with rownames that correspond to the sorted event-times, if the rownames are not unique the casting  to data.frame will make them:
```
raw_res <- resid(fit, type = "schoenfeld")
res <- as.data.frame(raw_res)
rownames(raw_res)[1:4]
rownames(res)[1:4]
```
The rownames of the data.frame then can't be converted to numeric. My Solution is to just keep the initial result `raw_res <- resid(fit, type = "schoenfeld")` to initiate xval.

