### PR TITLE
Fix ggflexsurvplot() factor grouping collapsing to "All" (#408)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Bug fixes
 
+- Fix `ggflexsurvplot()` collapsing a grouped Kaplan-Meier curve to a single "All" stratum when the grouping covariate is a factor: `is_factor_or_character()` called ggplot2's `is.facet()` (a Facet-object test, always `FALSE` for a data column) instead of `is.factor()` (#408).
+
 # survminer 0.5.2
 
 ## New features

--- a/R/ggflexsurvplot.R
+++ b/R/ggflexsurvplot.R
@@ -145,5 +145,5 @@ ggflexsurvplot <- function(fit, data = NULL,
 }
 
 is_factor_or_character <- function(x){
-  is.facet(x) | is.character(x)
+  is.factor(x) | is.character(x)
 }

--- a/tests/testthat/test-ggflexsurvplot.R
+++ b/tests/testthat/test-ggflexsurvplot.R
@@ -1,0 +1,13 @@
+context("ggflexsurvplot")
+
+# Regression test for #408: a factor grouping variable was silently collapsed to
+# a single "All" stratum because is_factor_or_character() called ggplot2's
+# is.facet() (a Facet-object test, always FALSE for a data column) instead of
+# is.factor(). The helper must recognise factors AND characters, but not numerics.
+test_that("is_factor_or_character recognises factors and characters (#408)", {
+  expect_true(is_factor_or_character(factor(c("a", "b", "a"))))
+  expect_true(is_factor_or_character(c("a", "b", "a")))
+  # no-regression: a numeric vector is not a grouping variable -> FALSE (unchanged)
+  expect_false(is_factor_or_character(1:5))
+  expect_false(is_factor_or_character(c(1.5, 2.5)))
+})


### PR DESCRIPTION
## Problem

`ggflexsurvplot()` collapsed a grouped Kaplan-Meier curve to a single **"All"** stratum when the grouping covariate was a **factor** (#408). Reproduced on dev 0.5.2.999: a `flexsurvreg(Surv(time,status) ~ factor_var)` fit plotted as one "All" curve instead of one curve per group.

## Root cause

`is_factor_or_character()` (`R/ggflexsurvplot.R`) tested `is.facet(x)` — that is **ggplot2's Facet-object predicate**, which returns `FALSE` for any data column (and is itself deprecated in ggplot2 3.5.2). So the expression reduced to `is.character(x)`; factor covariates were never recognised as grouping variables. Character covariates worked via the `is.character()` branch, which is why an earlier attempted fix appeared to help.

## Fix

```diff
 is_factor_or_character <- function(x){
-  is.facet(x) | is.character(x)
+  is.factor(x) | is.character(x)
 }
```

Since `is.facet(x)` was **always FALSE** for a data column, the only behavior change is that **factor** covariates now return `TRUE` (were `FALSE`) → grouped output. Character and numeric covariates are **byte-identical** to before. Also removes a live `is.facet` deprecation warning.

## Verification / no-regression
- Reproduced the bug (factor → "All"); after fix factor → grouped strata; character still grouped; numeric still "All" (unchanged).
- Added regression unit test (`factor`/`character` → TRUE, numeric → FALSE).
- Clean-session suite green: `Rscript --vanilla` → **FAIL 0 · PASS 46**.
- Two independent adversarial reviewers (read-only) reviewed the diff and both returned PASS.
- The separate `eval(fit$call$data)` scoping error mentioned later in the thread is a distinct issue (shared `.get_data()`), out of scope here.

Fixes #408
