### PR TITLE
Fix ggflexsurvplot() "object not found" by forwarding resolved data (#436)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 - Fix `ggflexsurvplot()` collapsing a grouped Kaplan-Meier curve to a single "All" stratum when the grouping covariate is a factor: `is_factor_or_character()` called ggplot2's `is.facet()` (a Facet-object test, always `FALSE` for a data column) instead of `is.factor()` (#408).
 - Fix `surv_group_by()` (and downstream `ggsurvplot_facet()` / grouped `surv_pvalue()`) failing with "cannot xtfrm data frame" when the input is a tibble: extract the grouping column with `data[[var]]` (a vector) instead of `data[, var]` (a one-column tibble) (#548, #670).
+- Fix `ggflexsurvplot()` erroring with "object '<name>' not found" when the model's data object is out of scope at plot time (even with `data =` supplied): the already-resolved `data` is now forwarded to the internal `.extract.survfit()` instead of being re-derived from `fit$call$data` (#436).
 # survminer 0.5.2
 
 ## New features

--- a/R/ggflexsurvplot.R
+++ b/R/ggflexsurvplot.R
@@ -55,7 +55,7 @@ ggflexsurvplot <- function(fit, data = NULL,
   .strata <- summ$strata
   n.strata <- .strata %>% .levels() %>% length()
 
-   fit.ext <- .extract.survfit(fit)
+   fit.ext <- .extract.survfit(fit, data = data)
    surv.obj <- fit.ext$surv
    surv.vars <- fit.ext$variables
    .formula <- fit.ext$formula

--- a/tests/testthat/test-ggflexsurvplot.R
+++ b/tests/testthat/test-ggflexsurvplot.R
@@ -11,3 +11,26 @@ test_that("is_factor_or_character recognises factors and characters (#408)", {
   expect_false(is_factor_or_character(1:5))
   expect_false(is_factor_or_character(c(1.5, 2.5)))
 })
+
+# Regression test for #436: ggflexsurvplot() called .extract.survfit(fit) without
+# forwarding the data it had already resolved, so .extract.survfit() re-derived the
+# data from fit$call$data and errored with "object '<name>' not found" when the
+# original data object was out of scope at plot time -- even when the user passed
+# data = explicitly. The resolved data must be forwarded.
+test_that("ggflexsurvplot() forwards user data to .extract.survfit (#436)", {
+  skip_if_not_installed("flexsurv")
+  # Build the fit inside a local scope so fit$call$data is NOT visible at plot time.
+  make_fit <- function() {
+    dd <- survival::lung
+    dd$sex <- factor(dd$sex, labels = c("m", "f"))
+    flexsurv::flexsurvreg(survival::Surv(time, status) ~ sex, data = dd,
+                          dist = "weibull")
+  }
+  fit <- make_fit()
+  dat <- survival::lung
+  dat$sex <- factor(dat$sex, labels = c("m", "f"))
+
+  # With an explicit data = argument this must no longer error, and must group.
+  p <- suppressWarnings(ggflexsurvplot(fit, data = dat))
+  expect_length(unique(as.character(p$plot$data$strata)), 2)
+})


### PR DESCRIPTION
## Problem

`ggflexsurvplot()` errored with **`object '<name>' not found`** when the model's data object was out of scope at plot time — **even when the caller passed `data =` explicitly** (#436).

## Root cause

`ggflexsurvplot()` resolves the data at line 51 (`data <- .get_data(fit, data = data, complain = FALSE)`), but then called `.extract.survfit(fit)` **without** forwarding it (line 58). The helper therefore re-derived the data from `fit$call$data`, which fails when the original object is no longer in scope.

## Fix

```diff
-   fit.ext <- .extract.survfit(fit)
+   fit.ext <- .extract.survfit(fit, data = data)
```

`.extract.survfit()` already accepts a `data =` argument. Every other caller in the package (`surv_pvalue`, `ggsurvplot_facet`, `ggsurvplot_group_by`, `ggsurvplot_add_all`) already forwards it — `ggflexsurvplot` was the lone outlier.

## Verification / no-regression
- Reproduced: fit built out of scope + `data =` supplied → `object 'dd' not found`; after fix → grouped plot (2 strata).
- Only `fit.ext$surv/variables/formula` are consumed downstream, and those are derived from `fit$call$formula` — **independent of `data`**. Field-by-field comparison (factor-grouped and multi-covariate fits) shows identical `surv`/`variables`/`formula`; the forwarded `data` only feeds the *unused* `data.*` fields. So output is byte-identical for previously-working inputs; the change only prevents the crash.
- In-scope fits (with or without `data =`) unchanged; out-of-scope + no `data =` still fails at line 51 (genuinely no data — unchanged, not worse).
- Composes correctly with the #408 factor-grouping fix.
- Regression test added; clean-session suite green (`Rscript --vanilla` → FAIL 0 · PASS 51). flexsurv guarded via `skip_if_not_installed()`.
- Two independent adversarial reviewers (read-only) both returned PASS.

Fixes #436
