### PR TITLE
Add pval.digits argument to surv_pvalue() (#343)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Minor changes
 
+- `surv_pvalue()` gains a `pval.digits` argument controlling the number of significant digits used to format the p-value in `pval.txt` (default `2`, unchanged; e.g. `pval.digits = 3` gives `"p = 0.00131"`). Requested for journals that report p-values to 3 digits (#343).
+
 ## Bug fixes
 
 - Fix `ggsurvplot_facet(..., pval = TRUE, pval.size = <n>)` ignoring `pval.size`: the per-facet p-value (and `pval.method`) text was drawn with ggplot2's default size and `pval.size` was silently routed into `...`. `pval.size` is now an explicit argument applied to the text; its default is `5`, consistent with `ggsurvplot()` (previously the faceted p-value text rendered at ggplot2's default size ~3.88) (#338).

--- a/R/surv_pvalue.R
+++ b/R/surv_pvalue.R
@@ -31,10 +31,14 @@ NULL
 #'  for trend can be only performed when the number of groups is > 2.
 #'@param combine logical value. Used only when fit is a list of survfit objects.
 #'  If TRUE, combine the results for multiple fits.
-#'@param ... other arguments including pval, pval.coord, pval.method.coord.
-#'  These are only used internally to specify custom pvalue, pvalue and pvalue
-#'  method coordinates on the survival plot. Normally, users don't need these
-#'  arguments.
+#'@param ... other arguments. One useful argument is \code{pval.digits}: the
+#'  number of significant digits used to format the p-value in the returned
+#'  \code{pval.txt}. Default is 2 (e.g. \code{"p = 0.0013"}); set
+#'  \code{pval.digits = 3} for \code{"p = 0.00131"}, etc. P-values below 0.0001
+#'  are still reported as \code{"p < 0.0001"}. The remaining arguments (pval,
+#'  pval.coord, pval.method.coord) are only used internally to specify custom
+#'  pvalue and pvalue-method coordinates on the survival plot; normally users
+#'  don't need them.
 #'
 #'@return  Return a data frame with the columns (pval, method, pval.txt and
 #'  variable). If additional arguments (pval, pval.coord, pval.method.coord,
@@ -104,6 +108,10 @@ surv_pvalue <- function(fit, data = NULL, method = "survdiff", test.for.trend = 
   if("pval" %in% .dots_n) pval <- .dots$pval
   if("pval.coord" %in% .dots_n) pval.coord <- .dots$pval.coord
   if("pval.method.coord" %in% .dots_n) pval.method.coord <- .dots$pval.method.coord
+  # pval.digits is read from ... (rather than a formal) so that a bare `pval`
+  # argument passed by callers does not partial-match it (#343).
+  pval.digits <- 2
+  if("pval.digits" %in% .dots_n) pval.digits <- .dots$pval.digits
 
   get_coord <- ("pval.coord" %in% .dots_n) | ("pval.method.coord" %in% .dots_n) | !is.null(.dots$get_coord)
 
@@ -117,18 +125,21 @@ surv_pvalue <- function(fit, data = NULL, method = "survdiff", test.for.trend = 
     res <- purrr::map2(fit, data, .pvalue,
                        method = method,  pval = pval,
                        pval.coord = pval.coord,  pval.method.coord = pval.method.coord,
-                       get_coord =  get_coord, test.for.trend = test.for.trend )
+                       get_coord =  get_coord, test.for.trend = test.for.trend,
+                       pval.digits = pval.digits )
   }
   else if(.is_list(fit)){
     res <- purrr::map(fit, .pvalue,
                       data = data, method = method,  pval = pval,
                       pval.coord = pval.coord,  pval.method.coord = pval.method.coord,
-                      get_coord  =  get_coord, test.for.trend = test.for.trend)
+                      get_coord  =  get_coord, test.for.trend = test.for.trend,
+                      pval.digits = pval.digits)
   }
   else{
     res <- .pvalue(fit, data = data, method = method,  pval = pval,
                    pval.coord = pval.coord,  pval.method.coord = pval.method.coord,
-                   get_coord  =  get_coord, test.for.trend = test.for.trend ) %>%
+                   get_coord  =  get_coord, test.for.trend = test.for.trend,
+                   pval.digits = pval.digits ) %>%
       dplyr::select(variable, dplyr::everything())
   }
 
@@ -153,7 +164,7 @@ surv_pvalue <- function(fit, data = NULL, method = "survdiff", test.for.trend = 
 # Will be used for a list of fits
 .pvalue <- function(fit, data, method = "survdiff",  pval = TRUE,
                     pval.coord = NULL,  pval.method.coord = NULL, get_coord = FALSE,
-                    test.for.trend = FALSE)
+                    test.for.trend = FALSE, pval.digits = 2)
 {
 
   if(is.null(method)) method <- "survdiff"
@@ -212,7 +223,7 @@ surv_pvalue <- function(fit, data = NULL, method = "survdiff", test.for.trend = 
                                   subset = eval(fit$call$subset))
     pvalue <- stats::pchisq(sdiff$chisq, length(sdiff$n) - 1, lower.tail = FALSE)
     pval.txt <- ifelse(pvalue < 1e-04, "p < 0.0001",
-                       paste("p =", signif(pvalue, 2)))
+                       paste("p =", signif(pvalue, pval.digits)))
     res <- list(pval = pvalue, method = "Log-rank", pval.txt = pval.txt)
   }
   # Weighted log-rank tests (internal implementation)
@@ -224,7 +235,7 @@ surv_pvalue <- function(fit, data = NULL, method = "survdiff", test.for.trend = 
     )
     pvalue <- round(wlr$pvalue, 4)
     pval.txt <- ifelse(pvalue < 1e-04, "p < 0.0001",
-                       paste("p =", signif(pvalue, 2)))
+                       paste("p =", signif(pvalue, pval.digits)))
     res <- list(pval = pvalue, method = wlr$method_name, pval.txt = pval.txt)
   }
   res$variable <- .collapse(surv.vars, sep =  "+")

--- a/man/surv_pvalue.Rd
+++ b/man/surv_pvalue.Rd
@@ -44,10 +44,14 @@ for trend can be only performed when the number of groups is > 2.}
 \item{combine}{logical value. Used only when fit is a list of survfit objects.
 If TRUE, combine the results for multiple fits.}
 
-\item{...}{other arguments including pval, pval.coord, pval.method.coord.
-These are only used internally to specify custom pvalue, pvalue and pvalue
-method coordinates on the survival plot. Normally, users don't need these
-arguments.}
+\item{...}{other arguments. One useful argument is \code{pval.digits}: the
+number of significant digits used to format the p-value in the returned
+\code{pval.txt}. Default is 2 (e.g. \code{"p = 0.0013"}); set
+\code{pval.digits = 3} for \code{"p = 0.00131"}, etc. P-values below 0.0001
+are still reported as \code{"p < 0.0001"}. The remaining arguments (pval,
+pval.coord, pval.method.coord) are only used internally to specify custom
+pvalue and pvalue-method coordinates on the survival plot; normally users
+don't need them.}
 }
 \value{
 Return a data frame with the columns (pval, method, pval.txt and

--- a/tests/testthat/test-surv_pvalue-digits.R
+++ b/tests/testthat/test-surv_pvalue-digits.R
@@ -1,0 +1,36 @@
+context("surv_pvalue pval.digits")
+
+# Regression test for #343: surv_pvalue()$pval.txt used a hard-coded 2
+# significant digits. A pval.digits argument now controls the number of
+# significant digits; its default (2) reproduces the previous output exactly.
+library(survival)
+
+test_that("surv_pvalue() default pval.digits is unchanged (#343)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  # default must be byte-identical to the previous hard-coded signif(pvalue, 2)
+  expect_identical(surv_pvalue(fit, data = lung)$pval.txt, "p = 0.0013")
+  expect_identical(surv_pvalue(fit, data = lung, pval.digits = 2)$pval.txt, "p = 0.0013")
+})
+
+test_that("surv_pvalue() honors pval.digits (#343)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  expect_identical(surv_pvalue(fit, data = lung, pval.digits = 3)$pval.txt, "p = 0.00131")
+  expect_identical(surv_pvalue(fit, data = lung, pval.digits = 4)$pval.txt, "p = 0.001311")
+  expect_identical(surv_pvalue(fit, data = lung, pval.digits = 1)$pval.txt, "p = 0.001")
+})
+
+test_that("pval.digits leaves the '< 0.0001' floor and the numeric pval intact (#343)", {
+  fit <- survfit(Surv(time, status) ~ ph.ecog, data = subset(lung, ph.ecog < 3))
+  res2 <- surv_pvalue(fit, data = subset(lung, ph.ecog < 3), pval.digits = 2)
+  res5 <- surv_pvalue(fit, data = subset(lung, ph.ecog < 3), pval.digits = 5)
+  # the numeric p-value must not depend on the display digits
+  expect_equal(res2$pval, res5$pval)
+})
+
+test_that("pval.digits works through the list (facet) code path (#343)", {
+  gb <- surv_group_by(lung, "sex")
+  fits <- surv_fit(Surv(time, status) ~ ph.ecog, data = gb$data)
+  res <- surv_pvalue(fits, gb$data, pval.digits = 3)
+  expect_true(is.list(res))
+  expect_true(all(grepl("^p [=<]", vapply(res, function(x) x$pval.txt, character(1)))))
+})


### PR DESCRIPTION
## Summary

`surv_pvalue()$pval.txt` used a hard-coded 2 significant digits. This adds a `pval.digits` argument controlling the number of significant digits in the formatted p-value. Default is **2 (unchanged)**; e.g. `pval.digits = 3` gives `"p = 0.00131"`. P-values below 0.0001 are still reported as `"p < 0.0001"`.

## Design note (partial-matching)

`pval.digits` is read from `...` rather than added as a formal of `surv_pvalue()`. Callers pass a bare `pval =` argument that `surv_pvalue()` reads from `...`; a `pval.digits` **formal** would be partial-matched by `pval =` (R argument matching), which broke `ggsurvplot_core`/`ggsurvplot_add_all`/`ggsurvplot_facet` with "non-numeric argument to signif". Reading it from `...` avoids this; the internal `.pvalue()` keeps it as a formal (safe — it has an exact `pval` formal).

## Verification

- New regression tests: default byte-identical (`"p = 0.0013"`), `pval.digits = 3/4/1` honored, numeric `$pval` unaffected, list/facet path works.
- No-regression: `ggsurvplot(pval=TRUE)`, `ggsurvplot_add_all()`, `ggsurvplot_facet(pval=TRUE)` all render (the partial-match paths).
- Clean-session `Rscript --vanilla -e 'devtools::test()'`: **FAIL 0 | PASS 96**.
- `tools::checkRd("man/surv_pvalue.Rd")` clean (documented under `...`, no phantom formal).
- Two independent adversarial pre-commit reviewers cleared the diff.

Note: applies to `surv_pvalue()` directly (and threads through `ggsurvplot_facet`); threading `pval.digits` onto the main `ggsurvplot()` label can be a follow-up.

Fixes #343