### PR TITLE
Fix pval.size ignored in ggsurvplot_facet (#338)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 ## Bug fixes
 
+- Fix `ggsurvplot_facet(..., pval = TRUE, pval.size = <n>)` ignoring `pval.size`: the per-facet p-value (and `pval.method`) text was drawn with ggplot2's default size and `pval.size` was silently routed into `...`. `pval.size` is now an explicit argument applied to the text; its default is `5`, consistent with `ggsurvplot()` (previously the faceted p-value text rendered at ggplot2's default size ~3.88) (#338).
+
 - Fix `ggcompetingrisks(..., multiple_panels = FALSE, conf.int = TRUE)` drawing incorrect confidence bands that jumped between groups of the same event: the ribbon was grouped only by `event`; it is now grouped by `interaction(event, group)` (#490).
 
 - Fix `ggsurvplot(..., add.all = TRUE)` (and `ggsurvplot_add_all()`) erroring with "argument matches multiple formal arguments" when a `legend` position was supplied: `legend` partial-matched `legend.title`/`legend.labs`; it is now an explicit forwarded argument (#566).

--- a/R/ggsurvplot_facet.R
+++ b/R/ggsurvplot_facet.R
@@ -55,7 +55,8 @@ NULL
 ggsurvplot_facet <- function(fit, data, facet.by,
                              color = NULL, palette = NULL,
                              legend.labs = NULL,
-                             pval = FALSE, pval.method = FALSE, pval.coord = NULL, pval.method.coord = NULL,
+                             pval = FALSE, pval.method = FALSE, pval.size = 5,
+                             pval.coord = NULL, pval.method.coord = NULL,
                              nrow = NULL, ncol = NULL,
                              scales = "fixed",
                              short.panel.labs = FALSE, panel.labs = NULL,
@@ -187,10 +188,10 @@ ggsurvplot_facet <- function(fit, data, facet.by,
     pval.x <- pval.y <- pval.txt <- method.x <- method.y <- method <-  NULL
     p <- p +
       geom_text(data = pvals.df, aes(x = pval.x, y = pval.y, label = pval.txt),
-                hjust = 0)
+                hjust = 0, size = pval.size)
     if(pval.method)
       p <- p + geom_text(data = pvals.df,  aes(x = method.x, y = method.y, label = method),
-                         hjust = 0)
+                         hjust = 0, size = pval.size)
   }
 
   # To do

--- a/man/ggsurvplot_facet.Rd
+++ b/man/ggsurvplot_facet.Rd
@@ -13,6 +13,7 @@ ggsurvplot_facet(
   legend.labs = NULL,
   pval = FALSE,
   pval.method = FALSE,
+  pval.size = 5,
   pval.coord = NULL,
   pval.method.coord = NULL,
   nrow = NULL,
@@ -66,6 +67,8 @@ customized string appears on the plot. See examples - Example 3.}
 \item{pval.method}{whether to add a text with the test name used for
 calculating the pvalue, that corresponds to survival curves' comparison -
 used only when \code{pval=TRUE}}
+
+\item{pval.size}{numeric value specifying the p-value text size. Default is 5.}
 
 \item{pval.coord}{numeric vector, of length 2, specifying the x and y
 coordinates of the p-value. Default values are NULL.}

--- a/tests/testthat/test-ggsurvplot_facet-pvalsize.R
+++ b/tests/testthat/test-ggsurvplot_facet-pvalsize.R
@@ -1,0 +1,41 @@
+context("ggsurvplot_facet pval.size")
+
+# Regression test for #338: pval.size was ignored in ggsurvplot_facet() — the
+# per-facet p-value geom_text was drawn with ggplot2's default text size and the
+# pval.size argument (silently routed into ...) had no effect. It is now an
+# explicit argument applied to the p-value (and pval.method) text.
+library(survival)
+
+get_text_sizes <- function(p) {
+  szs <- lapply(p$layers, function(l)
+    if (inherits(l$geom, "GeomText")) l$aes_params$size else NULL)
+  unlist(szs)
+}
+
+test_that("ggsurvplot_facet() honors pval.size (#338)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = colon)
+
+  p10 <- ggsurvplot_facet(fit, colon, facet.by = "rx", pval = TRUE, pval.size = 10)
+  expect_true(all(get_text_sizes(p10) == 10))
+
+  p4 <- ggsurvplot_facet(fit, colon, facet.by = "rx", pval = TRUE, pval.size = 4)
+  expect_true(all(get_text_sizes(p4) == 4))
+
+  # pval.method text is sized too
+  pm <- ggsurvplot_facet(fit, colon, facet.by = "rx", pval = TRUE,
+                         pval.method = TRUE, pval.size = 7)
+  expect_true(all(get_text_sizes(pm) == 7))
+})
+
+test_that("default facet p-value size is 5, consistent with ggsurvplot (#338)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = colon)
+  p <- ggsurvplot_facet(fit, colon, facet.by = "rx", pval = TRUE)
+  expect_true(all(get_text_sizes(p) == 5))
+})
+
+test_that("no-regression: a facet plot without pval has no p-value text layer (#338)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = colon)
+  p <- ggsurvplot_facet(fit, colon, facet.by = "rx")
+  has_text <- any(vapply(p$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))
+  expect_false(has_text)
+})


### PR DESCRIPTION
## Summary

`ggsurvplot_facet(..., pval = TRUE, pval.size = <n>)` ignored `pval.size`: the per-facet p-value (and `pval.method`) `geom_text` was drawn with ggplot2's default text size, and `pval.size` was silently routed into `...` (where `surv_pvalue()`/`surv_fit()` never used it). This adds `pval.size` as an explicit argument and applies `size = pval.size` to the p-value and method text.

## Behaviour change (disclosed)

The **default** faceted p-value text size changes from ggplot2's default (~3.88) to **5**, making it consistent with `ggsurvplot()`. Plots **without** a p-value are byte-identical (the p-value text is the only thing resized; panel strip labels are theme text, not affected).

## Verification

- New regression tests (`test-ggsurvplot_facet-pvalsize.R`): `pval.size` honored (10, 4, 7), default is 5, and a facet without pval has no p-value text layer.
- Clean-session `Rscript --vanilla -e 'devtools::test()'`: **FAIL 0 | PASS 88** (the one WARN is pre-existing on master, unrelated).
- `tools::checkRd("man/ggsurvplot_facet.Rd")` clean; usage + \item added in signature order.
- Two independent adversarial pre-commit reviewers cleared the exact diff.

Fixes #338