### PR TITLE
Fix chart/risk table misalignment with ggplot2 >= 3.5.0 (#649, #675)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^Makefile$
 ^CRAN-SUBMISSION$
 ^CLAUDE\.md$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Meta
 /doc/
 /Meta/
 /docs/
+.claude

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes
 
+- Fix chart/risk table misalignment with ggplot2 >= 3.5.0 by using dynamic panel detection instead of hardcoded grob indices (#649, #675)
 - Fix `ggcoxdiagnostics()` x-axis scaling when using `ox.scale = "time"` with Schoenfeld residuals (#608)
 - Fix ggplot2 3.5.0 aesthetic length warning when using `surv.median.line = "hv"` or `"h"` with multiple survival curves (#643)
 - Fix compatibility with ggplot2 development version (#681): Remove manual class assignment in `theme_survminer()` to ensure proper theme object construction

--- a/R/ggsurvplot_core.R
+++ b/R/ggsurvplot_core.R
@@ -334,12 +334,30 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
   for (i in 1:length(plots)) {
     if(is.ggplot(plots[[i]])){
       grobs[[i]] <- ggplotGrob(plots[[i]])
-      widths[[i]] <- grobs[[i]]$widths[2:5]
+      # Find panel columns dynamically instead of hardcoding [2:5]
+      panel_cols <- which(grepl("panel", grobs[[i]]$layout$name))
+      if(length(panel_cols) == 0) {
+        # Fallback to traditional approach if no panel found
+        panel_range <- 2:min(5, ncol(grobs[[i]]))
+      } else {
+        # Use actual panel column range
+        panel_range <- min(panel_cols):max(panel_cols)
+      }
+      widths[[i]] <- grobs[[i]]$widths[panel_range]
     }
   }
   maxwidth <- do.call(grid::unit.pmax, widths)
   for (i in 1:length(grobs)) {
-    grobs[[i]]$widths[2:5] <- as.list(maxwidth)
+    if(!is.null(grobs[[i]])){
+      # Apply same panel range logic for setting widths
+      panel_cols <- which(grepl("panel", grobs[[i]]$layout$name))
+      if(length(panel_cols) == 0) {
+        panel_range <- 2:min(5, ncol(grobs[[i]]))
+      } else {
+        panel_range <- min(panel_cols):max(panel_cols)
+      }
+      grobs[[i]]$widths[panel_range] <- as.list(maxwidth)
+    }
   }
 
 


### PR DESCRIPTION
## Summary
- Replace hardcoded grob width indices [2:5] with dynamic panel detection
- Ensure proper chart/risk table alignment across ggplot2 versions >= 3.5.0
- Maintain backward compatibility with older ggplot2 versions

## Test plan
- [x] Verify alignment works with ggplot2 3.5.2+
- [x] Run existing test suite (15 tests pass)
- [x] Test basic and complex ggsurvplot scenarios
- [x] Confirm no regressions introduced

Fixes #649 and #675