### PR TITLE
CRAN Check Failure for Upcoming broom Release

### DIFF
--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -42,7 +42,7 @@ ggforest <- function(model, data = NULL,
   main = "Hazard ratio", cpositions=c(0.02, 0.22, 0.4),
   fontsize = 0.7, refLabel = "reference", noDigits=2) {
   conf.high <- conf.low <- estimate <- NULL
-  stopifnot(class(model) == "coxph")
+  stopifnot(inherits(model, "coxph"))
 
   # get data and variables/terms from cox model
   data  <- .get_data(model, data = data)
@@ -52,7 +52,7 @@ ggforest <- function(model, data = NULL,
 #    gsub(rownames(anova(model))[-1], pattern = "`", replacement = ""))]
 
   # use broom to get some required statistics
-  coef <- as.data.frame(tidy(model))
+  coef <- as.data.frame(tidy(model, conf.int = TRUE))
   gmodel <- glance(model)
 
   # extract statistics for every variable


### PR DESCRIPTION
Hi there! The broom dev team just ran reverse dependency checks on the upcoming broom 0.7.0 release and found new errors/test failures for the CRAN version of this package. I've pasted the results below, which result from changes to the default `conf.int` argument in `tidy.coxph`. 

## Newly broken

*   checking examples ... ERROR
    ```
    Running examples in ‘survminer-Ex.R’ failed
    The error most likely occurred in:
    
    > ### Name: ggforest
    > ### Title: Forest Plot for Cox Proportional Hazards Model
    > ### Aliases: ggforest
    > 
    > ### ** Examples
    > 
    > require("survival")
    Loading required package: survival
    > model <- coxph( Surv(time, status) ~ sex + rx + adhere,
    +                 data = colon )
    > ggforest(model)
    Warning in .get_data(model, data = data) :
      The `data` argument is not provided. Data will be extracted from model fit.
    Error in `[.data.frame`(cbind(allTermsDF, coef[inds, ]), , c("var", "level",  : 
      undefined columns selected
    Calls: ggforest -> [ -> [.data.frame
    Execution halted
    ```

## In both

*   checking installed package size ... NOTE
    ```
      installed size is  5.2Mb
      sub-directories of 1Mb or more:
        doc   4.8Mb
    ```

The changes in this PR correct the new errors by explicitly setting `conf.int = TRUE` in the call to `tidy.coxph`.

We hope to submit this new version of the package to CRAN in the coming weeks. Hopeful that these fixes make getting a new version up on CRAN in the meantime easier. :-)

By the way, super neat package! Really interesting graphic coming out of that `ggforest()` function.