### PR TITLE
Add layout_matrix to arrange_ggsurvplots() (#300)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Minor changes
 
+- `arrange_ggsurvplots()` gains a `layout_matrix` argument (forwarded to `gridExtra::marrangeGrob()`) to control the position/order of the plots — e.g. `layout_matrix = matrix(seq_along(splots), nrow = nrow, byrow = TRUE)` orders them by row. Default is unchanged (plots fill column-wise) (#300).
+
 - `ggforest()` gains a `global.stats` argument. Set `global.stats = FALSE` to omit the bottom caption reporting the global statistics (number of events, global log-rank p-value, AIC, concordance index) — useful when arranging several forest plots in a panel. Default is `TRUE` (unchanged) (#392).
 
 - `surv_pvalue()` gains a `pval.digits` argument controlling the number of significant digits used to format the p-value in `pval.txt` (default `2`, unchanged; e.g. `pval.digits = 3` gives `"p = 0.00131"`). Requested for journals that report p-values to 3 digits (#343).

--- a/R/arrange_ggsurvplots.R
+++ b/R/arrange_ggsurvplots.R
@@ -15,6 +15,10 @@
 #'  TRUE}
 #'@param ncensor.plot.height The height of the censor plot. Used when
 #'  \code{ncensor.plot = TRUE}.
+#'@param layout_matrix optional layout matrix passed to
+#'  \code{\link[gridExtra]{marrangeGrob}} to control the position/order of the
+#'  plots. For example, \code{matrix(seq_along(x), nrow = nrow, byrow = TRUE)}
+#'  orders the plots by row. Default is NULL (plots are filled column-wise).
 #'@param ... not used
 #'
 #'@return returns an invisible object of class arrangelist (see
@@ -48,7 +52,8 @@
 #'@rdname arrange_ggsurvplots
 #'@export
 arrange_ggsurvplots <- function(x,  print = TRUE, title = NA, ncol = 2, nrow = 1, surv.plot.height = NULL,
-                                         risk.table.height = NULL, ncensor.plot.height = NULL, ...)
+                                         risk.table.height = NULL, ncensor.plot.height = NULL,
+                                         layout_matrix = NULL, ...)
 {
 
   # Build each ggsurvplot in the list
@@ -57,9 +62,12 @@ arrange_ggsurvplots <- function(x,  print = TRUE, title = NA, ncol = 2, nrow = 1
                          risk.table.height = risk.table.height,
                          ncensor.plot.height = ncensor.plot.height)
 
-  # Arrange multiple ggsurvplots
-  survs <- do.call(gridExtra::marrangeGrob,
-                  list(grobs = survs, ncol = ncol, nrow = nrow, top = title))
+  # Arrange multiple ggsurvplots. layout_matrix (passed to marrangeGrob) lets
+  # users control the plot order, e.g. fill by row with
+  # matrix(seq_along(x), nrow = nrow, byrow = TRUE) (#300).
+  .marrange.args <- list(grobs = survs, ncol = ncol, nrow = nrow, top = title)
+  if(!is.null(layout_matrix)) .marrange.args$layout_matrix <- layout_matrix
+  survs <- do.call(gridExtra::marrangeGrob, .marrange.args)
 
   if(print) print(survs)
 

--- a/man/arrange_ggsurvplots.Rd
+++ b/man/arrange_ggsurvplots.Rd
@@ -13,6 +13,7 @@ arrange_ggsurvplots(
   surv.plot.height = NULL,
   risk.table.height = NULL,
   ncensor.plot.height = NULL,
+  layout_matrix = NULL,
   ...
 )
 }
@@ -36,6 +37,11 @@ risk.table = FALSE.}
 
 \item{ncensor.plot.height}{The height of the censor plot. Used when
 \code{ncensor.plot = TRUE}.}
+
+\item{layout_matrix}{optional layout matrix passed to
+\code{\link[gridExtra]{marrangeGrob}} to control the position/order of the
+plots. For example, \code{matrix(seq_along(x), nrow = nrow, byrow = TRUE)}
+orders the plots by row. Default is NULL (plots are filled column-wise).}
 
 \item{...}{not used}
 }

--- a/tests/testthat/test-arrange-layout-matrix.R
+++ b/tests/testthat/test-arrange-layout-matrix.R
@@ -1,0 +1,33 @@
+context("arrange_ggsurvplots layout_matrix")
+
+# Regression test for #300: arrange_ggsurvplots() gains a layout_matrix argument
+# (forwarded to gridExtra::marrangeGrob) so plots can be ordered by row, as is
+# usual in journals. The default (layout_matrix = NULL) is unchanged.
+library(survival)
+
+make_splots <- function(n = 6) {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  lapply(seq_len(n), function(i) ggsurvplot(fit, data = lung, title = paste("Plot", i)))
+}
+
+# top,left cell position of each arranged plot on the (single) page
+cell_pos <- function(al) al[[1]]$layout[, c("t", "l")]
+
+test_that("no-regression: default arrange_ggsurvplots() fills column-wise (#300)", {
+  al <- arrange_ggsurvplots(make_splots(6), print = FALSE, ncol = 2, nrow = 3)
+  expect_s3_class(al, "arrangelist")
+  pos <- cell_pos(al)
+  # grobs stored 1..6, placed down columns: rows 1,2,3 then 1,2,3
+  expect_equal(pos$t, c(1, 2, 3, 1, 2, 3))
+  expect_equal(pos$l, c(1, 1, 1, 2, 2, 2))
+})
+
+test_that("layout_matrix orders plots by row (#300)", {
+  al <- arrange_ggsurvplots(make_splots(6), print = FALSE, ncol = 2, nrow = 3,
+                            layout_matrix = matrix(1:6, nrow = 3, byrow = TRUE))
+  expect_s3_class(al, "arrangelist")
+  pos <- cell_pos(al)
+  # row-wise fill: (1,1),(1,2),(2,1),(2,2),(3,1),(3,2)
+  expect_equal(pos$t, c(1, 1, 2, 2, 3, 3))
+  expect_equal(pos$l, c(1, 2, 1, 2, 1, 2))
+})


### PR DESCRIPTION
## Summary

`arrange_ggsurvplots()` gains a `layout_matrix` argument (forwarded to `gridExtra::marrangeGrob()`) so users can control the position/order of the plots. For example, `layout_matrix = matrix(seq_along(splots), nrow = nrow, byrow = TRUE)` orders the plots **by row** (the usual layout in journals) instead of the default column-wise fill.

## Implementation

The `marrangeGrob()` call now builds an args list and adds `layout_matrix` **only when non-NULL**, so the default (`layout_matrix = NULL`) call is byte-identical to before.

## Verification

- Non-regression: default page layout unchanged — column-wise fill (`$layout` `t = c(1,2,3,1,2,3)`, `l = c(1,1,1,2,2,2)`).
- Correctness: `matrix(1:6, nrow=3, byrow=TRUE)` gives row-wise fill (`t = c(1,1,2,2,3,3)`, `l = c(1,2,1,2,1,2)`).
- Edge cases: multi-page pagination unchanged; `marrangeGrob` owns layout_matrix validation (graceful passthrough).
- Regression tests added; clean-session `Rscript --vanilla -e 'devtools::test()'`: **FAIL 0 | PASS 123**; `tools::checkRd` clean.
- Two independent adversarial pre-commit reviewers cleared the diff.

Fixes #300