### PR TITLE
Fix GeomConfint incompatibility with ggplot2 4.0.x

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 
 ## Bug fixes
 
+- Fix `GeomConfint` incompatibility with ggplot2 4.0.x: normalize `linewidth` and `linetype` after stairstep transformation to prevent "Aesthetics can not vary along a ribbon" error (#694)
 - Fix `surv_fit()` error when using list of formulas with list of data sets (`match.fd = FALSE`): replace defunct `dplyr::combine()` with `unlist(recursive = FALSE)` (#697, #699)
 
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -63,6 +63,8 @@ GeomConfint <- ggplot2::ggproto('GeomConfint', ggplot2::GeomRibbon,
                                   if (na.rm) data <- data[stats::complete.cases(self$required_aes), ]
                                   data <- data[order(data$group, data$x), ]
                                   data <- self$stairstep_confint(data)
+                                  if (!is.null(data$linewidth)) data$linewidth <- data$linewidth[1]
+                                  if (!is.null(data$linetype)) data$linetype <- data$linetype[1]
                                   ggplot2::GeomRibbon$draw_group(data, panel_scales, coord, na.rm = na.rm)
                                 },
                                 stairstep_confint = function (data) {


### PR DESCRIPTION
## Summary

- Fix `GeomConfint$draw_group()` to normalize `linewidth` and `linetype` to constant values after `stairstep_confint()` transformation
- Prevents ggplot2 4.0.x "Aesthetics can not vary along a ribbon" error
- Update NEWS.md

Closes #694