### PR TITLE
Fix ggcompetingrisks single-panel confidence bands mixing across groups (#490)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 ## Bug fixes
 
+- Fix `ggcompetingrisks(..., multiple_panels = FALSE, conf.int = TRUE)` drawing incorrect confidence bands that jumped between groups of the same event: the ribbon was grouped only by `event`; it is now grouped by `interaction(event, group)` (#490).
+
 - Fix `ggsurvplot(..., add.all = TRUE)` (and `ggsurvplot_add_all()`) erroring with "argument matches multiple formal arguments" when a `legend` position was supplied: `legend` partial-matched `legend.title`/`legend.labs`; it is now an explicit forwarded argument (#566).
 
 - Fix `ggflexsurvplot()` collapsing a grouped Kaplan-Meier curve to a single "All" stratum when the grouping covariate is a factor: `is_factor_or_character()` called ggplot2's `is.facet()` (a Facet-object test, always `FALSE` for a data column) instead of `is.factor()` (#408).

--- a/R/ggcompetingrisks.R
+++ b/R/ggcompetingrisks.R
@@ -92,7 +92,13 @@ ggcompetingrisks.cuminc <- function(fit, gnames = NULL, gsep=" ",
     pl <- ggplot(df, aes(time, est, color=event, linetype=group))
   }
   if (conf.int) {
-    pl <- pl + geom_ribbon(aes(ymin = est - coef*std, ymax=est + coef*std, fill = event), alpha = 0.2, linetype=0)
+    # Group the ribbon by event AND group. Mapping only fill=event makes the
+    # ribbon's implicit grouping ignore `group`, so in a single panel the bands
+    # jump between groups of the same event (#490). interaction(event, group) is
+    # a no-op for the faceted case (one group per panel).
+    pl <- pl + geom_ribbon(aes(ymin = est - coef*std, ymax = est + coef*std,
+                               fill = event, group = interaction(event, group)),
+                           alpha = 0.2, linetype = 0)
   }
   pl +
     geom_line()

--- a/tests/testthat/test-ggcompetingrisks-ribbon.R
+++ b/tests/testthat/test-ggcompetingrisks-ribbon.R
@@ -1,0 +1,23 @@
+context("ggcompetingrisks ribbon grouping")
+
+# Regression test for #490: in a SINGLE panel with conf.int = TRUE, the
+# confidence ribbon mapped only fill = event, so its implicit grouping ignored
+# `group` and the bands jumped between groups of the same event ("messed up
+# plot"). The ribbon is now grouped by interaction(event, group), giving one
+# band per event x group.
+test_that("single-panel ggcompetingrisks conf.int groups ribbons by event x group (#490)", {
+  skip_if_not_installed("cmprsk")
+  ov <- survival::ovarian
+  ci <- cmprsk::cuminc(ov$futime, ov$fustat, cencode = 2, group = ov$resid.ds)
+
+  p <- ggcompetingrisks(ci, multiple_panels = FALSE, conf.int = TRUE)
+  b <- ggplot2::ggplot_build(p)
+  ribbon_idx <- which(vapply(p$layers,
+                             function(l) inherits(l$geom, "GeomRibbon"),
+                             logical(1)))
+  rb <- b$data[[ribbon_idx]]
+
+  # 2 events x 2 groups => 4 distinct ribbons (was 2, event-only, which mixed
+  # the bands across groups).
+  expect_equal(length(unique(rb$group)), 4L)
+})


### PR DESCRIPTION
## Problem

`ggcompetingrisks(fit, multiple_panels = FALSE, conf.int = TRUE)` drew **incorrect** confidence bands that jumped between groups of the same event — the `geom_ribbon()` mapped only `fill = event`, so its implicit grouping ignored the `group` aesthetic. The OP: *"the confidence bands jump around between the values for the lines of the same status but different groups … impossible to check whether confidence intervals overlap."*

## Fix

Group the ribbon by `interaction(event, group)`:
```r
geom_ribbon(aes(ymin = est - coef*std, ymax = est + coef*std,
                fill = event, group = interaction(event, group)), alpha = 0.2, linetype = 0)
```

## Verification (visual before/after + built data)
- **Single-panel + conf.int (fixed):** before = jagged, criss-crossing triangular bands connecting one group's estimates to another's; after = clean per-curve step ribbons tracking each line. Built ribbon now has one group per event×group (4 = 2 events × 2 groups on `ovarian`/`resid.ds`), matching the line layer.
- **Multi-panel (`multiple_panels = TRUE`) — byte-identical:** each facet holds one group, so `interaction(event, group)` is a no-op; ribbon geometry (`x/ymin/ymax/PANEL/fill/alpha`) is `identical()` to master (60 rows). Only the internal `group` id differs.
- `conf.int = FALSE` (no ribbon) and single-group fits unaffected; `interaction()` produces no empty/NA groups or legend artifacts (all combos populated).
- Regression test added; clean-session suite green (`Rscript --vanilla` → FAIL 0 · PASS 83; the 1 warning is a pre-existing unrelated `data(lung)` note).
- Two independent adversarial reviewers both PASS (both viewed the before/after images and confirmed the geometry correction + no multi-panel regression).

Fixes #490
