### PR TITLE
Draw median survival lines in ggsurvplot_combine (#316)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 ## Bug fixes
 
+- Fix `ggsurvplot_combine(..., surv.median.line = "hv")` (or `"h"`/`"v"`) not drawing the median survival lines: `surv.median.line` was forwarded to `ggsurvplot_df()` (which does not handle it) and silently ignored. The median lines are now computed from the combined fits and drawn on the plot (#316).
+
 - Fix `ggsurvplot_facet(..., pval = TRUE, pval.size = <n>)` ignoring `pval.size`: the per-facet p-value (and `pval.method`) text was drawn with ggplot2's default size and `pval.size` was silently routed into `...`. `pval.size` is now an explicit argument applied to the text; its default is `5`, consistent with `ggsurvplot()` (previously the faceted p-value text rendered at ggplot2's default size ~3.88) (#338).
 
 - Fix `ggcompetingrisks(..., multiple_panels = FALSE, conf.int = TRUE)` drawing incorrect confidence bands that jumped between groups of the same event: the ribbon was grouped only by `event`; it is now grouped by `interaction(event, group)` (#490).

--- a/R/ggsurvplot_combine.R
+++ b/R/ggsurvplot_combine.R
@@ -125,6 +125,24 @@ ggsurvplot_combine <- function(fit, data,
     # Survplot of combined survsummary data frame
     #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
     p <- ggsurvplot_df(all.survsummary, ggtheme = ggtheme, ...)
+
+    # Median survival lines. ggsurvplot_df() does not draw them (that is handled
+    # in ggsurvplot_core for a single fit); forward surv.median.line here by
+    # computing the medians from the list of fits (#316).
+    surv.median.line <- .dots$surv.median.line
+    if(is.null(surv.median.line)) surv.median.line <- "none"
+    surv.median.line <- match.arg(surv.median.line, c("none", "hv", "h", "v"))
+    if(surv.median.line %in% c("hv", "h", "v")){
+      .fun <- .dots$fun
+      if(!is.null(.fun) && .fun %in% c("cumhaz", "cloglog"))
+        warning("Adding survival median lines is not allowed when fun is: ", .fun)
+      else {
+        med_y <- if(!is.null(.fun) && .fun == "pct") 50 else 0.5
+        medians <- surv_median(fit, combine = TRUE)$median
+        p <- .add_median_lines(p, medians, type = surv.median.line, med_y = med_y)
+      }
+    }
+
     res <- list(plot = p)
 
 

--- a/R/ggsurvplot_core.R
+++ b/R/ggsurvplot_core.R
@@ -461,6 +461,36 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
 }
 
 
+# Draw median survival lines from a precomputed vector of median survival
+# times. Used by ggsurvplot_combine(), which works from a list of fits (combined
+# into one data frame) rather than a single survfit object, so it cannot use
+# .add_surv_median() above. NA medians (median not reached) are dropped.
+.add_median_lines <- function(p, medians, type = "hv", med_y = 0.5,
+                              color = "black", linetype = "dashed", size = 0.5){
+  x <- y <- xend <- yend <- x1 <- x2 <- y1 <- y2 <- NULL
+  medians <- medians[!is.na(medians)]
+  if(length(medians) == 0){
+    warning("Median survival not reached.")
+    return(p)
+  }
+  if(type %in% c("hv", "h")){
+    h_line_data <- data.frame(x = 0, y = med_y, xend = max(medians), yend = med_y)
+    p <- p +
+      geom_segment(aes(x = .data$x, y = .data$y, xend = .data$xend, yend = .data$yend),
+                   data = h_line_data, linetype = linetype, linewidth = size, color = color)
+  }
+  if(type %in% c("hv", "v")){
+    v_line_data <- data.frame(x1 = medians, x2 = medians,
+                              y1 = rep(0, length(medians)),
+                              y2 = rep(med_y, length(medians)))
+    p <- p +
+      geom_segment(aes(x = .data$x1, y = .data$y1, xend = .data$x2, yend = .data$y2),
+                   data = v_line_data, linetype = linetype, linewidth = size, color = color)
+  }
+  p
+}
+
+
 
 # Put risk table inside main plot
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/tests/testthat/test-ggsurvplot_combine-median.R
+++ b/tests/testthat/test-ggsurvplot_combine-median.R
@@ -1,0 +1,44 @@
+context("ggsurvplot_combine surv.median.line")
+
+# Regression test for #316: surv.median.line was documented to pass from
+# ggsurvplot_combine() to ggsurvplot(), but it was forwarded to ggsurvplot_df()
+# (which does not draw median lines) and silently ignored. Median lines are now
+# computed from the list of fits and drawn on the combined plot.
+library(survival)
+
+n_segments <- function(p) {
+  sum(vapply(p$plot$layers, function(l) inherits(l$geom, "GeomSegment"), logical(1)))
+}
+
+test_that("ggsurvplot_combine() draws median lines when requested (#316)", {
+  fits <- list(all = survfit(Surv(time, status) ~ 1, data = colon),
+               rx  = survfit(Surv(time, status) ~ rx, data = colon))
+
+  # "hv" -> a horizontal + a vertical geom_segment layer
+  expect_equal(n_segments(ggsurvplot_combine(fits, data = colon, surv.median.line = "hv")), 2L)
+  # "v" and "h" -> a single geom_segment layer each
+  expect_equal(n_segments(ggsurvplot_combine(fits, data = colon, surv.median.line = "v")), 1L)
+  expect_equal(n_segments(ggsurvplot_combine(fits, data = colon, surv.median.line = "h")), 1L)
+})
+
+test_that("no-regression: ggsurvplot_combine() without surv.median.line draws no segments (#316)", {
+  fits <- list(all = survfit(Surv(time, status) ~ 1, data = colon),
+               rx  = survfit(Surv(time, status) ~ rx, data = colon))
+  expect_equal(n_segments(ggsurvplot_combine(fits, data = colon)), 0L)
+  expect_equal(n_segments(ggsurvplot_combine(fits, data = colon, surv.median.line = "none")), 0L)
+})
+
+test_that(".add_median_lines() drops NA medians and warns if none reached (#316)", {
+  p <- ggsurvplot_combine(
+    list(a = survfit(Surv(time, status) ~ 1, data = colon)),
+    data = colon, surv.median.line = "hv"
+  )
+  expect_s3_class(p$plot, "ggplot")
+  # a fit whose median is never reached (1 event, 9 censored) -> warning, no segment
+  d <- data.frame(time = 1:10, status = c(1, rep(0, 9)))
+  expect_warning(
+    ggsurvplot_combine(list(x = survfit(Surv(time, status) ~ 1, data = d)),
+                       data = d, surv.median.line = "hv"),
+    "Median survival not reached"
+  )
+})


### PR DESCRIPTION
## Summary

`surv.median.line` is documented to pass from `ggsurvplot_combine()` to `ggsurvplot()`, but it was forwarded to `ggsurvplot_df()` (which does not draw median lines — that logic lives in `ggsurvplot_core`) and silently ignored. This computes the medians from the list of fits and draws the horizontal/vertical median lines on the combined plot.

## Implementation

- New **internal** helper `.add_median_lines(p, medians, type, med_y)` draws the h/v `geom_segment` layers from a precomputed vector of median times (NA dropped; warns if none reached).
- `ggsurvplot_combine()` reads `surv.median.line` from `...`, validates it with `match.arg`, and (unless `fun` is `cumhaz`/`cloglog`) computes `surv_median(fit, combine = TRUE)$median` and calls the helper. `fun = "pct"` uses `med_y = 50`.
- The single-fit `.add_surv_median()` path is **untouched**.

## Verification

- Non-regression: `ggsurvplot_combine()` **without** `surv.median.line` draws 0 segments (byte-identical); single-fit `ggsurvplot(surv.median.line=)` unchanged.
- Correctness: lines drawn at each stratum's median; `surv_median(fit, combine=TRUE)$median` matches `summary(fit)$table[,"median"]`; geometry matches `.add_surv_median()`.
- Robustness: NA medians dropped + "Median survival not reached" warning; `fun="pct"`/`"cumhaz"` handled; `match.arg` validates.
- Regression tests added; clean-session `Rscript --vanilla -e 'devtools::test()'`: **FAIL 0 | PASS 107**.
- Two independent adversarial pre-commit reviewers cleared the diff.

Fixes #316