### PR TITLE
Fix Rd cross-references

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,9 +43,9 @@ Suggests:
     testthat,
     rmarkdown
 VignetteBuilder: knitr
-URL:  https://rpkgs.datanovia.com/survminer/index.html
+URL: https://rpkgs.datanovia.com/survminer/index.html
 BugReports: https://github.com/kassambara/survminer/issues
-RoxygenNote: 7.1.1
+RoxygenNote: 7.3.2
 Collate: 
     'BMT.R'
     'BRCAOV.survInfo.R'

--- a/R/ggadjustedcurves.R
+++ b/R/ggadjustedcurves.R
@@ -24,7 +24,7 @@ NULL
 #' Note that \code{surv_adjustedcurves} function calculates survival curves and based on this function one can calculate median survival.
 #'
 #'@inheritParams ggsurvplot_arguments
-#'@param fit an object of class \link{coxph.object} - created with \link{coxph} function.
+#'@param fit an object of class \link[survival]{coxph.object} - created with \link[survival]{coxph} function.
 #'@param data a dataset for predictions. If not supplied then data will be extracted from the \code{fit} object.
 #'@param reference a dataset for reference population, to which dependent variables should be balanced. If not specified, then the \code{data} will be used instead. Note that the \code{reference} dataset should contain all variables used in \code{fit} object.
 #'@param method a character, describes how the expected survival curves shall be calculated. Possible options:

--- a/R/ggcompetingrisks.R
+++ b/R/ggcompetingrisks.R
@@ -2,7 +2,7 @@
 #' @importFrom survival survfit
 #' @description This function plots Cumulative Incidence Curves. For \code{cuminc} objects it's a \code{ggplot2} version of \code{plot.cuminc}.
 #' For \code{survfitms} objects a different geometry is used, as suggested by \code{@@teigentler}.
-#' @param fit an object of a class \code{cmprsk::cuminc} - created with \code{cmprsk::cuminc} function or \code{survfitms} created with \link{survfit} function.
+#' @param fit an object of a class \code{cmprsk::cuminc} - created with \code{cmprsk::cuminc} function or \code{survfitms} created with \link[survival]{survfit} function.
 #' @param gnames a vector with group names. If not supplied then will be extracted from \code{fit} object (\code{cuminc} only).
 #' @param gsep a separator that extracts group names and event names from \code{gnames} object (\code{cuminc} only).
 #' @param multiple_panels if \code{TRUE} then groups will be plotted in different panels (\code{cuminc} only).

--- a/R/ggcoxdiagnostics.R
+++ b/R/ggcoxdiagnostics.R
@@ -1,9 +1,9 @@
 #'Diagnostic Plots for Cox Proportional Hazards Model with ggplot2
 #'@description Displays diagnostics graphs presenting goodness of Cox Proportional Hazards Model fit, that
-#'can be calculated with \link{coxph} function.
-#'@param fit an object of class \link{coxph.object} - created with \link{coxph} function.
+#'can be calculated with \link[survival]{coxph} function.
+#'@param fit an object of class \link[survival]{coxph.object} - created with \link[survival]{coxph} function.
 #'@param type the type of residuals to present on Y axis of a diagnostic plot.
-#'The same as in \link{residuals.coxph}: character string indicating the type of
+#'The same as in \link[survival]{residuals.coxph}: character string indicating the type of
 #'residual desired. Possible values are \code{"martingale", "deviance", "score", "schoenfeld", "dfbeta", "dfbetas"}
 #' and \code{"scaledsch"}. Only enough of the string to
 #' determine a unique match is required.
@@ -16,9 +16,9 @@
 #'@param ... further arguments passed to \code{\link[survival]{residuals.coxph}} or
 #' to the function \code{\link[ggpubr]{ggpar}} for customizing the plot.
 #'@param point.col,point.size,point.shape,point.alpha color, size, shape and visibility to be used for points.
-#'@param hline.col,hline.size,hline.lty,hline.alpha,hline.yintercept color, size, linetype, visibility and Y-axis coordinate to be used for \link{geom_hline}.
+#'@param hline.col,hline.size,hline.lty,hline.alpha,hline.yintercept color, size, linetype, visibility and Y-axis coordinate to be used for \link[ggplot2]{geom_hline}.
 #'Used only when \code{hline = TRUE}.
-#'@param sline.col,sline.size,sline.lty,sline.alpha color, size, linetype and visibility to be used for \link{geom_smooth}.
+#'@param sline.col,sline.size,sline.lty,sline.alpha color, size, linetype and visibility to be used for \link[ggplot2]{geom_smooth}.
 #'Used only when \code{sline = TRUE}.
 #'@param hline a logical - should the horizontal line be added to highlight the \code{Y=0} level.
 #'@param sline,sline.se a logical - should the smooth line be added to highlight the local average for residuals.

--- a/R/ggcoxfunctional.R
+++ b/R/ggcoxfunctional.R
@@ -8,17 +8,17 @@ NULL
 #' Functional Form of Continuous Variable in Cox Proportional Hazards Model
 #'@description Displays graphs of continuous explanatory variable against martingale residuals of null
 #'cox proportional hazards model, for each term in of the right side of \code{formula}. This might help to properly
-#'choose the functional form of continuous variable in cox model (\link{coxph}). Fitted lines with \link{lowess} function
+#'choose the functional form of continuous variable in cox model (\link[survival]{coxph}). Fitted lines with \link[stats]{lowess} function
 #'should be linear to satisfy cox proportional hazards model assumptions.
-#'@param fit an object of class \link{coxph.object} - created with \link{coxph} function.
-#'@param formula a formula object, with the response on the left of a ~ operator, and the terms on the right. The response must be a survival object as returned by the \link{Surv} function.
+#'@param fit an object of class \link[survival]{coxph.object} - created with \link[survival]{coxph} function.
+#'@param formula a formula object, with the response on the left of a ~ operator, and the terms on the right. The response must be a survival object as returned by the \link[survival]{Surv} function.
 #'@param data a \code{data.frame} in which to interpret the variables named in the formula,
-#'@param iter parameter of \link{lowess}.
-#'@param f parameter of \link{lowess}.
+#'@param iter parameter of \link[stats]{lowess}.
+#'@param f parameter of \link[stats]{lowess}.
 #'@param xlim,ylim x and y axis limits e.g. xlim = c(0, 1000), ylim = c(0, 1).
 #'@param ylab y axis label.
-#'@param title the title of the final \link{grob} (\code{top} in \link{arrangeGrob})
-#'@param caption the caption of the final \link{grob} (\code{bottom} in \link{arrangeGrob})
+#'@param title the title of the final \link[grid]{grob} (\code{top} in \link[gridExtra]{arrangeGrob})
+#'@param caption the caption of the final \link[grid]{grob} (\code{bottom} in \link[gridExtra]{arrangeGrob})
 #'@param point.col,point.size,point.shape,point.alpha color, size, shape and visibility to be used for points.
 #'@param ggtheme function, ggplot2 theme name.
 #'  Allowed values include ggplot2 official themes: see \code{\link[ggplot2]{theme}}.
@@ -104,7 +104,7 @@ ggcoxfunctional <- function (formula, data = NULL, fit, iter = 0, f = 0.6,
 }
 
 #' @param x an object of class ggcoxfunctional
-#' @param newpage open a new page. See \code{\link{grid.arrange}}.
+#' @param newpage open a new page. See \code{\link[gridExtra]{grid.arrange}}.
 #' @method print ggcoxfunctional
 #' @rdname ggcoxfunctional
 #' @export

--- a/R/ggcoxzph.R
+++ b/R/ggcoxzph.R
@@ -1,7 +1,7 @@
 #'Graphical Test of Proportional Hazards with ggplot2
 #'@description Displays a graph of the scaled Schoenfeld residuals, along with a
-#'  smooth curve using \pkg{ggplot2}. Wrapper around \link{plot.cox.zph}.
-#'@param fit an object of class \link{cox.zph}.
+#'  smooth curve using \pkg{ggplot2}. Wrapper around \link[survival]{plot.cox.zph}.
+#'@param fit an object of class \link[survival]{cox.zph}.
 #'@param resid	a logical value, if TRUE the residuals are included on the plot,
 #'  as well as the smooth fit.
 #'@param se a logical value, if TRUE, confidence bands at two standard errors
@@ -12,7 +12,7 @@
 #'@param var the set of variables for which plots are desired. By default, plots
 #'  are produced in turn for each variable of a model.
 #'@param point.col,point.size,point.shape,point.alpha color, size, shape and visibility to be used for points.
-#'@param caption the caption of the final \link{grob} (\code{bottom} in \link{arrangeGrob})
+#'@param caption the caption of the final \link[grid]{grob} (\code{bottom} in \link[gridExtra]{arrangeGrob})
 #'@param ggtheme function, ggplot2 theme name.
 #'  Allowed values include ggplot2 official themes: see \code{\link[ggplot2]{theme}}.
 #'@param ... further arguments passed to either the print() function or to the \code{\link[ggpubr]{ggpar}} function for customizing the plot (see Details section).
@@ -159,7 +159,7 @@ ggcoxzph <- function (fit, resid = TRUE, se = TRUE, df = 4, nsmo = 40, var,
 }
 
 #' @param x an object of class ggcoxzph
-#' @param newpage open a new page. See \code{\link{grid.arrange}}.
+#' @param newpage open a new page. See \code{\link[gridExtra]{grid.arrange}}.
 #' @method print ggcoxzph
 #' @rdname ggcoxzph
 #' @export

--- a/R/ggsurvevents.R
+++ b/R/ggsurvevents.R
@@ -1,7 +1,7 @@
 #' Distribution of Events' Times
 #'
-#' @param surv an object of \link{Surv}. If not suplied, the censoring variable is extracted from the model.
-#' @param fit an object of class \link{survfit}.
+#' @param surv an object of \link[survival]{Surv}. If not suplied, the censoring variable is extracted from the model.
+#' @param fit an object of class \link[survival]{survfit}.
 #' @param data a dataset for predictions. If not supplied then data will be extracted from `fit` object.
 #' @param type one of \code{c("cumulative", "radius", "fraction")}. \code{"cumulative"} stands for cumulative number of events, \code{"radius"} stands for number of events within a given radius,
 #' @param normalized if \code{TRUE} relative number of events is presented,

--- a/R/ggsurvplot.R
+++ b/R/ggsurvplot.R
@@ -417,7 +417,7 @@ ggsurvplot <- function(fit, data = NULL, fun = NULL,
 
 #' @param x an object of class ggsurvplot
 #' @method print ggsurvplot
-#' @param newpage open a new page. See \code{\link{grid.arrange}}
+#' @param newpage open a new page. See \code{\link[gridExtra]{grid.arrange}}
 #' @rdname ggsurvplot
 #' @export
 print.ggsurvplot <- function(x, surv.plot.height = NULL, risk.table.height = NULL, ncensor.plot.height = NULL, newpage = TRUE, ...){

--- a/R/ggurvplot_arguments.R
+++ b/R/ggurvplot_arguments.R
@@ -59,8 +59,11 @@
 #'@param pval.size numeric value specifying the p-value text size. Default is 5.
 #'@param pval.coord numeric vector, of length 2, specifying the x and y
 #'  coordinates of the p-value. Default values are NULL.
-#'@param title,xlab,ylab main title and axis labels
-#'@param xlim,ylim x and y axis limits e.g. xlim = c(0, 1000), ylim = c(0, 1).
+#'@param title main title
+#'@param xlab x axis label
+#'@param ylab y axis label
+#'@param xlim x axis limits e.g. \code{xlim = c(0, 1000)}.
+#'@param ylim y axis limits e.g. \code{xlim = c(0, 1)}.
 #'@param axes.offset logical value. Default is TRUE. If FALSE, set the plot axes
 #'  to start at the origin.
 #'@param legend character specifying legend position. Allowed values are one of

--- a/R/surv_cutpoint.R
+++ b/R/surv_cutpoint.R
@@ -181,8 +181,7 @@ print.surv_cutpoint <- function(x, ...){
 
 
 #' @param ggtheme function, ggplot2 theme name. Default value is
-#'   \link[ggplot2]{theme_classic}. Allowed values include ggplot2 official themes. see
-#'   ?ggplot2::ggtheme.
+#'   \link[ggplot2]{theme_classic}. Allowed values include ggplot2 official themes. See \code{\link[ggplot2]{theme}()}.
 #' @param bins Number of bins for histogram. Defaults to 30.
 #' @method plot surv_cutpoint
 #' @rdname surv_cutpoint

--- a/R/surv_cutpoint.R
+++ b/R/surv_cutpoint.R
@@ -181,7 +181,7 @@ print.surv_cutpoint <- function(x, ...){
 
 
 #' @param ggtheme function, ggplot2 theme name. Default value is
-#'   \link{theme_classic}. Allowed values include ggplot2 official themes. see
+#'   \link[ggplot2]{theme_classic}. Allowed values include ggplot2 official themes. see
 #'   ?ggplot2::ggtheme.
 #' @param bins Number of bins for histogram. Defaults to 30.
 #' @method plot surv_cutpoint
@@ -240,7 +240,7 @@ plot.surv_cutpoint <- function(x, variables = NULL, ggtheme = theme_classic(), b
   p
 }
 
-#' @param newpage open a new page. See \code{\link{grid.arrange}}.
+#' @param newpage open a new page. See \code{\link[gridExtra]{grid.arrange}}.
 #' @method print plot_surv_cutpoint
 #' @rdname surv_cutpoint
 #' @export

--- a/man/ggadjustedcurves.Rd
+++ b/man/ggadjustedcurves.Rd
@@ -30,7 +30,7 @@ surv_adjustedcurves(
 )
 }
 \arguments{
-\item{fit}{an object of class \link{coxph.object} - created with \link{coxph} function.}
+\item{fit}{an object of class \link[survival]{coxph.object} - created with \link[survival]{coxph} function.}
 
 \item{variable}{a character, name of the grouping variable to be plotted. If not supplied then it will be extracted from the model formula from the \code{strata()} component. If there is no \code{strata()} component then only a single curve will be plotted - average for the thole population.}
 

--- a/man/ggcompetingrisks.Rd
+++ b/man/ggcompetingrisks.Rd
@@ -16,7 +16,7 @@ ggcompetingrisks(
 )
 }
 \arguments{
-\item{fit}{an object of a class \code{cmprsk::cuminc} - created with \code{cmprsk::cuminc} function or \code{survfitms} created with \link{survfit} function.}
+\item{fit}{an object of a class \code{cmprsk::cuminc} - created with \code{cmprsk::cuminc} function or \code{survfitms} created with \link[survival]{survfit} function.}
 
 \item{gnames}{a vector with group names. If not supplied then will be extracted from \code{fit} object (\code{cuminc} only).}
 

--- a/man/ggcoxdiagnostics.Rd
+++ b/man/ggcoxdiagnostics.Rd
@@ -79,9 +79,9 @@ can be calculated with \link{coxph} function.
 }
 \section{Functions}{
 \itemize{
-\item \code{ggcoxdiagnostics}: Diagnostic Plots for Cox Proportional Hazards Model with \pkg{ggplot2}
-}}
+\item \code{ggcoxdiagnostics()}: Diagnostic Plots for Cox Proportional Hazards Model with \pkg{ggplot2}
 
+}}
 \examples{
 
 library(survival)

--- a/man/ggcoxdiagnostics.Rd
+++ b/man/ggcoxdiagnostics.Rd
@@ -34,10 +34,10 @@ ggcoxdiagnostics(
 )
 }
 \arguments{
-\item{fit}{an object of class \link{coxph.object} - created with \link{coxph} function.}
+\item{fit}{an object of class \link[survival]{coxph.object} - created with \link[survival]{coxph} function.}
 
 \item{type}{the type of residuals to present on Y axis of a diagnostic plot.
-The same as in \link{residuals.coxph}: character string indicating the type of
+The same as in \link[survival]{residuals.coxph}: character string indicating the type of
 residual desired. Possible values are \code{"martingale", "deviance", "score", "schoenfeld", "dfbeta", "dfbetas"}
 and \code{"scaledsch"}. Only enough of the string to
 determine a unique match is required.}
@@ -57,10 +57,10 @@ Id of an observation for \code{"observation.id"} or Time for \code{"time"}.}
 
 \item{sline, sline.se}{a logical - should the smooth line be added to highlight the local average for residuals.}
 
-\item{hline.col, hline.size, hline.lty, hline.alpha, hline.yintercept}{color, size, linetype, visibility and Y-axis coordinate to be used for \link{geom_hline}.
+\item{hline.col, hline.size, hline.lty, hline.alpha, hline.yintercept}{color, size, linetype, visibility and Y-axis coordinate to be used for \link[ggplot2]{geom_hline}.
 Used only when \code{hline = TRUE}.}
 
-\item{sline.col, sline.size, sline.lty, sline.alpha}{color, size, linetype and visibility to be used for \link{geom_smooth}.
+\item{sline.col, sline.size, sline.lty, sline.alpha}{color, size, linetype and visibility to be used for \link[ggplot2]{geom_smooth}.
 Used only when \code{sline = TRUE}.}
 
 \item{point.col, point.size, point.shape, point.alpha}{color, size, shape and visibility to be used for points.}
@@ -75,7 +75,7 @@ Returns an object of class \code{ggplot}.
 }
 \description{
 Displays diagnostics graphs presenting goodness of Cox Proportional Hazards Model fit, that
-can be calculated with \link{coxph} function.
+can be calculated with \link[survival]{coxph} function.
 }
 \section{Functions}{
 \itemize{

--- a/man/ggcoxfunctional.Rd
+++ b/man/ggcoxfunctional.Rd
@@ -27,15 +27,15 @@ ggcoxfunctional(
 \method{print}{ggcoxfunctional}(x, ..., newpage = TRUE)
 }
 \arguments{
-\item{formula}{a formula object, with the response on the left of a ~ operator, and the terms on the right. The response must be a survival object as returned by the \link{Surv} function.}
+\item{formula}{a formula object, with the response on the left of a ~ operator, and the terms on the right. The response must be a survival object as returned by the \link[survival]{Surv} function.}
 
 \item{data}{a \code{data.frame} in which to interpret the variables named in the formula,}
 
-\item{fit}{an object of class \link{coxph.object} - created with \link{coxph} function.}
+\item{fit}{an object of class \link[survival]{coxph.object} - created with \link[survival]{coxph} function.}
 
-\item{iter}{parameter of \link{lowess}.}
+\item{iter}{parameter of \link[stats]{lowess}.}
 
-\item{f}{parameter of \link{lowess}.}
+\item{f}{parameter of \link[stats]{lowess}.}
 
 \item{point.col, point.size, point.shape, point.alpha}{color, size, shape and visibility to be used for points.}
 
@@ -43,9 +43,9 @@ ggcoxfunctional(
 
 \item{ylab}{y axis label.}
 
-\item{title}{the title of the final \link{grob} (\code{top} in \link{arrangeGrob})}
+\item{title}{the title of the final \link[grid]{grob} (\code{top} in \link[gridExtra]{arrangeGrob})}
 
-\item{caption}{the caption of the final \link{grob} (\code{bottom} in \link{arrangeGrob})}
+\item{caption}{the caption of the final \link[grid]{grob} (\code{bottom} in \link[gridExtra]{arrangeGrob})}
 
 \item{ggtheme}{function, ggplot2 theme name.
 Allowed values include ggplot2 official themes: see \code{\link[ggplot2]{theme}}.}
@@ -54,7 +54,7 @@ Allowed values include ggplot2 official themes: see \code{\link[ggplot2]{theme}}
 
 \item{x}{an object of class ggcoxfunctional}
 
-\item{newpage}{open a new page. See \code{\link{grid.arrange}}.}
+\item{newpage}{open a new page. See \code{\link[gridExtra]{grid.arrange}}.}
 }
 \value{
 Returns an object of class \code{ggcoxfunctional} which is a list of ggplots.
@@ -62,7 +62,7 @@ Returns an object of class \code{ggcoxfunctional} which is a list of ggplots.
 \description{
 Displays graphs of continuous explanatory variable against martingale residuals of null
 cox proportional hazards model, for each term in of the right side of \code{formula}. This might help to properly
-choose the functional form of continuous variable in cox model (\link{coxph}). Fitted lines with \link{lowess} function
+choose the functional form of continuous variable in cox model (\link[survival]{coxph}). Fitted lines with \link[stats]{lowess} function
 should be linear to satisfy cox proportional hazards model assumptions.
 }
 \section{Functions}{

--- a/man/ggcoxfunctional.Rd
+++ b/man/ggcoxfunctional.Rd
@@ -67,9 +67,9 @@ should be linear to satisfy cox proportional hazards model assumptions.
 }
 \section{Functions}{
 \itemize{
-\item \code{ggcoxfunctional}: Functional Form of Continuous Variable in Cox Proportional Hazards Model.
-}}
+\item \code{ggcoxfunctional()}: Functional Form of Continuous Variable in Cox Proportional Hazards Model.
 
+}}
 \examples{
 
 library(survival)

--- a/man/ggcoxzph.Rd
+++ b/man/ggcoxzph.Rd
@@ -74,9 +74,9 @@ Displays a graph of the scaled Schoenfeld residuals, along with a
 }
 \section{Functions}{
 \itemize{
-\item \code{ggcoxzph}: Graphical Test of Proportional Hazards using ggplot2.
-}}
+\item \code{ggcoxzph()}: Graphical Test of Proportional Hazards using ggplot2.
 
+}}
 \examples{
 
 library(survival)

--- a/man/ggcoxzph.Rd
+++ b/man/ggcoxzph.Rd
@@ -24,7 +24,7 @@ ggcoxzph(
 \method{print}{ggcoxzph}(x, ..., newpage = TRUE)
 }
 \arguments{
-\item{fit}{an object of class \link{cox.zph}.}
+\item{fit}{an object of class \link[survival]{cox.zph}.}
 
 \item{resid}{a logical value, if TRUE the residuals are included on the plot,
 as well as the smooth fit.}
@@ -42,7 +42,7 @@ are produced in turn for each variable of a model.}
 
 \item{point.col, point.size, point.shape, point.alpha}{color, size, shape and visibility to be used for points.}
 
-\item{caption}{the caption of the final \link{grob} (\code{bottom} in \link{arrangeGrob})}
+\item{caption}{the caption of the final \link[grid]{grob} (\code{bottom} in \link[gridExtra]{arrangeGrob})}
 
 \item{ggtheme}{function, ggplot2 theme name.
 Allowed values include ggplot2 official themes: see \code{\link[ggplot2]{theme}}.}
@@ -51,14 +51,14 @@ Allowed values include ggplot2 official themes: see \code{\link[ggplot2]{theme}}
 
 \item{x}{an object of class ggcoxzph}
 
-\item{newpage}{open a new page. See \code{\link{grid.arrange}}.}
+\item{newpage}{open a new page. See \code{\link[gridExtra]{grid.arrange}}.}
 }
 \value{
 Returns an object of class \code{ggcoxzph} which is a list of ggplots.
 }
 \description{
 Displays a graph of the scaled Schoenfeld residuals, along with a
- smooth curve using \pkg{ggplot2}. Wrapper around \link{plot.cox.zph}.
+ smooth curve using \pkg{ggplot2}. Wrapper around \link[survival]{plot.cox.zph}.
 }
 \details{
 \strong{Customizing the plots}: The plot can be easily

--- a/man/ggsurvevents.Rd
+++ b/man/ggsurvevents.Rd
@@ -17,9 +17,9 @@ ggsurvevents(
 )
 }
 \arguments{
-\item{surv}{an object of \link{Surv}. If not suplied, the censoring variable is extracted from the model.}
+\item{surv}{an object of \link[survival]{Surv}. If not suplied, the censoring variable is extracted from the model.}
 
-\item{fit}{an object of class \link{survfit}.}
+\item{fit}{an object of class \link[survival]{survfit}.}
 
 \item{data}{a dataset for predictions. If not supplied then data will be extracted from `fit` object.}
 

--- a/man/ggsurvplot.Rd
+++ b/man/ggsurvplot.Rd
@@ -153,7 +153,7 @@ risk.table = FALSE.}
 \item{ncensor.plot.height}{The height of the censor plot. Used when
 \code{ncensor.plot = TRUE}.}
 
-\item{newpage}{open a new page. See \code{\link{grid.arrange}}}
+\item{newpage}{open a new page. See \code{\link[gridExtra]{grid.arrange}}}
 }
 \value{
 return an object of class ggsurvplot which is list containing the

--- a/man/ggsurvplot_arguments.Rd
+++ b/man/ggsurvplot_arguments.Rd
@@ -84,9 +84,15 @@ customized string appears on the plot. See examples - Example 3.}
 \item{pval.coord}{numeric vector, of length 2, specifying the x and y
 coordinates of the p-value. Default values are NULL.}
 
-\item{title, xlab, ylab}{main title and axis labels}
+\item{title}{main title}
 
-\item{xlim, ylim}{x and y axis limits e.g. xlim = c(0, 1000), ylim = c(0, 1).}
+\item{xlab}{x axis label}
+
+\item{ylab}{y axis label}
+
+\item{xlim}{x axis limits e.g. \code{xlim = c(0, 1000)}.}
+
+\item{ylim}{y axis limits e.g. \code{xlim = c(0, 1)}.}
 
 \item{axes.offset}{logical value. Default is TRUE. If FALSE, set the plot axes
 to start at the origin.}

--- a/man/ggsurvplot_df.Rd
+++ b/man/ggsurvplot_df.Rd
@@ -111,9 +111,15 @@ censors. Default value is "+" (3), a sensible choice is "|" (124).}
 \item{censor.size}{numveric value specifying the point size of censors.
 Default is 4.5.}
 
-\item{title, xlab, ylab}{main title and axis labels}
+\item{title}{main title}
 
-\item{xlim, ylim}{x and y axis limits e.g. xlim = c(0, 1000), ylim = c(0, 1).}
+\item{xlab}{x axis label}
+
+\item{ylab}{y axis label}
+
+\item{xlim}{x axis limits e.g. \code{xlim = c(0, 1000)}.}
+
+\item{ylim}{y axis limits e.g. \code{xlim = c(0, 1)}.}
 
 \item{axes.offset}{logical value. Default is TRUE. If FALSE, set the plot axes
 to start at the origin.}

--- a/man/ggsurvplot_df.Rd
+++ b/man/ggsurvplot_df.Rd
@@ -111,15 +111,9 @@ censors. Default value is "+" (3), a sensible choice is "|" (124).}
 \item{censor.size}{numveric value specifying the point size of censors.
 Default is 4.5.}
 
-\item{title}{main title and axis labels}
+\item{title, xlab, ylab}{main title and axis labels}
 
-\item{xlab}{main title and axis labels}
-
-\item{ylab}{main title and axis labels}
-
-\item{xlim}{x and y axis limits e.g. xlim = c(0, 1000), ylim = c(0, 1).}
-
-\item{ylim}{x and y axis limits e.g. xlim = c(0, 1000), ylim = c(0, 1).}
+\item{xlim, ylim}{x and y axis limits e.g. xlim = c(0, 1000), ylim = c(0, 1).}
 
 \item{axes.offset}{logical value. Default is TRUE. If FALSE, set the plot axes
 to start at the origin.}

--- a/man/ggsurvtable.Rd
+++ b/man/ggsurvtable.Rd
@@ -97,6 +97,8 @@ function \link[grDevices]{palette}.}
 \item{break.time.by}{numeric value controlling time axis breaks. Default value
 is NULL.}
 
+\item{xlim}{x axis limits e.g. \code{xlim = c(0, 1000)}.}
+
 \item{xscale}{numeric or character value specifying x-axis scale. \itemize{
 \item If numeric, the value is used to divide the labels on the x axis. For
 example, a value of 365.25 will give labels in years instead of the original
@@ -104,6 +106,10 @@ days. \item If character, allowed options include one of c("d_m", "d_y",
 "m_d", "m_y", "y_d", "y_m"), where d = days, m = months and y = years. For
 example, xscale = "d_m" will transform labels from days to months; xscale =
 "m_y", will transform labels from months to years.}}
+
+\item{xlab}{x axis label}
+
+\item{ylab}{y axis label}
 
 \item{xlog}{logical value. If TRUE, x axis is tansformed into log scale.}
 

--- a/man/ggsurvtable.Rd
+++ b/man/ggsurvtable.Rd
@@ -97,8 +97,6 @@ function \link[grDevices]{palette}.}
 \item{break.time.by}{numeric value controlling time axis breaks. Default value
 is NULL.}
 
-\item{xlim}{x and y axis limits e.g. xlim = c(0, 1000), ylim = c(0, 1).}
-
 \item{xscale}{numeric or character value specifying x-axis scale. \itemize{
 \item If numeric, the value is used to divide the labels on the x axis. For
 example, a value of 365.25 will give labels in years instead of the original
@@ -106,10 +104,6 @@ days. \item If character, allowed options include one of c("d_m", "d_y",
 "m_d", "m_y", "y_d", "y_m"), where d = days, m = months and y = years. For
 example, xscale = "d_m" will transform labels from days to months; xscale =
 "m_y", will transform labels from months to years.}}
-
-\item{xlab}{main title and axis labels}
-
-\item{ylab}{main title and axis labels}
 
 \item{xlog}{logical value. If TRUE, x axis is tansformed into log scale.}
 
@@ -163,15 +157,15 @@ Normally, users don't need to use this function directly. Internally used by the
 }
 \section{Functions}{
 \itemize{
-\item \code{ggrisktable}: Plot the number at risk table.
+\item \code{ggrisktable()}: Plot the number at risk table.
 
-\item \code{ggcumevents}: Plot the cumulative number of events table
+\item \code{ggcumevents()}: Plot the cumulative number of events table
 
-\item \code{ggcumcensor}: Plot the cumulative number of censor table
+\item \code{ggcumcensor()}: Plot the cumulative number of censor table
 
-\item \code{ggsurvtable}: Generic function to plot survival tables: risk.table, cumevents and cumcensor
+\item \code{ggsurvtable()}: Generic function to plot survival tables: risk.table, cumevents and cumcensor
+
 }}
-
 \examples{
 # Fit survival curves
 #:::::::::::::::::::::::::::::::::::::::::::::::

--- a/man/ggsurvtheme.Rd
+++ b/man/ggsurvtheme.Rd
@@ -45,13 +45,13 @@ Default theme for plots generated with survminer.
 }
 \section{Functions}{
 \itemize{
-\item \code{theme_survminer}: Default theme for survminer plots. A theme similar to theme_classic() with large font size.
+\item \code{theme_survminer()}: Default theme for survminer plots. A theme similar to theme_classic() with large font size.
 
-\item \code{theme_cleantable}: theme for drawing a clean risk table and cumulative
+\item \code{theme_cleantable()}: theme for drawing a clean risk table and cumulative
 number of events table. A theme similar to theme_survminer() without i)
 axis lines and, ii) x axis ticks and title.
-}}
 
+}}
 \examples{
 
 # Fit survival curves

--- a/man/surv_cutpoint.Rd
+++ b/man/surv_cutpoint.Rd
@@ -50,8 +50,7 @@ shown only, when the number of variables > 5.}
 \item{...}{other arguments. For plots, see ?ggpubr::ggpar}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is
-\link[ggplot2]{theme_classic}. Allowed values include ggplot2 official themes. see
-?ggplot2::ggtheme.}
+\link[ggplot2]{theme_classic}. Allowed values include ggplot2 official themes. See \code{\link[ggplot2]{theme}()}.}
 
 \item{bins}{Number of bins for histogram. Defaults to 30.}
 

--- a/man/surv_cutpoint.Rd
+++ b/man/surv_cutpoint.Rd
@@ -50,12 +50,12 @@ shown only, when the number of variables > 5.}
 \item{...}{other arguments. For plots, see ?ggpubr::ggpar}
 
 \item{ggtheme}{function, ggplot2 theme name. Default value is
-\link{theme_classic}. Allowed values include ggplot2 official themes. see
+\link[ggplot2]{theme_classic}. Allowed values include ggplot2 official themes. see
 ?ggplot2::ggtheme.}
 
 \item{bins}{Number of bins for histogram. Defaults to 30.}
 
-\item{newpage}{open a new page. See \code{\link{grid.arrange}}.}
+\item{newpage}{open a new page. See \code{\link[gridExtra]{grid.arrange}}.}
 }
 \value{
 \itemize{


### PR DESCRIPTION
Closes #664 

### Notes

- Updates reference to `ggplot2::theme()` in 6e5ecffc5ff2e0b20cc488c383e0c9168a6e8346
- R CMD check has trouble matching argument names when multiple arguments are documented with a single `@param`. Maybe this is an upstream issue. Worked around it in dbe3792e13c95de0ac9f149c517136adc1466d87. See section below for details.

#### Rd \usage issue

<pre>
W  checking Rd \usage sections (595ms)
   Undocumented arguments in Rd file 'ggsurvtable.Rd'
     'xlim' 'xlab' 'ylab'
   
   Functions with \usage entries need to have the appropriate \alias
   entries, and all their arguments documented.
   The \usage entries must correspond to syntactically valid R code.
   See chapter 'Writing R documentation files' in the 'Writing R
   Extensions' manual.
</pre>