### PR TITLE
Prepare version 0.5.2 for CRAN submission

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: survminer
 Type: Package
 Title: Drawing Survival Curves using 'ggplot2'
-Version: 0.5.1.999
-Date: 2025-09-03
+Version: 0.5.2
+Date: 2026-02-24
 Authors@R: c(
     person("Alboukadel", "Kassambara", role = c("aut", "cre"), email = "alboukadel.kassambara@gmail.com"),
     person("Marcin", "Kosinski", role = c("aut"), email = "m.p.kosinski@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# survminer 0.5.1.999
+# survminer 0.5.2
 
 ## New features
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,20 +1,19 @@
 ## Test environments
-* local Ubuntu 22.04.5 LTS install, R 4.4.1
-* Github Action, set up using `usethis::use_github_action("check-standard")`
+* local macOS (Darwin 24.6.0), R 4.4.2
+* GitHub Actions: ubuntu-latest (release), windows-latest (release), macOS-latest (release)
 
 ## R CMD check results
 There were no ERRORs or WARNINGs.
 
-       
 ## Downstream dependencies
-  
-I have also run R CMD check on downstream dependencies of survminer. 
+
+I have also run R CMD check on downstream dependencies of survminer.
 All packages that I could install passed.
 
 ## Update
 
-This is an update version 0.5.1 (see NEWS.md)
-
-
-
-
+This is an update to version 0.5.2 (see NEWS.md). Key changes:
+- Removed survMisc dependency by implementing weighted log-rank tests internally
+- Fixed GeomConfint incompatibility with ggplot2 4.0.x
+- Fixed surv_fit() error with list of formulas
+- Updated deprecated ggplot2 API usage (size -> linewidth, is.ggplot -> is_ggplot)


### PR DESCRIPTION
## Summary
- Bump version from 0.5.1.999 to 0.5.2 and update date to 2026-02-24
- Update NEWS.md heading to match release version
- Refresh cran-comments.md with current test environments and changelog summary

## Test plan
- [x] `devtools::check()` passes with 0 errors, 0 warnings

Closes #702