### PR TITLE
Fix rounding error in cum.n.event and cum.n.censor when using weighted observations

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -169,9 +169,9 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
     n.risk = round(survsummary$n.risk, digits = decimal.place),
     pct.risk = round(survsummary$n.risk*100/strata_size),
     n.event = round(survsummary$n.event, digits = decimal.place),
-    cum.n.event = unlist(by(survsummary$n.event, strata, cumsum)),
+    cum.n.event = round(unlist(by(survsummary$n.event, strata, cumsum)), digits = decimal.place),
     n.censor = round(survsummary$n.censor, digits = decimal.place),
-    cum.n.censor = unlist(by(survsummary$n.censor, strata, cumsum)),
+    cum.n.censor = round(unlist(by(survsummary$n.censor, strata, cumsum)), digits = decimal.place),
     strata_size = strata_size
   )
 


### PR DESCRIPTION
When plotting weighted data using `ggsurvplot`, and showing cumulative events - the numbers have too many decimal points, which obscure the plot. 

![image](https://user-images.githubusercontent.com/32735496/140325244-45b056c8-91a3-496d-b968-7839282b1f30.png)

This fix should solve [this ](https://github.com/kassambara/survminer/issues/554) issue and is instead of [this ](https://github.com/kassambara/survminer/pull/445) pull request which added (mistakenly) unwanted changes.