### PR TITLE
Warn on negative survival times in ggsurvplot() (#523)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 ## Bug fixes
 
+- `ggsurvplot()` (and the related builders such as `ggsurvplot_combine()`) now warn when the survival data contain negative times, which make the Kaplan-Meier curve appear to increase (not meaningful for a survival estimate). Previously such times were plotted silently. The plot itself is unchanged (#523).
+
 - Fix `ggcoxfunctional()` erroring with "'x' and 'y' lengths differ" when the Cox formula contains a covariate with missing values: `model.matrix()` drops rows with missing terms, but the null-model martingale residuals were computed from the full data. The data is now restricted to the complete-case (model-matrix) rows so the lengths match (#248).
 
 - Fix `ggcoxfunctional()` erroring with a cryptic "'x' and 'y' lengths differ" when the Cox formula contains a factor/character covariate (or a `strata()` term): such terms are renamed/expanded in the model matrix and cannot be checked for functional form. They are now dropped with a warning, and only continuous covariates are plotted (#357).

--- a/R/ggsurvplot_df.R
+++ b/R/ggsurvplot_df.R
@@ -86,6 +86,18 @@ ggsurvplot_df <- function(fit, fun = NULL,
     stop("fit should be a data frame.")
   df <- fit
 
+  # Negative survival times are not meaningful for a Kaplan-Meier estimate and
+  # make the curve appear to increase. survfit()/survminer plot them as-is, so
+  # warn the user rather than silently drawing a misleading (up-ticking) curve
+  # (#523). This is the common draw point for all entry points (ggsurvplot(),
+  # ggsurvplot_combine(), ggsurvplot_facet(), ...), so the warning fires once
+  # per plot regardless of route. The plot itself is unchanged.
+  if(any(df$time < 0, na.rm = TRUE))
+    warning("Negative survival times are present in the data. ",
+            "The survival curve can appear to increase, which is not meaningful ",
+            "for a Kaplan-Meier estimate. Consider removing observations with ",
+            "negative times.", call. = FALSE)
+
   # if(!is.null(.dots$risk.table))
   #   warning("Can't extract risk.table from a data frame.", call. = FALSE)
   # if(!is.null(.dots$pval))

--- a/tests/testthat/test-ggsurvplot-negative-times.R
+++ b/tests/testthat/test-ggsurvplot-negative-times.R
@@ -1,0 +1,46 @@
+context("ggsurvplot negative survival times")
+
+# Regression test for #523: ggsurvplot() silently plotted negative survival
+# times, producing a curve that appears to increase (not meaningful for a
+# Kaplan-Meier estimate). It now emits a warning. The plot itself is unchanged.
+library(survival)
+
+test_that("ggsurvplot() warns when survival times are negative (#523)", {
+  xx  <- data.frame(stim = c(-1, 1:4), sts = rep(1, 5))
+  fit <- survfit(Surv(stim, sts) ~ 1, data = xx)
+  expect_warning(ggsurvplot(fit, data = xx, xlim = c(-2, 5)),
+                 "[Nn]egative survival times")
+})
+
+test_that("ggsurvplot_combine() also warns on negative times (#523)", {
+  # The check lives in ggsurvplot_df(), the common draw point, so the combine
+  # path (which bypasses ggsurvplot_core) is covered too.
+  xx  <- data.frame(stim = c(-1, 1:4), sts = rep(1, 5))
+  fit <- survfit(Surv(stim, sts) ~ 1, data = xx)
+  expect_warning(ggsurvplot_combine(list(a = fit), data = xx),
+                 "[Nn]egative survival times")
+})
+
+test_that("no-regression: ordinary (non-negative) data does NOT warn (#523)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  # no negative-time warning should be raised for standard data
+  warns <- character(0)
+  withCallingHandlers(
+    ggsurvplot(fit, data = lung),
+    warning = function(w) {
+      warns <<- c(warns, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+  expect_false(any(grepl("[Nn]egative survival times", warns)))
+})
+
+test_that("no-regression: the plot is still produced despite the warning (#523)", {
+  xx  <- data.frame(stim = c(-1, 1:4), sts = rep(1, 5))
+  fit <- survfit(Surv(stim, sts) ~ 1, data = xx)
+  p   <- suppressWarnings(ggsurvplot(fit, data = xx, xlim = c(-2, 5)))
+  expect_s3_class(p, "ggsurvplot")
+  # the negative time is still present in the plotted curve (behaviour unchanged)
+  b <- ggplot2::ggplot_build(p$plot)
+  expect_true(min(b$data[[1]]$x, na.rm = TRUE) < 0)
+})


### PR DESCRIPTION
## Summary

Negative survival times are not meaningful for a Kaplan-Meier estimate and make the curve appear to increase, but `ggsurvplot()` plotted them silently. It now emits a warning.

## Fix

The check is placed in `ggsurvplot_df()` — the common draw point that **all** entry points funnel through (`ggsurvplot()` → `ggsurvplot_core()` → `ggsurvplot_df()`; `ggsurvplot_combine()` → `ggsurvplot_df()` directly; facet/list/add_all/ggflexsurvplot via core). So the warning fires **once per plot** regardless of route, including the combine path. Warning-only; the plot pixels are unchanged and negative points are still drawn (nothing is silently dropped).

## Behaviour change (maintainer sign-off obtained)

Adds a warning where there was none; no change to any plot output.

## Tests / gate

- New `test-ggsurvplot-negative-times.R`: warns for `ggsurvplot()` and `ggsurvplot_combine()`; no warning for ordinary data; plot still produced with the negative point present.
- Full clean-session suite green: `FAIL 0 | PASS 135`.
- Fires exactly once per call (verified across risk.table/ncensor.plot/cumcensor and every builder); `start.time` suppression preserved.
- Two independent adversarial pre-commit reviewers (fresh round on the relocated diff): both PASS.

Fixes #523