### PR TITLE
Fix add.all legend "matches multiple formal arguments" error (#566)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 ## Bug fixes
 
+- Fix `ggsurvplot(..., add.all = TRUE)` (and `ggsurvplot_add_all()`) erroring with "argument matches multiple formal arguments" when a `legend` position was supplied: `legend` partial-matched `legend.title`/`legend.labs`; it is now an explicit forwarded argument (#566).
+
 - Fix `ggflexsurvplot()` collapsing a grouped Kaplan-Meier curve to a single "All" stratum when the grouping covariate is a factor: `is_factor_or_character()` called ggplot2's `is.facet()` (a Facet-object test, always `FALSE` for a data column) instead of `is.factor()` (#408).
 - Fix `surv_group_by()` (and downstream `ggsurvplot_facet()` / grouped `surv_pvalue()`) failing with "cannot xtfrm data frame" when the input is a tibble: extract the grouping column with `data[[var]]` (a vector) instead of `data[, var]` (a one-column tibble) (#548, #670).
 - Fix `ggflexsurvplot()` erroring with "object '<name>' not found" when the model's data object is out of scope at plot time (even with `data =` supplied): the already-resolved `data` is now forwarded to the internal `.extract.survfit()` instead of being re-derived from `fit$call$data` (#436).

--- a/R/ggsurvplot_add_all.R
+++ b/R/ggsurvplot_add_all.R
@@ -27,8 +27,11 @@ NULL
 #'
 #' @export
 ggsurvplot_add_all <- function(fit, data, legend.title = "Strata", legend.labs = NULL,
-                               pval = FALSE,  ...)
+                               pval = FALSE, legend = "top", ...)
 {
+  # `legend` is an explicit argument (not left to `...`) because it partial-matches
+  # both `legend.title` and `legend.labs`, which made `legend = "right"` raise
+  # "argument matches multiple formal arguments" before reaching ggsurvplot_core (#566).
 
   .dots <- list(...)
   # Extract fit components
@@ -69,7 +72,8 @@ ggsurvplot_add_all <- function(fit, data, legend.title = "Strata", legend.labs =
                       pval = pval, pval.coord = .dots$pval.coord,
                       pval.method.coord = .dots$pval.method.coord)
 
-  p <- ggsurvplot_core(newfit, data = data, legend.title = legend.title, legend.labs = legend.labs,
+  p <- ggsurvplot_core(newfit, data = data, legend = legend,
+                       legend.title = legend.title, legend.labs = legend.labs,
                        pval = pval$pval.txt,  ...)
 
   p

--- a/man/ggsurvplot_add_all.Rd
+++ b/man/ggsurvplot_add_all.Rd
@@ -10,6 +10,7 @@ ggsurvplot_add_all(
   legend.title = "Strata",
   legend.labs = NULL,
   pval = FALSE,
+  legend = "top",
   ...
 )
 }
@@ -29,6 +30,11 @@ those strata.}
 p-value is added on the plot. If numeric, than the computet p-value is
 substituted with the one passed with this parameter. If character, then the
 customized string appears on the plot. See examples - Example 3.}
+
+\item{legend}{character specifying legend position. Allowed values are one of
+c("top", "bottom", "left", "right", "none"). Default is "top" side position.
+to remove the legend use legend = "none". Legend position can be also
+specified using a numeric vector c(x, y); see details section.}
 
 \item{...}{other arguments passed to the \code{\link{ggsurvplot}()} function.}
 }

--- a/tests/testthat/test-add-all-legend.R
+++ b/tests/testthat/test-add-all-legend.R
@@ -1,0 +1,20 @@
+context("ggsurvplot_add_all legend")
+
+# Regression test for #566: `legend = "right"` partial-matched BOTH `legend.title`
+# and `legend.labs`, raising "argument matches multiple formal arguments" before
+# reaching ggsurvplot_core(). `legend` is now an explicit argument and forwarded,
+# so any legend position works with add.all.
+test_that("ggsurvplot_add_all() accepts a legend position (#566)", {
+  library(survival)
+  fit <- survfit(Surv(time, status) ~ sex, data = colon)
+
+  for (pos in c("right", "bottom", "left", "none", "top")) {
+    p <- ggsurvplot_add_all(fit, colon, legend = pos)
+    expect_identical(
+      ggplot2::ggplot_build(p$plot)$plot$theme$legend.position, pos
+    )
+  }
+
+  # also via the ggsurvplot(add.all = TRUE) entry point (the reported call)
+  expect_error(ggsurvplot(fit, data = colon, add.all = TRUE, legend = "right"), NA)
+})


### PR DESCRIPTION
## Problem

`ggsurvplot_add_all(fit, data, legend = "right")` — and `ggsurvplot(..., add.all = TRUE, legend = "right")` — errored:
```
Error: argument N matches multiple formal arguments
```
because `legend` was left to `...` and **partial-matched both `legend.title` and `legend.labs`** formals (ambiguous), failing at call-time before reaching `ggsurvplot_core()`.

## Fix

Make `legend` an explicit argument of `ggsurvplot_add_all()` (default `"top"`, placed after `pval` so existing formal positions are unchanged) and forward it:
```r
ggsurvplot_core(newfit, data = data, legend = legend,
                legend.title = legend.title, legend.labs = legend.labs,
                pval = pval$pval.txt, ...)
```

## Verification / no-regression
- Reported error gone: all positions (`top`/`bottom`/`left`/`right`/`none`) and numeric `c(x, y)` coordinates work, via both `ggsurvplot_add_all()` and `ggsurvplot(add.all = TRUE)`.
- **Byte-identical when `legend` not supplied**: the default `"top"` equals `ggsurvplot_core()`'s own default, so a plain `ggsurvplot_add_all(fit, data)` build is unchanged (verified `data.survplot`/`ggplot_build`/strata/legend identical vs master).
- `legend` is bound to the explicit formal (not double-passed via `...`); other `...` args (`palette`, `conf.int`, `risk.table`, `pval.coord`, …) still forward; no new partial-match ambiguity introduced.
- Hand-edited `man/ggsurvplot_add_all.Rd` is **identical** to `roxygen2::document()` output (a reviewer regenerated to confirm); `tools::checkRd` + `checkDocFiles` clean.
- Regression test added; clean-session suite green (`Rscript --vanilla` → FAIL 0 · WARN 0 · PASS 82).
- Two independent adversarial reviewers both PASS.

Fixes #566
