### PR TITLE
Fix ggplot2 v >= 3.5.2 compatibility issues (#681)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - Fix compatibility with ggplot2 development version (#681): Remove manual class assignment in `theme_survminer()` to ensure proper theme object construction
 - Fix test suite compatibility with ggplot2 development version (#681): Update layer access syntax in tests to support both stable (`$layers`) and development (`@layers`) versions
 - Fix "Ignoring unknown labels" warnings by conditionally setting legend titles only for aesthetics that are actually used in plots
+- Update documentation to recommend `%++%` operator instead of `+` for adding themes to ggsurv objects with ggplot2 v >= 3.5.2
 
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 - Fix compatibility with ggplot2 development version (#681): Remove manual class assignment in `theme_survminer()` to ensure proper theme object construction
 - Fix test suite compatibility with ggplot2 development version (#681): Update layer access syntax in tests to support both stable (`$layers`) and development (`@layers`) versions
+- Fix "Ignoring unknown labels" warnings by conditionally setting legend titles only for aesthetics that are actually used in plots
 
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 - Fix test suite compatibility with ggplot2 development version (#681): Update layer access syntax in tests to support both stable (`$layers`) and development (`@layers`) versions
 - Fix "Ignoring unknown labels" warnings by conditionally setting legend titles only for aesthetics that are actually used in plots
 - Update documentation to recommend `%++%` operator instead of `+` for adding themes to ggsurv objects with ggplot2 v >= 3.5.2
+- Fix documentation examples to consistently use `%++%` operator in `theme_survminer()` help
 
 
 

--- a/R/add_ggsurvplot.R
+++ b/R/add_ggsurvplot.R
@@ -3,6 +3,8 @@
 #'  object of class ggsurv, which is a list of ggplots.
 #'@param e1 an object of class ggsurv.
 #'@param e2 a plot component such as theme and labs.
+#'@note For ggplot2 v >= 3.5.2 compatibility, use \code{\%++\%} operator
+#'  instead of \code{+} when adding themes to ggsurv objects.
 #'@seealso \code{\link{theme_survminer}} and \code{\link{ggsurvplot}}
 #'@examples
 #'# Fit survival curves
@@ -18,7 +20,7 @@
 #'p
 #'
 #'# Customizing the plots
-#'p + theme_survminer(
+#'p %++% theme_survminer(
 #'      font.main = c(16, "bold", "darkblue"),
 #'      font.submain = c(15, "bold.italic", "purple"),
 #'      font.caption = c(14, "plain", "orange"),

--- a/R/ggsurvplot_df.R
+++ b/R/ggsurvplot_df.R
@@ -232,10 +232,21 @@ ggsurvplot_df <- function(fit, fun = NULL,
   # Axis label and legend title
   #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   lty.leg.title <- ifelse(linetype == "strata", legend.title, linetype)
-  p <- p + ggplot2::labs(x = xlab, y = ylab, title = title,
-                         color = legend.title, fill = legend.title,
-                         linetype = lty.leg.title
-  )
+  
+  # Build labs() arguments - only include aesthetics that are actually used
+  labs_args <- list(x = xlab, y = ylab, title = title, color = legend.title)
+  
+  # Add fill legend only if confidence interval ribbon is used
+  if(conf.int && conf.int.style == "ribbon") {
+    labs_args$fill <- legend.title
+  }
+  
+  # Add linetype legend only if linetype is used as an aesthetic mapping
+  if(linetype == "strata") {
+    labs_args$linetype <- lty.leg.title
+  }
+  
+  p <- p + do.call(ggplot2::labs, labs_args)
   p <-  .set_general_gpar(p, legend = legend, ...) # general graphical parameters
   if(!is.null(linetype.manual)) p <- p + scale_linetype_manual(values = linetype.manual)
 

--- a/R/ggsurvtheme.R
+++ b/R/ggsurvtheme.R
@@ -40,7 +40,7 @@ NULL
 #' # Change font size, style and color at the same time
 #' # Use font.x = 14, to change only font size; or use
 #' # font.x = "bold", to change only font face.
-#'ggsurv %+% theme_survminer(
+#'ggsurv %++% theme_survminer(
 #'      font.main = c(16, "bold", "darkblue"),
 #'      font.submain = c(15, "bold.italic", "purple"),
 #'      font.caption = c(14, "plain", "orange"),

--- a/R/ggsurvtheme.R
+++ b/R/ggsurvtheme.R
@@ -121,6 +121,9 @@ theme_survminer <-
       legend.text = legend.text,
       legend.title = legend.text
     )
+    if (!is_pkg_version_sup("ggplot2", "3.5.2")){
+      class(result) <- "theme"  
+    }
     result
   }
 

--- a/man/add_ggsurvplot.Rd
+++ b/man/add_ggsurvplot.Rd
@@ -19,6 +19,10 @@ e1 \%++\% e2
 Allows to add ggplot components - theme(), labs(), ... - to an
  object of class ggsurv, which is a list of ggplots.
 }
+\note{
+For ggplot2 v >= 3.5.2 compatibility, use \code{\%++\%} operator
+ instead of \code{+} when adding themes to ggsurv objects.
+}
 \examples{
 # Fit survival curves
 require("survival")
@@ -33,7 +37,7 @@ p <- ggsurvplot(fit, data = lung, risk.table = TRUE,
 p
 
 # Customizing the plots
-p + theme_survminer(
+p \%++\% theme_survminer(
      font.main = c(16, "bold", "darkblue"),
      font.submain = c(15, "bold.italic", "purple"),
      font.caption = c(14, "plain", "orange"),


### PR DESCRIPTION
## Summary
- Fix theme validation errors with ggplot2 v >= 3.5.2 by removing manual class assignment
- Update test suite to handle layer access syntax changes (@layers vs $layers) 
- Eliminate "Ignoring unknown labels" warnings through conditional aesthetic mapping
- Update documentation to recommend %++% operator for theme addition compatibility

## Test plan
- [x] Test theme_survminer() with both ggplot2 stable and development versions
- [x] Verify test suite passes with ggplot2 development version
- [x] Confirm warning elimination in ggsurvplot examples
- [x] Check backward compatibility with older ggplot2 versions