### PR TITLE
Resolve formula stored in a variable for survfit-based plots (#324, #341, #602)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 - Fix `ggsurvplot(..., ncensor.plot = TRUE)` erroring at draw time with "Unknown colour name: strata" for a single-group fit (`~ 1`): the default `color = "strata"` was passed to the censoring bar plot as a literal colour when the data has no `strata` column. The bars now use the survival curve's own colour for that case only (falling back to black if it cannot be resolved), leaving grouped fits and explicit colours unchanged (#298).
 - Fix `ggadjustedcurves()` / `surv_adjustedcurves()` failing with "cannot xtfrm data frame" when a tibble is passed as `data` (or as `reference` for the marginal method): both are coerced to a plain data.frame so the internal `data[, variable]` extractions return a vector (#501, #628).
 - Fix `ggsurvplot()` erroring with "'names' attribute [n] must be the same length as the vector [m]" when the `palette` contains a duplicated colour (or a default palette rendered a repeated hue) together with `risk.table` / `ncensor.plot`: the internal colour extractor used `unique()`, collapsing duplicate colours; it now returns one colour per group (#397, #519, #595, #691).
+- Fix `ggsurvplot()` and `surv_pvalue()` erroring with "object of type 'symbol' is not subsettable" for a `survfit` built from a formula stored in a variable (e.g. `frm <- Surv(time, status) ~ sex; survfit(frm, data)`): the stored formula (a symbol) is now resolved with `stats::formula(fit)` instead of `as.formula(fit$call$formula)` (#324, #341, #602).
 
 # survminer 0.5.2
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -320,8 +320,14 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
 }
 
 .get_fit_formula <- function(fit){
-  fit$call$formula %>%
-    stats::as.formula()
+  # fit$call$formula may be an unevaluated symbol when the fit was built from a
+  # formula stored in a variable (e.g. survfit(frm, data)); as.formula() then
+  # fails with "object of type 'symbol' is not subsettable". stats::formula()
+  # resolves it via survival's method; fall back to the old path if unavailable.
+  tryCatch(
+    stats::formula(fit),
+    error = function(e) stats::as.formula(fit$call$formula)
+  )
 }
 
 .build_formula <- function(surv.obj, variables){
@@ -420,8 +426,10 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
   if(inherits(fit, c("survfit.cox", "survfitcox")))
     return(list())
 
-  .formula <- fit$call$formula %>%
-    stats::as.formula()
+  .formula <- tryCatch(
+    stats::formula(fit),
+    error = function(e) stats::as.formula(fit$call$formula)
+  )
   surv.obj <- deparse(.formula[[2]])
   surv.vars <- attr(stats::terms(.formula), "term.labels")
   data.all <- data <- .get_data(fit, data = data, complain = FALSE)

--- a/tests/testthat/test-formula-symbol.R
+++ b/tests/testthat/test-formula-symbol.R
@@ -1,0 +1,35 @@
+context("formula stored in a variable")
+
+# Regression test for #324 / #341 / #602: when a survfit is built from a formula
+# held in a variable (e.g. `frm <- Surv(time,status)~sex; survfit(frm, data)`),
+# fit$call$formula is an unevaluated symbol, and as.formula() could not subset it
+# ("object of type 'symbol' is not subsettable") -- breaking ggsurvplot() and
+# surv_pvalue(). .get_fit_formula()/.extract.survfit() now resolve it via
+# stats::formula(fit). The formula variable is assigned in the global environment
+# to reproduce the reported interactive scenario (where it is reachable, as in a
+# user session); a variable local to an already-exited function is out of scope
+# for either survival or survminer and is a separate, documented limitation.
+test_that("ggsurvplot()/surv_pvalue() handle a formula stored in a variable (#324, #341, #602)", {
+  library(survival)
+  assign("frm_324", as.formula("Surv(time, status) ~ sex"), envir = globalenv())
+  on.exit(rm("frm_324", envir = globalenv()), add = TRUE)
+
+  fit_var    <- survfit(frm_324, data = lung)                  # $call$formula is a symbol
+  fit_inline <- survfit(Surv(time, status) ~ sex, data = lung) # $call$formula is a call
+  expect_true(is.name(fit_var$call$formula))
+
+  # ggsurvplot() builds without the 'symbol not subsettable' error
+  expect_error(ggsurvplot(fit_var, data = lung), NA)
+
+  # surv_pvalue() works and equals the inline-formula result (no-regression)
+  expect_equal(
+    surv_pvalue(fit_var, data = lung)$pval,
+    surv_pvalue(fit_inline, data = lung)$pval
+  )
+
+  # the helper resolves the symbol to the same formula as the inline fit
+  expect_equal(
+    deparse(.get_fit_formula(fit_var)),
+    deparse(.get_fit_formula(fit_inline))
+  )
+})


### PR DESCRIPTION
## Problem

When a `survfit` is built from a formula held in a **variable** —
```r
frm <- Surv(time, status) ~ sex
fit <- survfit(frm, data = lung)
```
— `fit$call$formula` is an unevaluated **symbol**. `ggsurvplot(fit)`, `surv_pvalue(fit)` (and other survfit-based helpers) then errored:
```
Error: object of type 'symbol' is not subsettable
```
because the internal helpers did `fit$call$formula %>% as.formula()`, and `as.formula()` can't subset a bare symbol. (#324, #341, #602)

## Fix

In `.get_fit_formula()` and `.extract.survfit()`, resolve the formula via `stats::formula(fit)` (which evaluates the stored symbol), falling back to the old path:
```r
tryCatch(stats::formula(fit), error = function(e) stats::as.formula(fit$call$formula))
```

## Verification / no-regression
- **Byte-identical for inline-formula fits** (grouped / `~1` / multi-covariate / `strata()` / `subset=`): same `deparse`, `term.labels`, `get_all_vars`, and computed outputs (e.g. grouped `surv_pvalue` = 0.001311165, `surv_summary` = 206 rows) old-vs-new.
- **Fixes the reported case**: a formula in a reachable (session) variable now works and equals the inline result, for `ggsurvplot()`, `surv_pvalue()`, and `ggflexsurvplot()`.
- **No regression on the unresolvable case**: a formula variable local to an already-exited function still errors (the `tryCatch` fallback never silently returns a wrong formula) — unchanged from before, honestly scoped in the test/NEWS.
- All 5 callers checked (surv_pvalue, ggsurvplot(_add_all/_facet/_group_by), ggflexsurvplot). Regression test added; clean-session suite green (`Rscript --vanilla` → FAIL 0 · WARN 0 · PASS 76).
- Two independent adversarial reviewers both PASS.

Fixes #324
Fixes #341
Fixes #602
