### PR TITLE
Handle missing data in ggcoxfunctional() (#248)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 ## Bug fixes
 
+- Fix `ggcoxfunctional()` erroring with "'x' and 'y' lengths differ" when the Cox formula contains a covariate with missing values: `model.matrix()` drops rows with missing terms, but the null-model martingale residuals were computed from the full data. The data is now restricted to the complete-case (model-matrix) rows so the lengths match (#248).
+
 - Fix `ggcoxfunctional()` erroring with a cryptic "'x' and 'y' lengths differ" when the Cox formula contains a factor/character covariate (or a `strata()` term): such terms are renamed/expanded in the model matrix and cannot be checked for functional form. They are now dropped with a warning, and only continuous covariates are plotted (#357).
 
 - Fix `ggsurvplot_combine(..., surv.median.line = "hv")` (or `"h"`/`"v"`) not drawing the median survival lines: `surv.median.line` was forwarded to `ggsurvplot_df()` (which does not handle it) and silently ignored. The median lines are now computed from the combined fits and drawn on the plot (#316).

--- a/R/ggcoxfunctional.R
+++ b/R/ggcoxfunctional.R
@@ -61,6 +61,12 @@ ggcoxfunctional <- function (formula, data = NULL, fit, iter = 0, f = 0.6,
 
   attr(stats::terms(formula), "term.labels") -> explanatory.variables.names
   stats::model.matrix(formula, data = data) -> explanatory.variables.values
+  # Restrict data to the model-matrix rows (i.e. the complete cases for the
+  # formula). model.matrix() drops rows with a missing value in any term, so
+  # without this the null-model martingale residuals (computed from data below)
+  # would be longer than the covariate values and error with "'x' and 'y'
+  # lengths differ" (#248). For data without missing values this is a no-op.
+  data <- data[rownames(explanatory.variables.values), , drop = FALSE]
   SurvFormula <- deparse(formula[[2]])
 
   # Keep only continuous terms. A functional-form (linearity) check plots

--- a/tests/testthat/test-ggcoxfunctional-missing.R
+++ b/tests/testthat/test-ggcoxfunctional-missing.R
@@ -1,0 +1,37 @@
+context("ggcoxfunctional missing data")
+
+# Regression test for #248: ggcoxfunctional() failed with "'x' and 'y' lengths
+# differ" when the Cox formula contained a covariate with missing values.
+# model.matrix() drops rows with missing terms, but the null-model martingale
+# residuals were computed from the full data, so the two had different lengths.
+# The data is now restricted to the model-matrix (complete-case) rows.
+library(survival)
+
+test_that("ggcoxfunctional() works with a covariate that has missing values (#248)", {
+  # lung$wt.loss has 14 NAs
+  fit <- coxph(Surv(time, status) ~ age + wt.loss, data = lung)
+  expect_error(p <- ggcoxfunctional(fit, data = lung), NA)   # no error
+  expect_identical(names(p), c("age", "wt.loss"))
+
+  # each plot uses the complete-case rows only (228 - 14 = 214)
+  n_complete <- sum(stats::complete.cases(lung[, c("time", "status", "age", "wt.loss")]))
+  b <- ggplot2::ggplot_build(p[["wt.loss"]])
+  expect_equal(nrow(b$data[[1]]), n_complete)
+})
+
+test_that("no-regression: complete-data ggcoxfunctional() is unaffected (#248)", {
+  cc <- na.omit(lung[, c("time", "status", "age", "wt.loss")])
+  fit <- coxph(Surv(time, status) ~ age + wt.loss, data = cc)
+  expect_silent(p <- ggcoxfunctional(fit, data = cc))
+  b <- ggplot2::ggplot_build(p[["age"]])
+  expect_equal(nrow(b$data[[1]]), nrow(cc))   # all rows used (no drop)
+})
+
+test_that("missing data + a factor term are both handled (#248 + #357)", {
+  lf <- lung
+  lf$sex <- factor(lf$sex, labels = c("male", "female"))
+  fit <- coxph(Surv(time, status) ~ age + sex + wt.loss, data = lf)
+  # factor sex dropped (#357) with a warning; NA rows handled (#248)
+  expect_warning(p <- ggcoxfunctional(fit, data = lf), "non-continuous")
+  expect_identical(names(p), c("age", "wt.loss"))
+})


### PR DESCRIPTION
## Summary

`ggcoxfunctional()` errored with `"'x' and 'y' lengths differ"` when the Cox formula contained a covariate with missing values. `model.matrix()` drops rows with a missing term (e.g. 214 of 228 for `lung` + `wt.loss`), but the null-model martingale residuals were computed from the full data (228) — so the covariate values and residuals had different lengths.

## Fix

One line, after `model.matrix()`:
```r
data <- data[rownames(explanatory.variables.values), , drop = FALSE]
```
This restricts `data` to the model-matrix (complete-case) rows, so the null-model residuals (computed from `data` in the loop) align with the covariate values. For data without missing values the subset equals the full data (same order), so it is a **no-op**.

## Verification

- Non-regression: complete-case data is `identical` before/after (same rows, same order) → byte-identical plots (`expect_silent`, point counts match).
- Correctness: an NA covariate now plots the complete cases (214), residuals aligned positionally with covariate values.
- Combined with #357: a factor + NA formula drops the factor (warning) and handles the NAs.
- Regression tests added; clean-session `Rscript --vanilla -e 'devtools::test()'`: **FAIL 0 | PASS 130**.
- Two independent adversarial pre-commit reviewers cleared the diff (rowname-subset edge cases — default/custom/tibble rownames, duplicate-rownames not reachable, order preserved — all verified safe).

Fixes #248