### PR TITLE
Fix Bug in ggcompetingrisks.cuminc

### DIFF
--- a/R/ggcompetingrisks.R
+++ b/R/ggcompetingrisks.R
@@ -89,7 +89,7 @@ ggcompetingrisks.cuminc <- function(fit, gnames = NULL, gsep=" ",
   if (multiple_panels) {
     pl <- ggplot(df, aes(time, est, color=event)) + facet_wrap(~group)
   } else {
-    pl <- ggplot(df, aes(time, est, color=event, linetype=group))
+    pl <- ggplot(df, aes(time, est, color=event, linetype=group, group=interaction(group, event)))
   }
   if (conf.int) {
     pl <- pl + geom_ribbon(aes(ymin = est - coef*std, ymax=est + coef*std, fill = event), alpha = 0.2, linetype=0)


### PR DESCRIPTION
Fix Bug #490 by adding correct group aesthetics to the ggplot-object, when using a single panel, grouping and confidence intervalls.