### PR TITLE
Coerce data to data.frame in ggsurvplot_facet() for tibble input (#591)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 ## Bug fixes
 
+- Fix `ggsurvplot_facet(..., panel.labs = ...)` failing with "cannot xtfrm data frames" when the data is a tibble: the panel-label code did `as.factor(data[, var])`, and `tibble[, var]` returns a one-column tibble rather than a vector. The data is now coerced to a plain data.frame at entry (#591).
+
 - Fix `ggforest()` crashing (`axisTicks(): '_LARGE_ range'`) for a Cox model with complete/quasi-complete separation, where a coefficient is near-infinite: the x-axis range is now clamped to a finite window (with a warning) so the plot still renders (#570, #590).
 
 - Fix `ggforest()` producing duplicated/crossed rows for prefix-colliding non-factor term names (e.g. logical covariates `add11` and `add17`): coefficients were matched to terms with a regex (`"^var*."`) that treated trailing digits as a quantifier, so each name matched the other's coefficient. Coefficients are now mapped to their term via `model$assign` (#689).

--- a/R/ggsurvplot_facet.R
+++ b/R/ggsurvplot_facet.R
@@ -88,7 +88,11 @@ ggsurvplot_facet <- function(fit, data, facet.by,
   all.variables <- c(surv.vars, facet.by) %>%
     unique()
   vars.notin.groupby <- setdiff(all.variables, facet.by)
-  data <- fit.ext$data.all
+  # Coerce to a plain data.frame so single-column extractions like
+  # data[, .grouping.var] return a vector: for a tibble they return a
+  # one-column tibble, so as.factor() below fails with "cannot xtfrm data
+  # frames" (#591; same tibble gotcha as #548/#670).
+  data <- as.data.frame(fit.ext$data.all)
 
   # Changing panel labs if specified
   #:::::::::::::::::::::::::::::::::::::::::

--- a/tests/testthat/test-facet-tibble.R
+++ b/tests/testthat/test-facet-tibble.R
@@ -1,0 +1,28 @@
+context("ggsurvplot_facet with a tibble")
+
+# Regression test for #591: ggsurvplot_facet() with panel.labs errored with
+# "cannot xtfrm data frames" when the data was a tibble, because the panel-label
+# code did as.factor(data[, var]) and tibble[, var] returns a one-column tibble
+# (not a vector). The data is now coerced to a plain data.frame at entry.
+library(survival)
+
+test_that("ggsurvplot_facet() + panel.labs works with a tibble (#591)", {
+  d   <- tibble::as_tibble(colon)
+  fit <- survfit(Surv(time, status) ~ rx, data = d)
+  expect_error(
+    ggsurvplot_facet(fit, data = d, facet.by = "sex",
+                     panel.labs = list(sex = c("Male", "Female"))),
+    NA
+  )
+})
+
+test_that("no-regression: data.frame input with panel.labs still works (#591)", {
+  fit <- survfit(Surv(time, status) ~ rx, data = colon)
+  expect_error(
+    ggsurvplot_facet(fit, data = colon, facet.by = "sex",
+                     panel.labs = list(sex = c("Male", "Female"))),
+    NA
+  )
+  # plain facet (no panel.labs) unaffected
+  expect_error(ggsurvplot_facet(fit, data = colon, facet.by = "sex"), NA)
+})


### PR DESCRIPTION
## Summary

`ggsurvplot_facet(..., panel.labs = ...)` failed with `"cannot xtfrm data frames"` when the data was a **tibble**: the panel-label code does `as.factor(data[, .grouping.var])`, and `tibble[, var]` returns a one-column tibble rather than a vector. The data is now coerced to a plain data.frame at entry (a no-op for data.frame input; the same tibble gotcha fixed for `surv_group_by()` in #548/#670).

## Gate

- Tibble + `panel.labs` now renders; a data.frame input is byte-identical (verified via `ggplot_build`).
- Attribute preservation confirmed: ordered factors, custom (non-alphabetical) level order, numeric and character facet vars all unchanged.
- New `test-facet-tibble.R`; full clean-session suite green (`FAIL 0 | PASS 181`).
- Two independent adversarial pre-commit reviewers: both PASS (the pre-existing #304 "subscript out of bounds" for `facet.by` == the survfit grouping var is unrelated and present on master too).

Fixes #591
