### PR TITLE
Fix ggcoxfunctional() clipping its own points via default ylim (#465)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 ## Bug fixes
 
+- Fix `ggcoxfunctional()` clipping most of its own points: the default y-axis limits were set to the range of the lowess smoother, which is much narrower than the martingale residuals plotted as points, so points with large residuals fell outside the visible panel. The y-axis now auto-scales to include all points by default; a user-supplied `ylim` is still honoured (#465).
+
 - Fix `ggcoxfunctional()` erroring with "'x' and 'y' lengths differ" when the Cox formula contains a covariate with missing values: `model.matrix()` drops rows with missing terms, but the null-model martingale residuals were computed from the full data. The data is now restricted to the complete-case (model-matrix) rows so the lengths match (#248).
 
 - Fix `ggcoxfunctional()` erroring with a cryptic "'x' and 'y' lengths differ" when the Cox formula contains a factor/character covariate (or a `strata()` term): such terms are renamed/expanded in the model matrix and cannot be checked for functional form. They are now dropped with a warning, and only continuous covariates are plotted (#357).

--- a/R/ggcoxfunctional.R
+++ b/R/ggcoxfunctional.R
@@ -104,7 +104,11 @@ ggcoxfunctional <- function (formula, data = NULL, fit, iter = 0, f = 0.6,
                                              f = f)$y)
 
     if(is.null(xlim)) xlim <- c(min(data2viz$explanatory), max(data2viz$explanatory))
-    if(is.null(ylim)) ylim <- c(min(data2viz$lowess_y), max(data2viz$lowess_y))
+    # ylim is left as supplied (NULL by default) so coord_cartesian() auto-scales
+    # the y-axis to include ALL martingale-residual points. Previously ylim
+    # defaulted to the range of the lowess smoother (lowess_y), which is much
+    # narrower than the residuals and clipped most of the plotted points from
+    # view (#465). A user-supplied ylim is still honoured unchanged.
 
     ggplot(data2viz, aes(x = explanatory,
                          y = martingale_resid)) +

--- a/tests/testthat/test-ggcoxfunctional-ylim.R
+++ b/tests/testthat/test-ggcoxfunctional-ylim.R
@@ -1,0 +1,44 @@
+context("ggcoxfunctional default y-limits")
+
+# Regression test for #465: ggcoxfunctional() previously defaulted the y-axis
+# limits to the range of the lowess smoother (lowess_y), which is much narrower
+# than the martingale residuals it plots as points, so most points were clipped
+# out of view. The default y-axis now auto-scales to include ALL points, while a
+# user-supplied ylim is still honoured.
+library(survival)
+
+test_that("default y-axis includes all martingale-residual points (#465)", {
+  fit <- coxph(Surv(time, status) ~ age, data = lung)
+  p   <- ggcoxfunctional(fit, data = lung)
+  b   <- ggplot2::ggplot_build(p[["age"]])
+  pts <- b$data[[1]]$y                      # geom_point layer = residuals
+  yr  <- b$layout$panel_params[[1]]$y.range
+  # every plotted point must fall inside the panel y-range
+  expect_true(all(pts >= yr[1] & pts <= yr[2], na.rm = TRUE))
+  # and the panel must be wider than the (narrow) lowess range that used to clip
+  lw <- range(b$data[[2]]$y, na.rm = TRUE)  # geom_line layer = lowess smoother
+  expect_true(yr[1] <= min(pts, na.rm = TRUE) && yr[2] >= max(pts, na.rm = TRUE))
+  expect_true((yr[2] - yr[1]) > (lw[2] - lw[1]))
+})
+
+test_that("no-regression: user-supplied ylim is honoured (#465)", {
+  fit <- coxph(Surv(time, status) ~ age, data = lung)
+  p   <- ggcoxfunctional(fit, data = lung, ylim = c(-0.5, 1))
+  b   <- ggplot2::ggplot_build(p[["age"]])
+  yr  <- b$layout$panel_params[[1]]$y.range
+  # The panel is clamped to the user's window (with a small axis expansion),
+  # NOT auto-scaled to the full residual range (which reaches ~ -2.9). Bounds
+  # are loose so the test is robust to ggplot2's expansion-factor defaults.
+  expect_true(yr[1] <= -0.5 && yr[1] > -1)    # near user lower bound, not the -2.9 default
+  expect_true(yr[2] >=  1.0 && yr[2] <  1.5)  # near user upper bound
+})
+
+test_that("no-regression: default x-axis is unchanged (#465)", {
+  fit <- coxph(Surv(time, status) ~ age, data = lung)
+  p   <- ggcoxfunctional(fit, data = lung)
+  b   <- ggplot2::ggplot_build(p[["age"]])
+  xr  <- b$layout$panel_params[[1]]$x.range
+  ar  <- range(lung$age)
+  # x-range still spans the covariate values (with expansion), as before
+  expect_true(xr[1] <= ar[1] && xr[2] >= ar[2])
+})


### PR DESCRIPTION
## Summary

`ggcoxfunctional()` defaulted the y-axis limits to the range of the lowess smoother (`lowess_y`), which is much narrower than the martingale residuals it plots as points. `coord_cartesian()` then clipped every residual outside that narrow band, so most of the plotted data was hidden.

Example (`coxph(Surv(time, status) ~ age, data = lung)`): residual points span **-2.89 .. 1.00**, but the default panel showed only **-0.39 .. 0.48** — hiding ~70% of the points.

## Fix

Leave the default `ylim` unset so `coord_cartesian()` auto-scales the y-axis to include **all** points. A user-supplied `ylim` is still honoured unchanged; the default `xlim` is unchanged.

## Behaviour change (maintainer sign-off obtained)

This alters the default y-range of every `ggcoxfunctional()` plot (points that were previously clipped are now visible). User-supplied `ylim` and `xlim` are unaffected.

## Tests / gate

- New `test-ggcoxfunctional-ylim.R`: all points visible by default; user `ylim` honoured; default `xlim` unchanged.
- Full clean-session suite green: `FAIL 0 | PASS 136`.
- Two independent adversarial pre-commit reviewers: both PASS.

Fixes #465