### PR TITLE
Fix surv_cutpoint()/surv_categorize() with hyphenated names; drop undefined alpha (#609, #598)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,10 @@
 
 ## Bug fixes
 
+- Fix `surv_categorize()` returning the raw numeric values (instead of `"high"`/`"low"`) for variables whose names contain characters that `make.names()` alters, such as a hyphen (e.g. gene names like `"A1BG-AS1"`): `summary.surv_cutpoint()` now builds its row names with `check.names = FALSE` so the name still matches (#609).
+
+- Remove an unused, undefined `alpha` argument passed by `surv_cutpoint()` to `maxstat::maxstat.test()` (it only worked by lazy evaluation); no change to computed cut points (#598).
+
 - Fix `ggsurvplot()` clipping events that occur after the last x-axis break: the default upper x-limit was the largest "nice" axis break, which can fall below the largest event/censoring time, so those events were invisible unless `xlim` was set manually. The upper x-limit now extends to cover the maximum time; the axis tick breaks (and risk-table columns) are unchanged, and a user-supplied `xlim` is still honoured (#655).
 
 - `ggsurvplot()` (and the related builders such as `ggsurvplot_combine()`) now warn when the survival data contain negative times, which make the Kaplan-Meier curve appear to increase (not meaningful for a survival estimate). Previously such times were plotted silently. The plot itself is unchanged (#523).

--- a/R/surv_cutpoint.R
+++ b/R/surv_cutpoint.R
@@ -93,8 +93,7 @@ surv_cutpoint <- function(data, time = "time", event = "event", variables,
     surv_data$var <- data[, var_i]
     max_stat_i <- maxstat::maxstat.test(survival::Surv(time, event) ~ var, data = surv_data,
                                       smethod = "LogRank", pmethod="none",
-                                      minprop = minprop, maxprop = 1-minprop,
-                                      alpha = alpha)
+                                      minprop = minprop, maxprop = 1-minprop)
     res[[var_i]] <- max_stat_i
     if(progressbar) utils::setTxtProgressBar(pb, i)
   }
@@ -165,8 +164,11 @@ summary.surv_cutpoint <- function(object, ...){
                  names(rr) <- c("cutpoint", "statistic")
                  return(rr)
                })
-  res <- t(as.data.frame(res))
-  as.data.frame(res)
+  # check.names = FALSE preserves variable names containing characters that
+  # make.names() would mangle (e.g. hyphens in gene names like "A1BG-AS1"),
+  # so surv_categorize() can still match them and dichotomize (#609).
+  res <- t(as.data.frame(res, check.names = FALSE))
+  as.data.frame(res, check.names = FALSE)
 }
 
 #' @method print surv_cutpoint

--- a/tests/testthat/test-surv_cutpoint.R
+++ b/tests/testthat/test-surv_cutpoint.R
@@ -1,0 +1,40 @@
+context("surv_cutpoint")
+
+# Regression tests for:
+#  - #609: surv_categorize() failed to dichotomize a variable whose name
+#    contains characters make.names() mangles (e.g. a hyphen "A1BG-AS1"),
+#    because summary.surv_cutpoint() built its row names via as.data.frame()
+#    without check.names = FALSE, so the name no longer matched.
+#  - #598: surv_cutpoint() passed a non-existent `alpha` object to
+#    maxstat::maxstat.test(); it only worked by lazy evaluation. The unused
+#    argument is removed.
+
+test_that("surv_cutpoint()/surv_categorize() handle names with hyphens (#609)", {
+  set.seed(1)
+  mye <- survminer::myeloma
+  d <- data.frame(time = mye$time, event = mye$event,
+                  `A1BG-AS1` = mye$DEPDC1, check.names = FALSE)
+  cut <- surv_cutpoint(d, time = "time", event = "event", variables = "A1BG-AS1")
+  # summary keeps the hyphenated name (not "A1BG.AS1")
+  expect_identical(rownames(summary(cut)), "A1BG-AS1")
+  # and surv_categorize dichotomizes it (not raw numeric values)
+  cats <- surv_categorize(cut)[["A1BG-AS1"]]
+  expect_setequal(unique(cats), c("high", "low"))
+})
+
+test_that("no-regression: ordinary variable names still work (#609/#598)", {
+  mye <- survminer::myeloma
+  cut <- surv_cutpoint(mye, time = "time", event = "event",
+                       variables = c("DEPDC1", "WHSC1"))
+  s <- summary(cut)
+  expect_identical(rownames(s), c("DEPDC1", "WHSC1"))
+  expect_true(is.numeric(s$cutpoint) && all(is.finite(s$cutpoint)))
+  cats <- surv_categorize(cut)$DEPDC1
+  expect_setequal(unique(cats), c("high", "low"))
+})
+
+test_that("surv_cutpoint() runs without the undefined alpha argument (#598)", {
+  mye <- survminer::myeloma
+  expect_error(surv_cutpoint(mye, time = "time", event = "event",
+                             variables = "DEPDC1"), NA)
+})


### PR DESCRIPTION
## Summary

Two small `surv_cutpoint` fixes.

**#609** — `summary.surv_cutpoint()` built its row names via `as.data.frame()` (default `check.names = TRUE`), so a variable name containing characters `make.names()` alters — e.g. a hyphen in a gene name like `A1BG-AS1` — was mangled to `A1BG.AS1`. `surv_categorize()` then failed to match the name and returned the **raw numeric values** instead of `"high"`/`"low"`. Both `as.data.frame()` calls now use `check.names = FALSE`.

**#598** — `surv_cutpoint()` passed `alpha = alpha` to `maxstat::maxstat.test()`, but `alpha` is not a formal of `surv_cutpoint()` and there is no `...`; it only survived by lazy evaluation (`pmethod = "none"` never forces it). The unused argument is removed — computed cut points are byte-identical.

## Gate

- New `test-surv_cutpoint.R`: hyphenated name preserved + dichotomized; ordinary names byte-identical; runs without the alpha error.
- Full clean-session suite green: `FAIL 0 | PASS 153`.
- Two independent adversarial pre-commit reviewers: both PASS (maxstat output byte-identical with/without alpha; ordinary-name summary identical; edge cases incl. `a-b`+`a.b` collision safe).

Fixes #609
Fixes #598