### PR TITLE
Risk table alignment modifications - possible fix for #302 and #448

### DIFF
--- a/R/ggsurvplot_core.R
+++ b/R/ggsurvplot_core.R
@@ -170,6 +170,7 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
     pms$y.text.col <- risk.table.y.text.col
     pms$fontsize <- risk.table.fontsize
     pms$survtable <- "risk.table"
+    pms$risk.table.pos <- risk.table.pos
     # color risk.table ticks by strata
     if(risk.table.y.text.col) pms$y.text.col <- scurve_cols
     res$table <- risktable <- do.call(ggsurvtable, pms)
@@ -241,6 +242,10 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
     cumevents = cumevents.y.text.col,
     cumcensor = cumcensor.y.text.col
   )
+  x.axis.limits <- list(
+    x.axis.min = xlim[1],
+    x.axis.max = xlim[2]
+  )
 
   # Returning the data used to generate the survival plots
   res$data.survplot <- d
@@ -255,6 +260,7 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
   attr(res, "cumcensor") <- cumcensor
   attr(res, "risk.table.pos") <- risk.table.pos
   attr(res, "axes.offset") <- axes.offset
+  attr(res, "x.axis.limits") <- x.axis.limits
   res
 }
 
@@ -462,14 +468,24 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
   .time <- survplot$data$time
   ymax <- nstrata*0.05
   ymin <- -0.05
-  xmin <- -max(.time)/20
+  x.axis.limits <- attr(ggsurv, "x.axis.limits")
+  xlim.lower <- x.axis.limits$x.axis.min
+  xlim.upper <- x.axis.limits$x.axis.max
+  expansion.lower <- (xlim.upper-xlim.lower)*0.05
+  expansion.upper <- (xlim.upper-xlim.lower)*0.05
 
-  if(!axes.offset){
-    ymin <- -0.02
-    xmin <- -max(.time)/50
+  if (axes.offset) {
+    xmin <- xlim.lower-expansion.lower
+    xmax <- xlim.upper+expansion.upper
+  }
+  else if(!axes.offset){
+    ymin <- 0
+    ymax <- nstrata*0.06
+    xmin <- xlim.lower
+    xmax <- xlim.upper
   }
   risktable_grob = ggplotGrob(risktable)
-  survplot <- survplot + annotation_custom(grob = risktable_grob, xmin = xmin,
+  survplot <- survplot + annotation_custom(grob = risktable_grob, xmin = xmin, xmax = xmax,
                                            ymin = ymin, ymax = ymax)
   ggsurv$plot <- survplot
   ggsurv$table <- NULL


### PR DESCRIPTION
Improvements to alignment of risk table for various combinations of risk.table.pos, axes.offset, and whether or not xlim is specified.

Summary of changes:
1. **ggsurvplot_core()**
- Added x-axis limits to the attr of the ggsurv object, which will be used by the .put_risktable_in_survplot function
- Added risk.table.pos to the pms object, which will be used by the .plot_survtable function

2. **.put_risktable_in_survplot()**
- This function now has access to the x axis limits via the attr added in (1) above
- Where axes.offset=TRUE, xmin and xmax now allow for the default 5% axis expansion used in scale_x_continuous.
- Where axes.offset=FALSE, xmin and xmax are set without this 5% expansion
- Additionally where axes.offset=FALSE, minor improvement applied to the vertical position of the risk table values via change to ymin and ymax

3. **.plot_survtable()**
- This function now has access to the risk.table.pos value
- Where axes.offset=FALSE, the "offset" from the origin is set to zero to align values with the y-axis.
- clip='off' prevents the first value on the risk table being cropped
- Where risk.table.pos="out" and axes.offset=FALSE, theme elements are updated to (i) make a margin between the strata labels and the first risk table value, and (ii) to remove elements that would obscure the risk table value such as the y-axis, y ticks, and border.

```
# Compare before and after
fit <- survfit(Surv(time, status) ~ sex, data = lung)

# Example 1 
ggsurvplot(fit,
           data = lung,
           break.time.by = 100,
           risk.table = TRUE,
           risk.table.pos = "out",
           axes.offset=F,
           xlim=c(0,1020),
           ggtheme = theme_classic())

# Example 2
ggsurvplot(fit,
           data = lung,
           break.time.by = 100,
           risk.table = TRUE,
           risk.table.pos = "in",
           xlim=c(0,520),
           ggtheme = theme_classic())

# Example 3
ggsurvplot(fit,
           data = lung,
           break.time.by = 100,
           risk.table = TRUE,
           risk.table.pos = "in",
           axes.offset=F,
           xlim=c(0,1020),
           ggtheme = theme_classic())
```

Results example 1:
![image](https://github.com/kassambara/survminer/assets/121236675/3fb0ab31-fde0-4db4-90b2-4a1cbd7dd162)

Results example 2:
![image](https://github.com/kassambara/survminer/assets/121236675/51c28840-00d9-486b-8a4f-21697c260654)

Results example 3:
![image](https://github.com/kassambara/survminer/assets/121236675/c69725d3-7609-41fb-a50a-d7b60fa056dd)
