### PR TITLE
Add global.stats argument to ggforest() (#392)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Minor changes
 
+- `ggforest()` gains a `global.stats` argument. Set `global.stats = FALSE` to omit the bottom caption reporting the global statistics (number of events, global log-rank p-value, AIC, concordance index) — useful when arranging several forest plots in a panel. Default is `TRUE` (unchanged) (#392).
+
 - `surv_pvalue()` gains a `pval.digits` argument controlling the number of significant digits used to format the p-value in `pval.txt` (default `2`, unchanged; e.g. `pval.digits = 3` gives `"p = 0.00131"`). Requested for journals that report p-values to 3 digits (#343).
 
 ## Bug fixes

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -9,6 +9,10 @@
 #' @param fontsize relative size of annotations in the plot. Default value: 0.7.
 #' @param refLabel label for reference levels of factor variables.
 #' @param noDigits number of digits for estimates and p-values in the plot.
+#' @param global.stats logical value. Default is TRUE. If FALSE, the bottom
+#'   caption reporting the global statistics (number of events, global log-rank
+#'   p-value, AIC and concordance index) is omitted. Useful when arranging
+#'   several forest plots in a panel.
 #'
 #' @return returns a ggplot2 object (invisibly)
 #'
@@ -40,7 +44,8 @@
 
 ggforest <- function(model, data = NULL,
   main = "Hazard ratio", cpositions=c(0.02, 0.22, 0.4),
-  fontsize = 0.7, refLabel = "reference", noDigits=2) {
+  fontsize = 0.7, refLabel = "reference", noDigits=2,
+  global.stats = TRUE) {
   conf.high <- conf.low <- estimate <- NULL
   stopifnot(inherits(model, "coxph"))
 
@@ -166,7 +171,11 @@ ggforest <- function(model, data = NULL,
       vjust = 1.1,  fontface = "italic") +
     annotate(geom = "text", x = x_annotate, y = exp(y_stars),
       label = toShowExpClean$stars, size = annot_size_mm,
-      hjust = -0.2,  fontface = "italic") +
+      hjust = -0.2,  fontface = "italic")
+  # Global statistics caption (# events, global p-value, AIC, concordance).
+  # Optional: set global.stats = FALSE to omit it (e.g. panels of forest plots).
+  if (global.stats)
+    p <- p +
     annotate(geom = "text", x = 0.5, y = exp(y_variable),
       label = paste0("# Events: ", gmodel$nevent, "; Global p-value (Log-Rank): ",
         format.pval(gmodel$p.value.log, eps = ".001"), " \nAIC: ", round(gmodel$AIC,2),

--- a/man/ggforest.Rd
+++ b/man/ggforest.Rd
@@ -11,7 +11,8 @@ ggforest(
   cpositions = c(0.02, 0.22, 0.4),
   fontsize = 0.7,
   refLabel = "reference",
-  noDigits = 2
+  noDigits = 2,
+  global.stats = TRUE
 )
 }
 \arguments{
@@ -29,6 +30,11 @@ will be extracted from 'fit' object.}
 \item{refLabel}{label for reference levels of factor variables.}
 
 \item{noDigits}{number of digits for estimates and p-values in the plot.}
+
+\item{global.stats}{logical value. Default is TRUE. If FALSE, the bottom caption
+reporting the global statistics (number of events, global log-rank p-value, AIC
+and concordance index) is omitted. Useful when arranging several forest plots in
+a panel.}
 }
 \value{
 returns a ggplot2 object (invisibly)

--- a/tests/testthat/test-ggforest-global-stats.R
+++ b/tests/testthat/test-ggforest-global-stats.R
@@ -1,0 +1,38 @@
+context("ggforest global.stats")
+
+# Regression test for #392: ggforest() always drew the global-statistics caption
+# ("# Events; Global p-value; AIC; Concordance Index") at the bottom, with no way
+# to omit it (e.g. when arranging several forest plots in a panel). A global.stats
+# argument now controls it; the default (TRUE) keeps the caption unchanged.
+library(survival)
+
+# ggforest() returns ggpubr::as_ggplot(gtable); the forest itself lives in a
+# single GeomCustomAnn layer whose grob is the assembled gtable. Search that grob
+# tree for the caption text.
+caption_present <- function(g) {
+  grob <- g$layers[[1]]$geom_params$grob
+  labels <- character(0)
+  rec <- function(x) {
+    if (!is.null(x$label)) labels <<- c(labels, unlist(x$label))
+    if (!is.null(x$grobs)) lapply(x$grobs, rec)
+    if (!is.null(x$children)) lapply(x$children, rec)
+    invisible(NULL)
+  }
+  rec(grob)
+  any(grepl("# Events", labels))
+}
+
+test_that("ggforest() draws the global-statistics caption by default (#392)", {
+  cm <- coxph(Surv(time, status) ~ age + sex + ph.ecog, data = lung)
+  g <- ggforest(cm, data = lung)
+  expect_true(caption_present(g))
+  expect_true(caption_present(ggforest(cm, data = lung, global.stats = TRUE)))
+})
+
+test_that("ggforest(global.stats = FALSE) omits the global-statistics caption (#392)", {
+  cm <- coxph(Surv(time, status) ~ age + sex + ph.ecog, data = lung)
+  g <- ggforest(cm, data = lung, global.stats = FALSE)
+  expect_false(caption_present(g))
+  # the plot still builds without error
+  expect_s3_class(g, "ggplot")
+})


### PR DESCRIPTION
## Summary

`ggforest()` always drew the bottom caption reporting the global statistics (number of events, global log-rank p-value, AIC, concordance index), with no way to omit it. This adds a `global.stats` argument; set `global.stats = FALSE` to hide that caption — useful when arranging several forest plots in a panel (requested with a fork in the issue). Default is **TRUE (unchanged)**.

## Implementation

The global-stats `annotate()` is moved out of the `p` build chain and added conditionally: `if (global.stats) p <- p + annotate(...)`. Nothing else changes.

## Verification

- New regression tests: default draws the caption; `global.stats = FALSE` omits it (verified by searching the returned `as_ggplot(gtable)` grob tree for the caption text).
- No-regression: default output byte-identical — the caption `annotate()` and all other layers are unchanged; `global.stats = FALSE` removes exactly the one caption string and nothing else (confirmed via `setdiff()` on the label set).
- Edge cases (single covariate, factor, interaction) render for both values.
- `ggforest()` has no `...` and `global.stats` collides with no existing argument.
- Clean-session `Rscript --vanilla -e 'devtools::test()'`: **FAIL 0 | PASS 100**; `tools::checkRd("man/ggforest.Rd")` clean.
- Two independent adversarial pre-commit reviewers cleared the diff.

Fixes #392