### PR TITLE
Fix ggadjustedcurves() "cannot xtfrm data frame" on tibble input (#501, #628)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 - Fix `surv_group_by()` (and downstream `ggsurvplot_facet()` / grouped `surv_pvalue()`) failing with "cannot xtfrm data frame" when the input is a tibble: extract the grouping column with `data[[var]]` (a vector) instead of `data[, var]` (a one-column tibble) (#548, #670).
 - Fix `ggflexsurvplot()` erroring with "object '<name>' not found" when the model's data object is out of scope at plot time (even with `data =` supplied): the already-resolved `data` is now forwarded to the internal `.extract.survfit()` instead of being re-derived from `fit$call$data` (#436).
 - Fix `ggsurvplot(..., ncensor.plot = TRUE)` erroring at draw time with "Unknown colour name: strata" for a single-group fit (`~ 1`): the default `color = "strata"` was passed to the censoring bar plot as a literal colour when the data has no `strata` column. The bars now use the survival curve's own colour for that case only (falling back to black if it cannot be resolved), leaving grouped fits and explicit colours unchanged (#298).
+- Fix `ggadjustedcurves()` / `surv_adjustedcurves()` failing with "cannot xtfrm data frame" when a tibble is passed as `data` (or as `reference` for the marginal method): both are coerced to a plain data.frame so the internal `data[, variable]` extractions return a vector (#501, #628).
 
 # survminer 0.5.2
 

--- a/R/ggadjustedcurves.R
+++ b/R/ggadjustedcurves.R
@@ -134,10 +134,19 @@ surv_adjustedcurves <- function(fit,
                              ...) {
   stopifnot(method %in% c("marginal", "average", "conditional", "single"))
   data <- .get_data(fit, data)
+  # Coerce to a plain data.frame: the curve helpers index columns with
+  # data[, variable], which returns a one-column tibble (not a vector) for a
+  # tibble input and then fails in sort()/unique() with "cannot xtfrm data
+  # frame". A no-op for a data.frame, so existing results are unchanged.
+  data <- as.data.frame(data)
   # deal with default arguments
   # reference = NULL
   if (is.null(reference))
     reference <- data
+  # coerce a user-supplied reference too: the marginal method indexes
+  # reference[, variable] and rbind()s it with data, so a tibble reference
+  # would re-introduce the "cannot xtfrm data frame" error.
+  reference <- as.data.frame(reference)
 
   # variable = NULL
   if (is.null(variable)) {

--- a/tests/testthat/test-ggadjustedcurves.R
+++ b/tests/testthat/test-ggadjustedcurves.R
@@ -1,0 +1,44 @@
+context("ggadjustedcurves")
+
+# Regression test for #501 / #628: ggadjustedcurves() / surv_adjustedcurves()
+# errored with "cannot xtfrm data frame" for a tibble input, because the curve
+# helpers index columns with data[, variable], which returns a one-column
+# tibble (not a vector) that then fails in sort()/unique(). The data is now
+# coerced to a plain data.frame, so tibble and data.frame give identical curves.
+test_that("ggadjustedcurves() accepts a tibble input (#501, #628)", {
+  library(survival)
+  df <- lung
+  df$sex <- factor(df$sex)
+  fit <- coxph(Surv(time, status) ~ sex + age, data = df)
+  tb <- tibble::as_tibble(df)
+
+  # default method ("conditional"): tibble must not error and must match df
+  expect_error(ggadjustedcurves(fit, data = tb, variable = "sex"), NA)
+
+  # tibble and data.frame produce identical adjusted curves for each method
+  for (m in c("single", "average", "conditional")) {
+    v <- if (m == "single") NULL else "sex"
+    r_df <- surv_adjustedcurves(fit, data = df, variable = v, method = m)
+    r_tb <- surv_adjustedcurves(fit, data = tb, variable = v, method = m)
+    expect_equal(r_tb, r_df)
+  }
+})
+
+# The "marginal" method also indexes the `reference` argument, so a tibble
+# passed there (not just as `data`) must be coerced too (#628 review).
+test_that("marginal adjusted curves accept tibble data and reference (#628)", {
+  library(survival)
+  fit2 <- coxph(Surv(stop, event) ~ size + strata(rx), data = bladder)
+  df <- bladder
+  tb <- tibble::as_tibble(df)
+
+  base <- surv_adjustedcurves(fit2, data = df, variable = "rx",
+                              method = "marginal", reference = df)
+  # tibble as data, as reference, and as both -> identical to the data.frame run
+  expect_equal(surv_adjustedcurves(fit2, data = tb, variable = "rx",
+                                   method = "marginal", reference = df), base)
+  expect_equal(surv_adjustedcurves(fit2, data = df, variable = "rx",
+                                   method = "marginal", reference = tb), base)
+  expect_equal(surv_adjustedcurves(fit2, data = tb, variable = "rx",
+                                   method = "marginal", reference = tb), base)
+})


### PR DESCRIPTION
## Problem

`ggadjustedcurves()` / `surv_adjustedcurves()` errored with **`cannot xtfrm data frame`** when given a **tibble** (#501, #628).

## Root cause

The curve helpers index columns with `data[, variable]` (and `reference[, variable]` in the `marginal` method). For a **tibble**, `data[, "col"]` returns a **one-column tibble** (not a vector), which then fails in `sort()` / `unique()` / `factor()` with "cannot xtfrm data frame".

## Fix

Coerce both the resolved `data` and the `reference` to a plain data.frame in `surv_adjustedcurves()`:

```r
data <- .get_data(fit, data)
data <- as.data.frame(data)
if (is.null(reference))
  reference <- data
reference <- as.data.frame(reference)
```

`as.data.frame()` is a no-op for a data.frame, so existing data.frame results are **byte-identical**; tibble input now yields **identical** curves. `ggadjustedcurves()` (plot) routes through `surv_adjustedcurves()`, so both entry points are covered.

## Verification / no-regression
- Reproduced the crash for a tibble; after fix, tibble and data.frame give `all.equal == TRUE` for `single`, `average`, `conditional`, and (with a `strata()` formula) `marginal` — including tibble `data`, tibble `reference`, and both.
- data.frame inputs unchanged; data.table / grouped_df / `data = NULL` reconstruction also verified.
- The `marginal` method has a **separate, pre-existing** bug for no-`strata` formulas ("subscript out of bounds") — unrelated to this fix and left untouched; the test uses a working `strata()` formula.
- Regression tests added; clean-session suite green (`Rscript --vanilla` → FAIL 0 · WARN 0 · PASS 62). `tibble` is in Imports.
- **Four** independent adversarial reviewers across two rounds; the first round caught that a user-supplied tibble `reference` was still uncoerced, which this version fixes — both final reviewers PASS.

Fixes #501
Fixes #628
