### PR TITLE
Round weighted cumulative event/censor counts (#560, #554)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 ## Bug fixes
 
+- Fix the cumulative number-of-events and number-censored columns showing decimals for a weighted `survfit()` (in the risk/cumevents/cumcensor tables): the cumulative sums of the fractional weighted counts were not rounded, unlike the per-interval columns. They are now rounded to the same precision (#560, #554).
+
 - Fix `surv_categorize()` returning the raw numeric values (instead of `"high"`/`"low"`) for variables whose names contain characters that `make.names()` alters, such as a hyphen (e.g. gene names like `"A1BG-AS1"`): `summary.surv_cutpoint()` now builds its row names with `check.names = FALSE` so the name still matches (#609).
 
 - Remove an unused, undefined `alpha` argument passed by `surv_cutpoint()` to `maxstat::maxstat.test()` (it only worked by lazy evaluation); no change to computed cut points (#598).

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -185,9 +185,9 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
     n.risk = round(survsummary$n.risk, digits = decimal.place),
     pct.risk = round(survsummary$n.risk*100/strata_size),
     n.event = round(survsummary$n.event, digits = decimal.place),
-    cum.n.event = unlist(by(survsummary$n.event, strata, cumsum)),
+    cum.n.event = round(unlist(by(survsummary$n.event, strata, cumsum)), digits = decimal.place),
     n.censor = round(survsummary$n.censor, digits = decimal.place),
-    cum.n.censor = unlist(by(survsummary$n.censor, strata, cumsum)),
+    cum.n.censor = round(unlist(by(survsummary$n.censor, strata, cumsum)), digits = decimal.place),
     strata_size = strata_size
   )
 

--- a/tests/testthat/test-weighted-cumcount.R
+++ b/tests/testthat/test-weighted-cumcount.R
@@ -1,0 +1,26 @@
+context("weighted cumulative event/censor counts")
+
+# Regression test for #560 (and its duplicate #554): with a weighted survfit,
+# the cumulative number-of-events / number-censored columns were the raw
+# cumulative sums of the (fractional) weighted counts, so the risk/cumevents
+# tables showed decimals (e.g. 30.89) while the per-interval n.event/n.censor
+# were rounded. The cumulative columns are now rounded to the same precision.
+library(survival)
+
+test_that("weighted cumulative counts are rounded like their siblings (#560, #554)", {
+  set.seed(1)
+  d <- lung
+  d$w <- runif(nrow(d), 0.5, 1.5)
+  fw <- survfit(Surv(time, status) ~ sex, data = d, weights = w)
+  ss <- survminer:::.get_timepoints_survsummary(fw, d, times = c(0, 200, 400, 600))
+  expect_equal(ss$cum.n.event,  round(ss$cum.n.event))
+  expect_equal(ss$cum.n.censor, round(ss$cum.n.censor))
+})
+
+test_that("no-regression: unweighted cumulative counts unchanged (#560)", {
+  fu <- survfit(Surv(time, status) ~ sex, data = lung)
+  ss <- survminer:::.get_timepoints_survsummary(fu, lung, times = c(0, 200, 400, 600))
+  # integers before and after (round of an integer is identity)
+  expect_equal(ss$cum.n.event,  c(0, 54, 89, 103, 0, 18, 37, 45))
+  expect_equal(ss$cum.n.censor, c(0, 6, 18, 22, 0, 6, 27, 34))
+})


### PR DESCRIPTION
## Summary

For a weighted `survfit()`, the cumulative number-of-events and number-censored columns in the risk / cumevents / cumcensor tables were the raw cumulative sums of the fractional weighted counts, so they showed decimals (e.g. `30.89`), while the per-interval `n.event`/`n.censor` were rounded. The cumulative columns are now rounded to the same precision (`digits = decimal.place`).

## Gate

- **Unweighted** counts are byte-identical (round of an integer is identity).
- **Weighted** cumulative counts are now integers (default), monotonic per stratum; `decimal.place` is honoured (not hardcoded).
- New `test-weighted-cumcount.R`; full clean-session suite green (`FAIL 0 | PASS 157`).
- Two independent adversarial pre-commit reviewers: both PASS (grouping intact, downstream tables render integers, pct.risk unaffected).

Fixes #560
Fixes #554