### PR TITLE
Skip non-continuous terms in ggcoxfunctional() (#357)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 ## Bug fixes
 
+- Fix `ggcoxfunctional()` erroring with a cryptic "'x' and 'y' lengths differ" when the Cox formula contains a factor/character covariate (or a `strata()` term): such terms are renamed/expanded in the model matrix and cannot be checked for functional form. They are now dropped with a warning, and only continuous covariates are plotted (#357).
+
 - Fix `ggsurvplot_combine(..., surv.median.line = "hv")` (or `"h"`/`"v"`) not drawing the median survival lines: `surv.median.line` was forwarded to `ggsurvplot_df()` (which does not handle it) and silently ignored. The median lines are now computed from the combined fits and drawn on the plot (#316).
 
 - Fix `ggsurvplot_facet(..., pval = TRUE, pval.size = <n>)` ignoring `pval.size`: the per-facet p-value (and `pval.method`) text was drawn with ggplot2's default size and `pval.size` was silently routed into `...`. `pval.size` is now an explicit argument applied to the text; its default is `5`, consistent with `ggsurvplot()` (previously the faceted p-value text rendered at ggplot2's default size ~3.88) (#338).

--- a/R/ggcoxfunctional.R
+++ b/R/ggcoxfunctional.R
@@ -62,6 +62,23 @@ ggcoxfunctional <- function (formula, data = NULL, fit, iter = 0, f = 0.6,
   attr(stats::terms(formula), "term.labels") -> explanatory.variables.names
   stats::model.matrix(formula, data = data) -> explanatory.variables.values
   SurvFormula <- deparse(formula[[2]])
+
+  # Keep only continuous terms. A functional-form (linearity) check plots
+  # martingale residuals against the covariate, which is only meaningful for
+  # continuous covariates. Factor/character terms (and terms such as strata())
+  # are expanded/renamed in the model matrix (e.g. 'sex' -> 'sex2'), so they do
+  # not match their term label and previously triggered a cryptic
+  # "'x' and 'y' lengths differ" error (#357). Drop them with a warning.
+  is_continuous <- explanatory.variables.names %in% colnames(explanatory.variables.values)
+  if(any(!is_continuous)){
+    warning("Skipping non-continuous term(s) in ggcoxfunctional(): ",
+            paste(explanatory.variables.names[!is_continuous], collapse = ", "),
+            ". Functional-form checks apply to continuous covariates only.",
+            call. = FALSE)
+    explanatory.variables.names <- explanatory.variables.names[is_continuous]
+  }
+  if(length(explanatory.variables.names) == 0)
+    stop("No continuous covariate to plot in ggcoxfunctional().", call. = FALSE)
   martingale_resid <- lowess_x <- lowess_y <- NULL
   lapply(explanatory.variables.names, function(i){
     which_col <- which(colnames(explanatory.variables.values) == i)

--- a/tests/testthat/test-ggcoxfunctional-nonnumeric.R
+++ b/tests/testthat/test-ggcoxfunctional-nonnumeric.R
@@ -1,0 +1,43 @@
+context("ggcoxfunctional non-continuous terms")
+
+# Regression test for #357: ggcoxfunctional() failed with a cryptic
+# "'x' and 'y' lengths differ" error when the Cox formula contained a factor or
+# character covariate (its model-matrix column is renamed, e.g. sex -> sex2, so
+# it no longer matches the term label). Non-continuous terms are now dropped
+# with a warning; continuous-only formulas are unaffected.
+library(survival)
+
+# complete-case numeric data to avoid the separate missing-data issue (#248)
+cc <- na.omit(lung[, c("time", "status", "age", "ph.karno", "wt.loss", "sex")])
+cc$sex <- factor(cc$sex, labels = c("male", "female"))
+
+test_that("ggcoxfunctional() skips a factor covariate with a warning (#357)", {
+  fit <- coxph(Surv(time, status) ~ age + sex + ph.karno, data = cc)
+  expect_warning(p <- ggcoxfunctional(fit, data = cc), "non-continuous")
+  expect_identical(names(p), c("age", "ph.karno"))   # sex dropped
+  expect_s3_class(p, "ggcoxfunctional")
+})
+
+test_that("ggcoxfunctional() also skips character terms and strata() (#357)", {
+  cc2 <- cc
+  cc2$grp <- ifelse(cc2$age > 60, "old", "young")
+  fit_chr <- coxph(Surv(time, status) ~ age + grp, data = cc2)
+  expect_warning(p <- ggcoxfunctional(fit_chr, data = cc2), "non-continuous")
+  expect_identical(names(p), "age")
+
+  fit_str <- coxph(Surv(time, status) ~ age + strata(sex), data = cc)
+  expect_warning(p2 <- ggcoxfunctional(fit_str, data = cc), "non-continuous")
+  expect_identical(names(p2), "age")
+})
+
+test_that("no-regression: a continuous-only formula is unaffected (#357)", {
+  fit <- coxph(Surv(time, status) ~ age + ph.karno, data = cc)
+  expect_silent(p <- ggcoxfunctional(fit, data = cc))
+  expect_identical(names(p), c("age", "ph.karno"))
+})
+
+test_that("ggcoxfunctional() errors clearly when no continuous covariate remains (#357)", {
+  fit <- coxph(Surv(time, status) ~ sex, data = cc)
+  expect_error(suppressWarnings(ggcoxfunctional(fit, data = cc)),
+               "No continuous covariate")
+})


### PR DESCRIPTION
## Summary

`ggcoxfunctional()` errored with a cryptic `"'x' and 'y' lengths differ"` when the Cox formula contained a factor/character covariate (or a `strata()` term). Such terms are renamed/expanded in the model matrix (e.g. `sex` → `sex2`), so `which(colnames(mm) == "sex")` returned nothing and the downstream data frame had mismatched lengths. A functional-form (linearity) check is only meaningful for continuous covariates anyway.

## Fix

Keep only terms whose label appears verbatim as a model-matrix column (`term.labels %in% colnames(model.matrix)`); drop the rest with a warning listing them; `stop()` with a clear message if none remain.

## Why it is non-regressive

A term previously plotted **iff** `which(colnames == label)` found its column — i.e. `label %in% colnames` is TRUE. So the filter drops exactly the terms that previously crashed and keeps exactly those that previously worked. Continuous-only formulas are byte-identical (no warning — verified with `expect_silent`). Transformations like `log(age)`, `I(age^2)`, `scale(age)` (column name == label) are kept; `poly(age,2)` and interactions (renamed columns) are dropped-with-warning instead of crashing.

## Verification

- Regression tests: factor/character/`strata()` dropped + warning; continuous-only unchanged/silent; all-non-numeric → clear `stop()`.
- Clean-session `Rscript --vanilla -e 'devtools::test()'`: **FAIL 0 | PASS 117**.
- Two independent adversarial pre-commit reviewers cleared the diff (edge cases: log/I/scale kept, poly/interaction/backticked-names handled).

The separate missing-data case (#248) is out of scope and unaffected.

Fixes #357