### PR TITLE
Issue 455 - Alternative to elemnt_text() to support vectorized inputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,13 +32,15 @@ Imports:
     tidyr,
     survMisc,
     purrr,
-    tibble, 
-    rlang
+    tibble,
+    rlang,
+    ggtext (>= 0.1.0)
 Suggests:
     knitr,
     flexsurv,
     cmprsk,
-    markdown
+    markdown,
+    testthat
 VignetteBuilder: knitr
 URL: http://www.sthda.com/english/rpkgs/survminer/
 BugReports: https://github.com/kassambara/survminer/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 
 ## Minor changes
 
+- Since ggplot2 v3.3.0, the function `element_text()` issues a warning when vectorized arguments are provided, as in colour = c("red", "green", "blue"). This is a breaking change affecting the function `ggsurvtable()`. To fix this, the function `ggtext::element_markdown()` is now used in place of `element_text()` to handle vectorized colors (issue #455).
+
 ## Bug fixes
 
 

--- a/R/ggsurvtable.R
+++ b/R/ggsurvtable.R
@@ -245,7 +245,7 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
   #:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   yticklabs <- rev(levels(survsummary$strata))
   n_strata <- length(levels(survsummary$strata))
-  if(!y.text) yticklabs <- rep("-", n_strata)
+  if(!y.text) yticklabs <- rep("\\-", n_strata)
 
   time <- strata <- label <- n.event <- cum.n.event  <- cum.n.censor<- NULL
 

--- a/R/ggsurvtable.R
+++ b/R/ggsurvtable.R
@@ -317,10 +317,10 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
   # Color table tick labels by strata
   if(is.logical(y.text.col) & y.text.col[1] == TRUE){
     cols <- .extract_ggplot_colors(p, grp.levels = legend.labs)
-    p <- p + theme(axis.text.y = element_text(colour = rev(cols)))
+    p <- p + theme(axis.text.y = ggtext::element_markdown(colour = rev(cols)))
   }
   else if(is.character(y.text.col))
-    p <- p + theme(axis.text.y = element_text(colour = rev(y.text.col)))
+    p <- p + theme(axis.text.y = ggtext::element_markdown(colour = rev(y.text.col)))
 
   p
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -239,7 +239,7 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
 # This is used for tables under the main survival plots
 #
 .set_large_dash_as_ytext <- function(ggp){
-  ggp + theme(axis.text.y = element_text(size = 50, vjust = 0.35),
+  ggp + theme(axis.text.y = ggtext::element_markdown(size = 50, vjust = 0.5),
         axis.ticks.y = element_blank())
 }
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(survminer)
+
+test_check("survminer")

--- a/tests/testthat/test-ggsurvtable.R
+++ b/tests/testthat/test-ggsurvtable.R
@@ -1,0 +1,16 @@
+context("test-ggsurvtable")
+
+library(dplyr)
+library("survival")
+data("lung")
+fit <- survfit(Surv(time, status) ~ sex, data = lung)
+
+test_that("survtable y axis label colors work", {
+  p <- ggrisktable(fit, data = lung, color = "strata")
+  .build <- ggplot_build(p)
+  .build_data <- .build$data[[1]]
+  .table <- .build_data[, c("colour", "y")] %>%
+    dplyr::distinct()
+  expect_equal(.table$colour, c("#F8766D", "#00BFC4"))
+  expect_equal(as.numeric(.table$y), c(2, 1))
+})

--- a/vignettes/Informative_Survival_Plots.Rmd
+++ b/vignettes/Informative_Survival_Plots.Rmd
@@ -45,8 +45,7 @@ After regular installation
 
 ```{r, eval = FALSE}
 install.packages('survminer')
-source("https://bioconductor.org/biocLite.R")
-biocLite("RTCGA.clinical") # data for examples
+BiocManager::install("RTCGA.clinical") # data for examples
 ```
 
 we can create simple estimates of survival curves just after we put `survfit` (survival package) object into `ggsurvplot()` function. Let's have a look at differences in survival times between patients suffering from Ovarian Cancer (*Ovarian serous cystadenocarcinoma*) and patients suffering from Breast Cancer (*Breast invasive carcinoma*), where data were collected by [The Cancer Genome Atlas Project](http://cancergenome.nih.gov/).


### PR DESCRIPTION
Since the release of ggplot2 v3.3.0, the function `element_text()` issues a warning when vectorized arguments are provided, as in colour = c("red", "green", "blue"). This is a breaking change affecting the function `ggsurvtable()`. To fix this, the function `ggtext::element_markdown()` is now used in place of `element_text()` to handle vectorized colors (fix for #455).