### PR TITLE
Update ggforest.R

### DIFF
--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -72,8 +72,10 @@ ggforest <- function(model, data = NULL,
                  pos = seq_along(vars))
     }
   })
+  for (i in 1:length(allTerms)) {
+    colnames(allTerms[[i]]) <- c("var", "level", "N", "pos")
+  }
   allTermsDF <- do.call(rbind, allTerms)
-  colnames(allTermsDF) <- c("var", "level", "N", "pos")
   inds <- apply(allTermsDF[,1:2], 1, paste0, collapse="")
 
   # use broom again to get remaining required statistics


### PR DESCRIPTION
Proposed fix for ggforest. Error was being presented when attempting to run ggforest with coxph model: Error in match.names(clabs, names(xi)) : 
  names do not match previous names

Isolated where column names for allTerms were using variable names, which would prevent rbind from working. By relabeling column names before rbind, ggforest functions as expected. 

R version 4.2.1 (2022-06-23 ucrt)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 10 x64 (build 19044)

Matrix products: default

locale:
[1] LC_COLLATE=English_United States.utf8  LC_CTYPE=English_United States.utf8    LC_MONETARY=English_United States.utf8
[4] LC_NUMERIC=C                           LC_TIME=English_United States.utf8    

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
 [1] ggstatsplot_0.9.4  survminer_0.4.9    ggpubr_0.4.0       survival_3.4-0     modelsummary_1.0.2 summarytools_1.0.1
 [7] SAScii_1.0.1       labelled_2.10.0    forcats_0.5.2      stringr_1.4.1      dplyr_1.0.10       purrr_0.3.5       
[13] readr_2.1.3        tidyr_1.2.1        tibble_3.1.8       ggplot2_3.3.6      tidyverse_1.3.2   
