### PR TITLE
Guard ggforest() against near-infinite coefficients (#570, #590)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 ## Bug fixes
 
+- Fix `ggforest()` crashing (`axisTicks(): '_LARGE_ range'`) for a Cox model with complete/quasi-complete separation, where a coefficient is near-infinite: the x-axis range is now clamped to a finite window (with a warning) so the plot still renders (#570, #590).
+
 - Fix `ggforest()` reference level inheriting the statistics of a similarly-named non-reference level (e.g. a reference level `Bar` showing the hazard ratio of `Barb`): term rows were matched by character row indexing, which partial-matches. They are now matched exactly, so the reference level is correctly shown as the reference (#312).
 
 - Fix `ggforest()` erroring with "undefined columns selected" when the Cox formula contains an in-formula factor transformation such as `as.factor(x)`: the term is now evaluated rather than looked up as a column name (a plain column name is unaffected) (#240).

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -121,6 +121,20 @@ ggforest <- function(model, data = NULL,
   toShowExpClean <- toShowExpClean[nrow(toShowExpClean):1, ]
 
   rangeb <- range(toShowExpClean$conf.low, toShowExpClean$conf.high, na.rm = TRUE)
+  # (Quasi-)complete separation in the Cox model yields near-infinite
+  # coefficients, whose exp()-ed confidence limits overflow and make
+  # axisTicks() error with "'at' creation, _LARGE_ range". Clamp the (log-scale)
+  # axis range to a finite window and warn, so the plot still renders (#570,
+  # #590). This is a no-op for ordinary models (their range sits well inside).
+  finite.range <- log(c(1e-6, 1e6))
+  if (any(!is.finite(rangeb)) || rangeb[1] < finite.range[1] || rangeb[2] > finite.range[2]) {
+    warning("Some hazard ratios or confidence limits are extreme or non-finite ",
+            "(possible complete/quasi-complete separation in the Cox model); ",
+            "the x-axis range has been clamped so the plot can be drawn.",
+            call. = FALSE)
+    rangeb <- c(max(rangeb[1], finite.range[1], na.rm = TRUE),
+                min(rangeb[2], finite.range[2], na.rm = TRUE))
+  }
   breaks <- axisTicks(rangeb/2, log = TRUE, nint = 7)
   rangeplot <- rangeb
   # make plot twice as wide as needed to create space for annotations

--- a/tests/testthat/test-ggforest-separation.R
+++ b/tests/testthat/test-ggforest-separation.R
@@ -1,0 +1,30 @@
+context("ggforest with extreme/near-infinite coefficients")
+
+# Regression test for #570 / #590: a Cox model with (quasi-)complete separation
+# produces near-infinite coefficients; exp() of the confidence limits overflows
+# and axisTicks() errored with "'at' creation, _LARGE_ range", so ggforest()
+# crashed. The axis range is now clamped to a finite window (with a warning) so
+# the plot still renders.
+library(survival)
+
+test_that("ggforest() renders (with a warning) for a separated model (#570, #590)", {
+  d <- lung
+  # 'sep' is (near) perfectly associated with the event -> coef ~ -Inf
+  d$sep <- ifelse(d$status == 2, "event", "noevent")
+  m <- suppressWarnings(coxph(Surv(time, status) ~ age + sep, data = d))
+  expect_warning(p <- ggforest(m, data = d), "separation|clamped")
+  # and it actually draws (previously errored in axisTicks at build time)
+  expect_error(ggplot2::ggplotGrob(p), NA)
+})
+
+test_that("no-regression: ordinary model does not warn or change (#570)", {
+  m <- coxph(Surv(time, status) ~ age + sex, data = lung)
+  w <- character(0)
+  withCallingHandlers(
+    ggforest(m, data = lung),
+    warning = function(cnd) {
+      w <<- c(w, conditionMessage(cnd)); invokeRestart("muffleWarning")
+    }
+  )
+  expect_false(any(grepl("separation|clamped", w)))
+})


### PR DESCRIPTION
## Summary

A Cox model with complete/quasi-complete separation has a near-infinite coefficient; the exp()-ed confidence limits overflow and `axisTicks(rangeb/2, log = TRUE)` errored with `"'at' creation, _LARGE_ range"`, so `ggforest()` crashed at build time.

The (log-scale) axis range is now clamped to a finite window `log(c(1e-6, 1e6))` (with a warning) so the plot still renders, with the extreme point clipped at the panel edge and the other rows correctly placed.

## Gate

- Separated model now renders (with a clear warning) instead of crashing.
- **No-op for ordinary models** (range sits well inside the window; large-but-valid HRs up to ~1e6 are not clamped) — `breaks`/`rangeplot`/output byte-identical, no warning.
- Clamp math handles `-Inf`/`NA` via `na.rm`; no NA/Inf leaks downstream.
- New `test-ggforest-separation.R`; full clean-session suite green (`FAIL 0 | PASS 174`).
- Two independent adversarial pre-commit reviewers: both PASS.

Fixes #570
Fixes #590
