### PR TITLE
Apply fun transformation in ggadjustedcurves() (#287, #498, #660)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 ## Bug fixes
 
+- Fix `ggadjustedcurves(..., fun = ...)` not transforming the curve: `fun` (e.g. `"event"`, `"cumhaz"`, `"pct"`) only changed the y-axis limits, while the plotted curve stayed the raw survival probability. The transformation is now applied to the curve (a no-op when `fun = NULL`, the default) (#287, #498, #660).
+
 - Fix `ggforest()` producing duplicated/crossed rows for prefix-colliding non-factor term names (e.g. logical covariates `add11` and `add17`): coefficients were matched to terms with a regex (`"^var*."`) that treated trailing digits as a quantifier, so each name matched the other's coefficient. Coefficients are now mapped to their term via `model$assign` (#689).
 
 - Fix `ggforest()` reference level inheriting the statistics of a similarly-named non-reference level (e.g. a reference level `Bar` showing the hazard ratio of `Barb`): term rows were matched by character row indexing, which partial-matches. They are now matched exactly, so the reference level is correctly shown as the reference (#312).

--- a/R/ggadjustedcurves.R
+++ b/R/ggadjustedcurves.R
@@ -110,6 +110,12 @@ ggadjustedcurves <- function(fit,
                                method = method,
                                size = size,
                                ...)
+  # Apply the transformation requested via `fun` (e.g. "event", "cumhaz",
+  # "pct"). Previously `fun` only affected the y-axis limits and the plotted
+  # curve was always the raw survival probability (#287, #498, #630, #660).
+  # This is a no-op when fun = NULL (the default), so ordinary calls are
+  # unchanged.
+  curve <- .apply_surv_func(curve, fun = fun)
   time <- surv <- NULL
   pl <- ggplot(curve, aes(x = time, y = surv, color = variable)) +
     geom_step(linewidth = size) + ggtheme +

--- a/tests/testthat/test-ggadjustedcurves-fun.R
+++ b/tests/testthat/test-ggadjustedcurves-fun.R
@@ -1,0 +1,33 @@
+context("ggadjustedcurves fun transformation")
+
+# Regression test for #287 (and duplicates #498, #630, #660): ggadjustedcurves()
+# accepted a `fun` argument but used it only to set the y-axis limits; the
+# plotted curve was always the raw survival probability. `fun` now transforms
+# the curve (e.g. "event" -> 1 - surv, "cumhaz" -> -log(surv)).
+library(survival)
+
+curve_y <- function(p) ggplot2::ggplot_build(p)$data[[1]]$y
+
+test_that("fun = 'event' plots 1 - survival (#287)", {
+  fit <- coxph(Surv(stop, event) ~ rx + number + size, data = bladder)
+  p_def <- ggadjustedcurves(fit, data = bladder, method = "average", variable = "rx")
+  p_evt <- ggadjustedcurves(fit, data = bladder, method = "average", variable = "rx",
+                            fun = "event")
+  expect_equal(sort(curve_y(p_evt)), sort(1 - curve_y(p_def)))
+})
+
+test_that("fun = 'cumhaz' transforms the curve (#498)", {
+  fit <- coxph(Surv(stop, event) ~ rx + number + size, data = bladder)
+  p_def <- ggadjustedcurves(fit, data = bladder, method = "average", variable = "rx")
+  p_cum <- ggadjustedcurves(fit, data = bladder, method = "average", variable = "rx",
+                            fun = "cumhaz")
+  expect_false(isTRUE(all.equal(curve_y(p_cum), curve_y(p_def))))
+  expect_equal(sort(curve_y(p_cum)), sort(-log(curve_y(p_def))))
+})
+
+test_that("no-regression: default (fun = NULL) is the raw survival curve (#287)", {
+  fit <- coxph(Surv(stop, event) ~ rx + number + size, data = bladder)
+  p <- ggadjustedcurves(fit, data = bladder, method = "average", variable = "rx")
+  y <- curve_y(p)
+  expect_true(all(y >= 0 & y <= 1))
+})


### PR DESCRIPTION
## Summary

`ggadjustedcurves()` accepted a `fun` argument but used it **only to set the y-axis limits** — the plotted curve was always the raw survival probability. So `fun = "event"`, `"cumhaz"`, `"pct"`, etc. had no visible effect.

The transformation is now applied to the curve via the existing `.apply_surv_func()` helper (the same one `ggsurvplot()` uses): `"event"` → `1 - surv`, `"cumhaz"` → `-log(surv)`, `"pct"` → `100 * surv`, a user function, etc. It is a **no-op when `fun = NULL`** (the default), so ordinary calls are unchanged.

## Gate

- `fun = "event"` → `1 - surv`; `"cumhaz"` → `-log(surv)`; `"pct"` → `100 * surv`; custom functions work (verified for methods `"average"` and `"conditional"`).
- Default (`fun = NULL`) curve is byte-identical to before; transformed values are not clipped (ylim is `NULL` when `fun` is set).
- New `test-ggadjustedcurves-fun.R`; full clean-session suite green (`FAIL 0 | PASS 178`).
- Two independent adversarial pre-commit reviewers: both PASS. (The `method = "marginal"` `predict.glm` error some models hit is **pre-existing** and unrelated to this change.)

Note: `surv_adjustedcurves()` (the data helper) is unchanged; #630 also asks for that function to transform its output, which is left for a follow-up — hence `Refs #630` rather than closing it here.

Fixes #287
Fixes #498
Fixes #660
Refs #630
