### PR TITLE
Fix surv_group_by() "cannot xtfrm data frame" on tibble input (#548, #670)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Bug fixes
 
+- Fix `surv_group_by()` (and downstream `ggsurvplot_facet()` / grouped `surv_pvalue()`) failing with "cannot xtfrm data frame" when the input is a tibble: extract the grouping column with `data[[var]]` (a vector) instead of `data[, var]` (a one-column tibble) (#548, #670).
+
 # survminer 0.5.2
 
 ## New features

--- a/R/surv_group_by.R
+++ b/R/surv_group_by.R
@@ -53,7 +53,7 @@ surv_group_by <- function(data, grouping.vars){
   # We should do this because original level orders are altered by the nest() function
   #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   if(length(grouping.vars) == 1){
-    grp.levels <- .levels(data[, grouping.vars])
+    grp.levels <- .levels(data[[grouping.vars]])
     current.order <- grouped.d[, grouping.vars] %>% as.data.frame() %>% .[,1]
     grouped.d <- grouped.d[match(grp.levels, current.order), , drop = FALSE]
   }

--- a/tests/testthat/test-surv_group_by.R
+++ b/tests/testthat/test-surv_group_by.R
@@ -1,0 +1,24 @@
+context("surv_group_by")
+
+# Regression test for #548 / #670: surv_group_by() errored with
+# "cannot xtfrm data frame" when the input was a tibble, because
+# data[, grouping.vars] returns a one-column tibble (not a vector) which
+# .levels() then tried to coerce with as.factor(). data[[grouping.vars]]
+# returns a vector for both data.frame and tibble input.
+test_that("surv_group_by() handles a tibble input (#548, #670)", {
+  df <- survival::colon
+  tb <- tibble::as_tibble(df)
+
+  # tibble path must not error
+  expect_error(surv_group_by(tb, "rx"), NA)
+
+  # no-regression: data.frame path still works and tibble yields the SAME
+  # group names / order (the fix must not change the data.frame result)
+  g_df <- surv_group_by(df, "rx")
+  g_tb <- surv_group_by(tb, "rx")
+  expect_identical(names(g_tb$data), names(g_df$data))
+
+  # two grouping variables also work for both inputs
+  expect_error(surv_group_by(df, c("rx", "adhere")), NA)
+  expect_error(surv_group_by(tb, c("rx", "adhere")), NA)
+})


### PR DESCRIPTION
## Problem

`surv_group_by()` (and downstream `ggsurvplot_facet()` / grouped `surv_pvalue()`) failed with **`cannot xtfrm data frame`** when the input `data` was a **tibble** (#548, #670). data.frame input worked fine.

## Root cause

In the single grouping-variable branch:
```r
grp.levels <- .levels(data[, grouping.vars])
```
For a **tibble**, `data[, "col"]` returns a **one-column tibble** (tibbles don't drop to a vector), which `.levels()` then passes to `as.factor()` → `xtfrm` error. For a plain data.frame, `data[, "col"]` drops to a vector, so it worked.

## Fix

```diff
-    grp.levels <- .levels(data[, grouping.vars])
+    grp.levels <- .levels(data[[grouping.vars]])
```
`grouping.vars` is length 1 in this branch, so `[[ ]]` is unambiguous and returns a vector for **both** data.frame and tibble. For a data.frame the extracted vector — and the resulting group **names and order** — is **byte-identical** to before.

## Verification / no-regression
- Reproduced: data.frame OK, tibble → `cannot xtfrm data frame`; after fix both work.
- data.frame result byte-identical (factor/character/numeric/ordered-factor grouping); tibble now yields identical group names/order to data.frame.
- End-to-end: `ggsurvplot_facet(..., data = tibble, pval = TRUE)` and `ggsurvplot_group_by()` now work with tibble input.
- Line 56 was the only place indexing the raw user `data` with `[,]`; lines 57/62/72 operate on the `nest()` output and coerce via `as.data.frame()`, so they were already class-agnostic (2-var path confirmed working for tibbles).
- Regression test added; clean-session suite green (`Rscript --vanilla` → FAIL 0 · PASS 46). `tibble` is already in Imports (CI-safe).
- Two independent adversarial reviewers (read-only) both returned PASS.

Fixes #548
Fixes #670
