### PR TITLE
Fix ggsurvplot() names-length error with duplicated palette colours (#397, #519, #595, #691)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - Fix `ggflexsurvplot()` erroring with "object '<name>' not found" when the model's data object is out of scope at plot time (even with `data =` supplied): the already-resolved `data` is now forwarded to the internal `.extract.survfit()` instead of being re-derived from `fit$call$data` (#436).
 - Fix `ggsurvplot(..., ncensor.plot = TRUE)` erroring at draw time with "Unknown colour name: strata" for a single-group fit (`~ 1`): the default `color = "strata"` was passed to the censoring bar plot as a literal colour when the data has no `strata` column. The bars now use the survival curve's own colour for that case only (falling back to black if it cannot be resolved), leaving grouped fits and explicit colours unchanged (#298).
 - Fix `ggadjustedcurves()` / `surv_adjustedcurves()` failing with "cannot xtfrm data frame" when a tibble is passed as `data` (or as `reference` for the marginal method): both are coerced to a plain data.frame so the internal `data[, variable]` extractions return a vector (#501, #628).
+- Fix `ggsurvplot()` erroring with "'names' attribute [n] must be the same length as the vector [m]" when the `palette` contains a duplicated colour (or a default palette rendered a repeated hue) together with `risk.table` / `ncensor.plot`: the internal colour extractor used `unique()`, collapsing duplicate colours; it now returns one colour per group (#397, #519, #595, #691).
 
 # survminer 0.5.2
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -293,7 +293,13 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
 # Will be used to color the y.text of risk table and cumevents table
 .extract_ggplot_colors <- function(p, grp.levels){
   g <- ggplot_build(p)
-  .cols <- unlist(unique(g$data[[1]]["colour"]))
+  .d <- g$data[[1]]
+  # One colour per group, in group order. Using unique() here would collapse
+  # duplicated palette colours and return a vector shorter than the number of
+  # groups, so naming it with grp.levels then failed with "'names' attribute
+  # [n] must be the same length as the vector [m]" (#397, #519, #595, #691).
+  # For a palette of distinct colours this yields the same result as before.
+  .cols <- .d$colour[match(sort(unique(.d$group)), .d$group)]
   if(!is.null(grp.levels)){
     if(length(.cols)==1) .cols <- rep(.cols, length(grp.levels))
     names(.cols) <- grp.levels

--- a/tests/testthat/test-extract-colors.R
+++ b/tests/testthat/test-extract-colors.R
@@ -1,0 +1,31 @@
+context("extract_ggplot_colors")
+
+# Regression test for #397 / #519 / #595 / #691: a palette containing duplicate
+# colours (or a default palette that ggplot2 rendered with a repeated hue) made
+# .extract_ggplot_colors() call unique() on the colour column, returning fewer
+# colours than groups. Naming that shorter vector with the group levels then
+# failed with "'names' attribute [n] must be the same length as the vector [m]",
+# which surfaced whenever risk.table / ncensor.plot were requested.
+test_that(".extract_ggplot_colors keeps one colour per group (#397, #519, #595, #691)", {
+  library(survival)
+  set.seed(1)
+  d <- lung
+  d$grp <- factor(sample(c("a", "b", "c", "d"), nrow(d), replace = TRUE))
+  fit <- survfit(Surv(time, status) ~ grp, data = d)
+
+  # a palette with a duplicated colour (groups a and b share "red")
+  pal <- c("red", "red", "blue", "green")
+  p <- ggsurvplot(fit, data = d, palette = pal)$plot
+  cols <- .extract_ggplot_colors(p, grp.levels = c("a", "b", "c", "d"))
+  expect_length(cols, 4)
+  expect_equal(unname(cols), pal)
+
+  # no-regression: a palette of distinct colours still yields one colour per group
+  p2 <- ggsurvplot(fit, data = d)$plot
+  cols2 <- .extract_ggplot_colors(p2, grp.levels = c("a", "b", "c", "d"))
+  expect_length(cols2, 4)
+
+  # end-to-end: duplicate palette + risk.table / ncensor.plot no longer error
+  expect_error(ggsurvplot(fit, data = d, palette = pal, risk.table = TRUE), NA)
+  expect_error(ggsurvplot(fit, data = d, palette = pal, ncensor.plot = TRUE), NA)
+})


### PR DESCRIPTION
## Problem

`ggsurvplot()` errored with **`'names' attribute [n] must be the same length as the vector [m]`** whenever the `palette` contained a **duplicated colour** (or a default palette rendered a repeated hue) together with `risk.table` / `ncensor.plot` / `cumevents` / `risk.table.y.text.col`. Reported across #397, #519, #595, #691.

## Root cause

`.extract_ggplot_colors()` did `unlist(unique(g$data[[1]]["colour"]))`. `unique()` collapses duplicated colours, so the returned vector was **shorter than the number of groups**; `names(.cols) <- grp.levels` then failed the length check.

## Fix

Extract **one colour per ggplot group id**, in group order, preserving duplicates:

```r
.d <- g$data[[1]]
.cols <- .d$colour[match(sort(unique(.d$group)), .d$group)]
```

For a palette of **distinct** colours this returns the **same values in the same order** as before (verified `identical()` for 2/3/4/6 groups), so existing plots are unchanged. Duplicated-colour palettes now yield one correctly-aligned colour per group, e.g. `palette = c("red","red","blue","green")` → `a=red, b=red, c=blue, d=green`.

## Verification / no-regression
- Reproduced the crash (dup palette + risk.table); after fix it renders. Verified for `risk.table`, `ncensor.plot`, `risk.table.y.text.col`, and combinations.
- No-regression: distinct palettes identical to before; correct colour↔label alignment confirmed under reordered / dropped factor levels and non-sequential group ids (`legend.labs` is display-only).
- Interaction with the recent #298 fix (single-group `ncensor.plot` uses `scurve_cols[1]`) preserved — bar still matches the curve colour.
- Layer-1 (`g$data[[1]]`) is the survival step curve across `conf.int` / `censor` / combined variants (same assumption the old code already relied on).
- Regression test added; clean-session suite green (`Rscript --vanilla` → FAIL 0 · PASS 67).
- Two independent adversarial reviewers (read-only) both PASS after a full caller audit.

Fixes #397
Fixes #519
Fixes #595
Fixes #691
