### PR TITLE
Extend default x-axis to show events beyond the last break (#655)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 ## Bug fixes
 
+- Fix `ggsurvplot()` clipping events that occur after the last x-axis break: the default upper x-limit was the largest "nice" axis break, which can fall below the largest event/censoring time, so those events were invisible unless `xlim` was set manually. The upper x-limit now extends to cover the maximum time; the axis tick breaks (and risk-table columns) are unchanged, and a user-supplied `xlim` is still honoured (#655).
+
 - Fix `ggcoxfunctional()` clipping most of its own points: the default y-axis limits were set to the range of the lowess smoother, which is much narrower than the martingale residuals plotted as points, so points with large residuals fell outside the visible panel. The y-axis now auto-scales to include all points by default; a user-supplied `ylim` is still honoured (#465).
 
 - Fix `ggcoxfunctional()` erroring with "'x' and 'y' lengths differ" when the Cox formula contains a covariate with missing values: `model.matrix()` drops rows with missing terms, but the null-model martingale residuals were computed from the full data. The data is now restricted to the complete-case (model-matrix) rows so the lengths match (#248).

--- a/R/ggsurvplot_core.R
+++ b/R/ggsurvplot_core.R
@@ -85,7 +85,15 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
   # Axis limits
    xmin <- ifelse(.is_cloglog(fun), min(c(1, d$time)), 0)
    if(!is.null(fit$start.time)) xmin <- fit$start.time
-   xmax <- .get_default_breaks(d$time, .log = .is_cloglog(fun)) %>% max()
+   # Extend the upper x-limit to cover the largest event/censoring time, not
+   # just the largest "nice" axis break. scales::extended_breaks() can return a
+   # last break below max(d$time), which previously clipped events beyond it
+   # from the default plot (#655). This is a no-op when the data already fit
+   # within the breaks; the axis tick breaks are unchanged (computed separately
+   # in ggsurvplot_df()), and a user-supplied xlim is unaffected (gated below).
+   xmax <- max(c(max(d$time, na.rm = TRUE),
+                 .get_default_breaks(d$time, .log = .is_cloglog(fun)) %>% max()),
+               na.rm = TRUE)
    if(is.null(xlim)) xlim <- c(xmin, xmax)
 
   # Main survival curves

--- a/tests/testthat/test-ggsurvplot-xmax-events.R
+++ b/tests/testthat/test-ggsurvplot-xmax-events.R
@@ -1,0 +1,53 @@
+context("ggsurvplot x-axis covers all events")
+
+# Regression test for #655: the default upper x-limit was the largest "nice"
+# axis break (scales::extended_breaks), which can be below max(time), silently
+# clipping events beyond it. The upper x-limit now extends to cover max(time),
+# while the axis tick breaks (and risk-table columns) are unchanged.
+library(survival)
+
+x_range <- function(p) ggplot2::ggplot_build(p$plot)$layout$panel_params[[1]]$x.range
+
+test_that("default x-axis extends to show an event beyond the last break (#655)", {
+  df <- lung
+  df$status[6] <- 2
+  df$time[6]   <- 1100          # event beyond the default last break (1000)
+  fit <- survfit(Surv(time, status) ~ sex, data = df)
+  p   <- ggsurvplot(fit, data = df)
+  expect_gte(x_range(p)[2], 1100)
+})
+
+test_that("no-regression: data within the breaks is unchanged (#655)", {
+  # max(time) <= last nice break -> xmax stays at the break, x-range unchanged
+  d2  <- subset(lung, time <= 1000)
+  fit <- survfit(Surv(time, status) ~ sex, data = d2)
+  p   <- ggsurvplot(fit, data = d2)
+  last_break <- max(scales::extended_breaks()(d2$time))
+  # upper panel limit is driven by the break (with the usual expansion), not by
+  # a value beyond max(time); assert it does not exceed the break by much
+  expect_lte(x_range(p)[2], last_break * 1.06)
+  expect_gte(x_range(p)[2], max(d2$time))
+})
+
+test_that("no-regression: user-supplied xlim is honoured (#655)", {
+  df <- lung
+  df$status[6] <- 2
+  df$time[6]   <- 1100
+  fit <- survfit(Surv(time, status) ~ sex, data = df)
+  p   <- ggsurvplot(fit, data = df, xlim = c(0, 500))
+  xr  <- x_range(p)
+  expect_lt(xr[2], 600)          # clipped to the user window, not extended to 1100
+})
+
+test_that("no-regression: axis tick breaks (and risk-table columns) are unchanged (#655)", {
+  df <- lung
+  df$status[6] <- 2
+  df$time[6]   <- 1100
+  fit <- survfit(Surv(time, status) ~ sex, data = df)
+  p   <- ggsurvplot(fit, data = df, risk.table = TRUE, break.time.by = 250)
+  tb  <- ggplot2::ggplot_build(p$table)$layout$panel_params[[1]]$x$breaks
+  tb  <- tb[!is.na(tb)]
+  # no stray 1100 tick was introduced; breaks stay on the round grid
+  expect_false(any(abs(tb - 1100) < 1e-6))
+  expect_true(all(tb %% 250 == 0))
+})


### PR DESCRIPTION
## Summary

`ggsurvplot()` set the default upper x-limit to the largest "nice" axis break (`scales::extended_breaks()`), which can fall **below** the largest event/censoring time. Such events were clipped from the default plot and only appeared if `xlim` was set manually (e.g. an event at `t = 1100` when the breaks stop at 1000).

## Fix

The upper x-limit now extends to cover `max(time)`:

```r
xmax <- max(c(max(d$time, na.rm = TRUE),
              .get_default_breaks(d$time, .log = .is_cloglog(fun)) %>% max()),
            na.rm = TRUE)
```

- **No-op** when the data already fit within the breaks (byte-identical `xlim`).
- The axis **tick breaks and risk-table columns are unchanged** (they are computed separately in `ggsurvplot_df()`), so no stray tick is introduced and the main plot / risk table / ncensor plot stay aligned — only the panel *extent* widens.
- A user-supplied `xlim` is still honoured (the change is gated on `is.null(xlim)`).

## Behaviour change (maintainer sign-off obtained)

The default panel widens slightly for datasets whose maximum time exceeds the last break (this includes `lung`/`ovarian`/`colon`, which previously relied on the 5% axis expansion to show their tail and were clipped under `axes.offset = FALSE`).

## Strategy / gate

- Approach chosen by **two independent strategy agents** (both converged on extending `xmax`; rejected recompute-breaks, round-up, and warning-only).
- **Two independent adversarial pre-commit reviewers on the diff: both PASS** (event now visible; risk table/ncensor/main byte-aligned; cloglog/log/facet/conf.int/start.time/break.time.by all verified; no-op case unchanged).
- New `test-ggsurvplot-xmax-events.R`: event covered; no-op within breaks; user `xlim` honoured; tick breaks unchanged.
- Full clean-session suite green: `FAIL 0 | PASS 147`. Rendered-image verified (event tail visible, panels aligned, no stray tick).

Fixes #655