### PR TITLE
Fix ggforest() reference level (partial-match) and in-formula factor terms (#312, #240)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,10 @@
 
 ## Bug fixes
 
+- Fix `ggforest()` reference level inheriting the statistics of a similarly-named non-reference level (e.g. a reference level `Bar` showing the hazard ratio of `Barb`): term rows were matched by character row indexing, which partial-matches. They are now matched exactly, so the reference level is correctly shown as the reference (#312).
+
+- Fix `ggforest()` erroring with "undefined columns selected" when the Cox formula contains an in-formula factor transformation such as `as.factor(x)`: the term is now evaluated rather than looked up as a column name (a plain column name is unaffected) (#240).
+
 - Fix `ggsurvplot_combine()` ignoring the risk-table type: `risk.table = "nrisk_cumcensor"` (and other types) is now honoured instead of always showing the absolute number at risk (#641).
 
 - Fix `ggsurvplot_combine()` ignoring `risk.table.fontsize`: the risk-table text size can now be set with `risk.table.fontsize` (as in `ggsurvplot()`), not only with `fontsize` (#514).

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -64,7 +64,15 @@ ggforest <- function(model, data = NULL,
   allTerms <- lapply(seq_along(terms), function(i){
     var <- names(terms)[i]
     if (terms[i] %in% c("factor", "character")) {
-      adf <- as.data.frame(table(data[, var]))
+      # A plain column name is extracted directly with data[[var]] (this also
+      # handles non-syntactic names such as "risk group"/"a-b", which parse()
+      # would choke on, and sidesteps the tibble one-column-data-frame gotcha);
+      # only an in-formula transformation (e.g. as.factor(rx), which is not a
+      # column) is evaluated. The lookup is kept inline so the column keeps its
+      # own name for the later rbind (#240).
+      adf <- as.data.frame(table(
+        if (var %in% colnames(data)) data[[var]]
+        else eval(parse(text = var), envir = data)))
       cbind(var = var, adf, pos = 1:nrow(adf))
     }
     else if (terms[i] == "numeric") {
@@ -83,7 +91,11 @@ ggforest <- function(model, data = NULL,
 
   # use broom again to get remaining required statistics
   rownames(coef) <- gsub(coef$term, pattern = "`", replacement = "")
-  toShow <- cbind(allTermsDF, coef[inds,])[,c("var", "level", "N", "p.value", "estimate", "conf.low", "conf.high", "pos")]
+  # Match term rows EXACTLY: character row indexing (coef[inds, ]) partial-
+  # matches, so a reference level (e.g. "grpBar", absent from coef) would wrongly
+  # inherit a prefix-colliding level's statistics (e.g. "grpBarb") instead of
+  # being left as the reference (NA). match() gives an exact lookup (#312).
+  toShow <- cbind(allTermsDF, coef[match(inds, rownames(coef)),])[,c("var", "level", "N", "p.value", "estimate", "conf.low", "conf.high", "pos")]
   toShowExp <- toShow[,5:7]
   toShowExp[is.na(toShowExp)] <- 0
   toShowExp <- format(exp(toShowExp), digits=noDigits)

--- a/tests/testthat/test-ggforest-reflevel.R
+++ b/tests/testthat/test-ggforest-reflevel.R
@@ -1,0 +1,55 @@
+context("ggforest term extraction and reference level")
+
+# Regression tests for:
+#  - #240: ggforest() errored ("undefined columns selected") when the Cox
+#    formula contained an in-formula transformation such as as.factor(x),
+#    because the factor branch indexed data[, "as.factor(x)"] (a non-column).
+#  - #312: the reference level of a factor inherited the statistics of a
+#    prefix-colliding level (e.g. reference "grpBar" picked up "grpBarb"'s HR),
+#    because coef[inds, ] used character row indexing, which partial-matches.
+library(survival)
+
+# collect all text labels drawn in a ggforest (grob-forced so annotations
+# are materialised)
+forest_labels <- function(p) {
+  gt <- grid::grid.force(ggplot2::ggplotGrob(p))
+  labs <- character(0)
+  walk <- function(gr) {
+    if (inherits(gr, "gTree") && !is.null(gr$children))
+      for (nm in names(gr$children)) walk(gr$children[[nm]])
+    if (!is.null(gr$label)) labs <<- c(labs, as.character(gr$label))
+  }
+  walk(gt)
+  unique(labs[nzchar(labs)])
+}
+
+test_that("ggforest() works with an in-formula factor transformation (#240)", {
+  m <- coxph(Surv(time, status) ~ age + as.factor(ph.ecog), data = lung)
+  expect_error(ggforest(m, data = lung), NA)
+})
+
+test_that("no-regression: a factor column with a non-syntactic name renders (#240)", {
+  set.seed(1)
+  d <- lung
+  d$`risk group` <- factor(sample(c("lo", "hi"), nrow(d), replace = TRUE))
+  m <- coxph(Surv(time, status) ~ `risk group`, data = d)
+  expect_error(p <- ggforest(m, data = d), NA)
+  expect_true(any(grepl("reference", forest_labels(p))))
+})
+
+test_that("reference level does not inherit a prefix-colliding level (#312)", {
+  set.seed(1)
+  d <- lung
+  d$grp <- factor(sample(c("Bar", "Barb", "Baz"), nrow(d), replace = TRUE))
+  m <- coxph(Surv(time, status) ~ grp, data = d)      # "Bar" is the reference
+  labs <- forest_labels(ggforest(m, data = d))
+  # With the partial-match bug the reference row showed grpBarb's numeric HR, so
+  # no "reference" label was drawn. Exact matching restores it.
+  expect_true(any(grepl("reference", labs)))
+})
+
+test_that("no-regression: ordinary factor model renders with a reference (#312)", {
+  m <- coxph(Surv(time, status) ~ sex + rx, data = colon)
+  expect_error(p <- ggforest(m, data = colon), NA)
+  expect_true(any(grepl("reference", forest_labels(p))))
+})


### PR DESCRIPTION
## Summary

Two `ggforest()` fixes.

**#312** — the reference level of a factor inherited the statistics of a **similarly-named** non-reference level (e.g. reference `Bar` displayed `Barb`'s hazard ratio). Term rows were looked up with character row indexing (`coef[inds, ]`), which **partial-matches** in R (`coef["grpBar", ]` matches row `grpBarb`). They are now matched exactly with `match()`, so an absent reference level yields `NA` and is correctly rendered as the reference.

**#240** — `ggforest()` errored with "undefined columns selected" when the formula contained an in-formula transformation such as `as.factor(x)`, because the factor branch did `data[, "as.factor(x)"]`. A plain column is now extracted with `data[[var]]` (which also handles non-syntactic backtick names like ```risk group``` and sidesteps the tibble one-column gotcha); only a real transformation is `eval`'d.

## Gate

- Ordinary models (numeric / binary / multi-level factor / transformations / non-syntactic names / tibble) render with correct references and hazard ratios; plain-column extraction is byte-identical.
- New `test-ggforest-reflevel.R` (incl. a backtick-named-factor regression test); full clean-session suite green (`FAIL 0 | PASS 167`).
- **Two independent adversarial pre-commit reviewers, two rounds**: the first round caught a regression (an `eval(parse())`-only #240 attempt crashed on backtick column names); the revised guarded lookup then passed both reviewers.

Fixes #312
Fixes #240