### PR TITLE
Honour risk.table type and fontsize in ggsurvplot_combine() (#641, #514)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,10 @@
 
 ## Bug fixes
 
+- Fix `ggsurvplot_combine()` ignoring the risk-table type: `risk.table = "nrisk_cumcensor"` (and other types) is now honoured instead of always showing the absolute number at risk (#641).
+
+- Fix `ggsurvplot_combine()` ignoring `risk.table.fontsize`: the risk-table text size can now be set with `risk.table.fontsize` (as in `ggsurvplot()`), not only with `fontsize` (#514).
+
 - Fix `ggsurvplot()` clipping events that occur after the last x-axis break: the default upper x-limit was the largest "nice" axis break, which can fall below the largest event/censoring time, so those events were invisible unless `xlim` was set manually. The upper x-limit now extends to cover the maximum time; the axis tick breaks (and risk-table columns) are unchanged, and a user-supplied `xlim` is still honoured (#655).
 
 - `ggsurvplot()` (and the related builders such as `ggsurvplot_combine()`) now warn when the survival data contain negative times, which make the Kaplan-Meier curve appear to increase (not meaningful for a survival estimate). Previously such times were plotted silently. The plot itself is unchanged (#523).

--- a/R/ggsurvplot_combine.R
+++ b/R/ggsurvplot_combine.R
@@ -149,13 +149,19 @@ ggsurvplot_combine <- function(fit, data,
     # The main plot parameters, will be used to plot survival tables
     pms <- attr(p, "parameters")
     surv.color <- pms$color
-    pms$risk.table.type <- ifelse(is.null(.dots$risk.table.type),
-                                  "absolute", .dots$risk.table.type)
+    # Honour the risk-table type parsed from the `risk.table` argument (e.g.
+    # risk.table = "nrisk_cumcensor"), falling back to an explicit
+    # risk.table.type in ... and then to "absolute" (#641).
+    pms$risk.table.type <- if(!is.null(.dots$risk.table.type)) .dots$risk.table.type
+                           else risk.table.type
 
     pms$risk.table.title <- .dots$risk.table.title
     pms$cumevents.title <- .dots$cumevents.title
     pms$cumcensor.title <- .dots$cumcensor.title
-    pms$fontsize <- .dots$fontsize
+    # Honour risk.table.fontsize (as ggsurvplot() does), falling back to
+    # fontsize (#514).
+    pms$fontsize <- if(!is.null(.dots$risk.table.fontsize)) .dots$risk.table.fontsize
+                    else .dots$fontsize
     pms$ggtheme <- ggtheme
     pms$ylab <- pms$legend.title
     pms$tables.theme <- tables.theme

--- a/tests/testthat/test-ggsurvplot_combine-risktable.R
+++ b/tests/testthat/test-ggsurvplot_combine-risktable.R
@@ -1,0 +1,40 @@
+context("ggsurvplot_combine risk table type/fontsize")
+
+# Regression tests for:
+#  - #641: ggsurvplot_combine() ignored the risk-table type parsed from the
+#    `risk.table` argument (e.g. "nrisk_cumcensor"), always using "absolute".
+#  - #514: ggsurvplot_combine() ignored `risk.table.fontsize` (only `fontsize`
+#    worked), so the risk-table text stayed at the default size.
+library(survival)
+
+make_fits <- function() {
+  f1 <- survfit(Surv(time, status) ~ 1, data = lung[lung$sex == 1, ])
+  f2 <- survfit(Surv(time, status) ~ 1, data = lung[lung$sex == 2, ])
+  list(male = f1, female = f2)
+}
+
+risk_labels <- function(p) {
+  lab <- ggplot2::ggplot_build(p$table)$data[[1]]$label
+  lab[nzchar(lab)]
+}
+risk_size <- function(p) ggplot2::ggplot_build(p$table)$data[[1]]$size[1]
+
+test_that("risk.table = 'nrisk_cumcensor' shows n (censored) in combine (#641)", {
+  p   <- ggsurvplot_combine(make_fits(), data = lung, risk.table = "nrisk_cumcensor")
+  lab <- risk_labels(p)
+  expect_true(any(grepl("\\(", lab)))     # e.g. "138 (0)"
+})
+
+test_that("no-regression: default risk.table = TRUE stays absolute (#641)", {
+  p   <- ggsurvplot_combine(make_fits(), data = lung, risk.table = TRUE)
+  lab <- risk_labels(p)
+  expect_false(any(grepl("\\(", lab)))    # plain counts, no "(censored)"
+})
+
+test_that("risk.table.fontsize is honoured in combine (#514)", {
+  p_def <- ggsurvplot_combine(make_fits(), data = lung, risk.table = TRUE)
+  p_big <- ggsurvplot_combine(make_fits(), data = lung, risk.table = TRUE,
+                              risk.table.fontsize = 8)
+  expect_equal(risk_size(p_big), 8)
+  expect_false(isTRUE(all.equal(risk_size(p_def), 8)))  # default differs
+})


### PR DESCRIPTION
## Summary

`ggsurvplot_combine()` had two risk-table options that were silently ignored:

**#641** — the risk-table *type* parsed from the `risk.table` argument was discarded; the code always forced `"absolute"`. So `risk.table = "nrisk_cumcensor"` (and `"percentage"`, `"abs_pct"`, …) had no effect. It now uses the parsed type (an explicit `risk.table.type` in `...` still takes precedence).

**#514** — `risk.table.fontsize` was ignored (only `fontsize` worked). It is now honoured, falling back to `fontsize`.

## Gate

- Default `risk.table = TRUE` output is **unchanged** (`"absolute"`, plain counts, default size 4.5).
- `nrisk_cumcensor` now shows `"138 (0)"`; `risk.table.fontsize = 8` sizes the table text to 8 (was stuck at 4.5); the main plot/legend are unaffected.
- New `test-ggsurvplot_combine-risktable.R`; full clean-session suite green (`FAIL 0 | PASS 157`).
- Two independent adversarial pre-commit reviewers: both PASS (censored counts verified accurate, default byte-identical, fontsize isolated to the table).

Fixes #641
Fixes #514