### PR TITLE
Map ggforest() coefficients via model$assign, not a regex (#689)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 ## Bug fixes
 
+- Fix `ggforest()` producing duplicated/crossed rows for prefix-colliding non-factor term names (e.g. logical covariates `add11` and `add17`): coefficients were matched to terms with a regex (`"^var*."`) that treated trailing digits as a quantifier, so each name matched the other's coefficient. Coefficients are now mapped to their term via `model$assign` (#689).
+
 - Fix the cumulative number-of-events and number-censored columns showing decimals for a weighted `survfit()` (in the risk/cumevents/cumcensor tables): the cumulative sums of the fractional weighted counts were not rounded, unlike the per-interval columns. They are now rounded to the same precision (#560, #554).
 
 - Fix `ggsurvplot_combine()` ignoring the risk-table type: `risk.table = "nrisk_cumcensor"` (and other types) is now honoured instead of always showing the absolute number at risk (#641).

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -72,7 +72,14 @@ ggforest <- function(model, data = NULL,
                  pos = 1)
     }
     else {
-      vars = grep(paste0("^", var, "*."), coef$term, value=TRUE)
+      # Map coefficients to this term via model$assign, which is reliable,
+      # rather than a regex on the coefficient names. The old pattern
+      # "^var*." treated trailing digits of the name as a regex quantifier, so
+      # e.g. term "add11" matched coefficient "add17TRUE" and vice-versa,
+      # producing duplicated/wrong rows for prefix-colliding names (#689).
+      idx <- model$assign[[var]]
+      if (is.null(idx)) idx <- which(startsWith(coef$term, var)) # literal fallback
+      vars = coef$term[idx]
       data.frame(var = vars, Var1 = "", Freq = nrow(data),
                  pos = seq_along(vars))
     }

--- a/tests/testthat/test-ggforest-grep.R
+++ b/tests/testthat/test-ggforest-grep.R
@@ -1,0 +1,44 @@
+context("ggforest coefficient-to-term mapping")
+
+# Regression test for #689: for non-factor/non-numeric terms (e.g. logical
+# covariates), ggforest() found the matching coefficients with
+# grep("^var*.", coef$term). The trailing digits of a name were treated as a
+# regex quantifier, so prefix-colliding names such as add11 / add17 each matched
+# BOTH coefficients, producing duplicated/crossed forest rows. Coefficients are
+# now mapped to their term via model$assign.
+library(survival)
+
+# all drawn text labels in a ggforest (grob-forced)
+forest_labels <- function(p) {
+  gt <- grid::grid.force(ggplot2::ggplotGrob(p))
+  labs <- character(0)
+  walk <- function(gr) {
+    if (inherits(gr, "gTree") && !is.null(gr$children))
+      for (nm in names(gr$children)) walk(gr$children[[nm]])
+    if (!is.null(gr$label)) labs <<- c(labs, as.character(gr$label))
+  }
+  walk(gt)
+  labs[nzchar(labs)]
+}
+
+test_that("prefix-colliding logical covariates are not duplicated (#689)", {
+  set.seed(1)
+  d <- lung
+  d$add11 <- lung$age > 60
+  d$add17 <- lung$wt.loss > 10
+  m <- coxph(Surv(time, status) ~ add11 + add17, data = d)
+  labs <- forest_labels(ggforest(m, data = d))
+  # one "(N=...)" label per forest row: two covariates -> two rows (was four)
+  expect_equal(sum(grepl("^\\(N=", labs)), 2L)
+  expect_true(any(grepl("add11", labs)) && any(grepl("add17", labs)))
+})
+
+test_that("no-regression: ordered factor and numeric+logical mix render (#689)", {
+  set.seed(1)
+  d <- lung
+  d$grade <- ordered(sample(c("lo", "mid", "hi"), nrow(d), replace = TRUE),
+                     levels = c("lo", "mid", "hi"))
+  expect_error(ggforest(coxph(Surv(time, status) ~ grade, data = d), data = d), NA)
+  expect_error(ggforest(coxph(Surv(time, status) ~ age + I(age > 60), data = lung),
+                        data = lung), NA)
+})


### PR DESCRIPTION
## Summary

For non-factor/non-numeric terms (e.g. logical covariates), `ggforest()` matched coefficients to a term with `grep("^var*.", coef$term)`. The trailing digits of a name were treated as a **regex quantifier** (`1*` = zero-or-more `1`), so prefix-colliding names such as `add11` and `add17` each matched **both** coefficients, producing duplicated/crossed forest rows.

Coefficients are now mapped to their term via `model$assign` (positional indices into the model's coefficients), with a literal-prefix `startsWith()` fallback for the rare case the lookup is unavailable.

## Gate

- Colliding logicals `add11`/`add17` now give one row each with the correct HR (was 4 crossed rows); even `add1`/`add11`/`add111` map correctly.
- `model$assign` alignment with `broom::tidy()` order verified (including aliased/NA coefficients); ordered factors, `poly()`, interactions, strata all render correctly; factor/numeric branches untouched.
- New `test-ggforest-grep.R`; full clean-session suite green (`FAIL 0 | PASS 171`).
- Two independent adversarial pre-commit reviewers: both PASS.

Fixes #689
