### PR TITLE
Fix ncensor.plot draw-time crash for single-group fits (#298)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
 - Fix `ggflexsurvplot()` collapsing a grouped Kaplan-Meier curve to a single "All" stratum when the grouping covariate is a factor: `is_factor_or_character()` called ggplot2's `is.facet()` (a Facet-object test, always `FALSE` for a data column) instead of `is.factor()` (#408).
 - Fix `surv_group_by()` (and downstream `ggsurvplot_facet()` / grouped `surv_pvalue()`) failing with "cannot xtfrm data frame" when the input is a tibble: extract the grouping column with `data[[var]]` (a vector) instead of `data[, var]` (a one-column tibble) (#548, #670).
 - Fix `ggflexsurvplot()` erroring with "object '<name>' not found" when the model's data object is out of scope at plot time (even with `data =` supplied): the already-resolved `data` is now forwarded to the internal `.extract.survfit()` instead of being re-derived from `fit$call$data` (#436).
+- Fix `ggsurvplot(..., ncensor.plot = TRUE)` erroring at draw time with "Unknown colour name: strata" for a single-group fit (`~ 1`): the default `color = "strata"` was passed to the censoring bar plot as a literal colour when the data has no `strata` column. The bars now use the survival curve's own colour for that case only (falling back to black if it cannot be resolved), leaving grouped fits and explicit colours unchanged (#298).
+
 # survminer 0.5.2
 
 ## New features

--- a/R/ggsurvplot_core.R
+++ b/R/ggsurvplot_core.R
@@ -189,8 +189,20 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
   # Add ncensor.plot or cumcensor plot
   #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   if(ncensor.plot){
+    # A single-group fit (e.g. ~ 1) has no 'strata' column, so the default
+    # color = "strata" would be passed to geom_bar as a literal colour and
+    # error ("Unknown colour name: strata"). For that sentinel only, use the
+    # survival curve's own colour (so the bars match the curve, as grouped
+    # bars do), falling back to black if it can't be resolved. A real strata
+    # column (grouped) or a user-supplied colour is left untouched.
+    ncensor.color <- surv.color
+    if(identical(surv.color, "strata") && !("strata" %in% colnames(d))){
+      ncensor.color <- unname(scurve_cols)[1]
+      if(length(ncensor.color) == 0 || is.na(ncensor.color))
+        ncensor.color <- "black"
+    }
     ncensor_plot <- ggplot(d, ggplot2::aes(x = !!sym("time"), y = !!sym("n.censor"))) +
-      ggpubr::geom_exec(geom_bar, d, color = surv.color, fill = surv.color,
+      ggpubr::geom_exec(geom_bar, d, color = ncensor.color, fill = ncensor.color,
                         stat = "identity", position = "dodge")+
       coord_cartesian(xlim = xlim)+
       scale_y_continuous(breaks = sort(unique(d$n.censor))) +

--- a/tests/testthat/test-ncensor-plot.R
+++ b/tests/testthat/test-ncensor-plot.R
@@ -1,0 +1,34 @@
+context("ncensor.plot")
+
+# Regression test for #298: ggsurvplot(..., ncensor.plot = TRUE) errored at
+# DRAW time with "Unknown colour name: strata" for a single-group fit (~ 1),
+# because the default color = "strata" was passed to geom_bar as a literal
+# colour when the data has no 'strata' column. The bars must render, and
+# grouped fits / explicit colours must be unaffected.
+test_that("ncensor.plot renders for a single-group fit (#298)", {
+  lung <- survival::lung
+
+  # single group (~ 1): previously crashed at draw time
+  f1 <- survival::survfit(survival::Surv(time, status) ~ 1, data = lung)
+  p1 <- ggsurvplot(f1, data = lung, ncensor.plot = TRUE)
+  expect_error(ggplot2::ggplot_build(p1$ncensor.plot), NA)
+  # the single bar matches the survival curve colour (not a stray literal)
+  curve_col <- unique(stats::na.omit(
+    ggplot2::ggplot_build(p1$plot)$data[[1]]$colour))
+  bar_col <- unique(ggplot2::ggplot_build(p1$ncensor.plot)$data[[1]]$fill)
+  expect_identical(bar_col, curve_col)
+
+  # no-regression: grouped fit still renders, bars coloured by strata (> 1 fill)
+  f2 <- survival::survfit(survival::Surv(time, status) ~ sex, data = lung)
+  p2 <- ggsurvplot(f2, data = lung, ncensor.plot = TRUE)
+  b2 <- ggplot2::ggplot_build(p2$ncensor.plot)
+  expect_gt(length(unique(b2$data[[1]]$fill)), 1)
+
+  # no-regression: an explicit colour is honoured (not overridden), single group.
+  # (color = <literal> triggers an unrelated survminer "use palette=" advisory.)
+  p3 <- suppressWarnings(
+    ggsurvplot(f1, data = lung, ncensor.plot = TRUE, color = "dodgerblue")
+  )
+  b3 <- ggplot2::ggplot_build(p3$ncensor.plot)
+  expect_true("dodgerblue" %in% b3$data[[1]]$fill)
+})


### PR DESCRIPTION
## Problem

`ggsurvplot(..., ncensor.plot = TRUE)` errored at **draw time** with **`Unknown colour name: strata`** for a single-group fit (`Surv(...) ~ 1`) — reported by several users (#298).

## Root cause

The censoring bar plot is built with `color = surv.color`, where `surv.color` is the default `"strata"`. `ggpubr::geom_exec()` maps an argument as an aesthetic when it matches a data column, otherwise treats it as a literal. A **grouped** fit's plot data has a `strata` column → mapped correctly; a **single-group** fit has **no** `strata` column → `"strata"` is treated as a literal colour name → crash.

## Fix

Guard only the sentinel case — default `color = "strata"` **and** no `strata` column:

```r
ncensor.color <- surv.color
if(identical(surv.color, "strata") && !("strata" %in% colnames(d))){
  ncensor.color <- unname(scurve_cols)[1]                 # the survival curve's own colour
  if(length(ncensor.color) == 0 || is.na(ncensor.color))
    ncensor.color <- "black"                              # last-resort fallback
}
```

The single-group bars now use the **survival curve's own colour** (`scurve_cols`, already computed for the risk/censor tables), so they match the curve — and `palette=` is respected. Grouped fits (strata column present) and user-supplied colours (`surv.color != "strata"`) are **untouched**, so their output is byte-identical.

## Verification / no-regression
- Reproduced the draw-time crash (single group); after fix it renders, bar fill == curve colour (`#F8766D`), and `palette="dodgerblue"` → bar `dodgerblue`.
- Grouped fits: bars still coloured by strata (`#F8766D`, `#00BFC4`), unchanged. Explicit `color="red"` single-group → red (guard skipped).
- `cumcensor` / `risk.table` / `cumevents` paths already use fixed colours — not affected.
- Regression test added (`tests/testthat/test-ncensor-plot.R`) comparing the bar fill to the *dynamically extracted* curve colour (robust across ggplot2 defaults). Clean-session suite green: `Rscript --vanilla` → FAIL 0 · WARN 0 · PASS 55.
- **Four** independent adversarial reviewers across two rounds (the fallback was upgraded from hard-coded black to the curve colour after round 1) all returned PASS; the NULL/NA/length-0 guard edge was specifically verified.

Fixes #298
