### PR TITLE
Guard ggsurvplot_facet() pval and correct its documentation (#636)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 ## Bug fixes
 
+- Fix `ggsurvplot_facet(..., pval = "<string>")` erroring with "argument is not interpretable as logical", and clarify the documentation: `ggsurvplot_facet()` computes a p-value for each panel, so (unlike `ggsurvplot()`) a numeric or character `pval` cannot be substituted. Such a value is now ignored with a warning instead of crashing (#636).
+
 - Fix `ggadjustedcurves(..., fun = ...)` not transforming the curve: `fun` (e.g. `"event"`, `"cumhaz"`, `"pct"`) only changed the y-axis limits, while the plotted curve stayed the raw survival probability. The transformation is now applied to the curve (a no-op when `fun = NULL`, the default) (#287, #498, #660).
 
 - Fix `ggforest()` crashing (`axisTicks(): '_LARGE_ range'`) for a Cox model with complete/quasi-complete separation, where a coefficient is near-infinite: the x-axis range is now clamped to a finite window (with a warning) so the plot still renders (#570, #590).

--- a/R/ggsurvplot_facet.R
+++ b/R/ggsurvplot_facet.R
@@ -5,6 +5,10 @@ NULL
 #'@description Draw multi-panel survival curves of a data set grouped by one or
 #'  two variables.
 #'@inheritParams ggsurvplot_arguments
+#'@param pval logical value. If TRUE, a log-rank p-value is computed and
+#'  displayed for each panel. Note that, unlike \code{\link{ggsurvplot}()},
+#'  a numeric or character \code{pval} is not substituted here (there is one
+#'  p-value per panel); such a value is ignored with a warning.
 #'@param facet.by character vector, of length 1 or 2, specifying grouping
 #'  variables for faceting the plot. Should be in the data.
 #'@param nrow,ncol Number of rows and columns in the pannel. Used only when the
@@ -169,7 +173,17 @@ ggsurvplot_facet <- function(fit, data, facet.by,
 
   # Pvalues
   #:::::::::::::::::::::::::::::::::::::::::
-  if(pval){
+  # ggsurvplot_facet() computes and shows a p-value for EACH panel, so unlike
+  # ggsurvplot() a single numeric/character `pval` cannot be substituted. Treat
+  # any non-FALSE `pval` as a request to draw the per-panel p-values (this also
+  # stops a character `pval` from erroring in `if(pval)` with "argument is not
+  # interpretable as logical"), and warn that the supplied value is ignored (#636).
+  draw.pval <- !is.null(pval) && !isFALSE(pval) && !identical(pval, "")
+  if(draw.pval && !isTRUE(pval))
+    warning("ggsurvplot_facet() displays a p-value computed for each panel; a ",
+            "numeric or character `pval` is not substituted. Use `pval = TRUE`.",
+            call. = FALSE)
+  if(draw.pval){
     # Grouped data
     grouped.d <- surv_group_by(data, grouping.vars = facet.by)
     # Compute survfit on each subset ==> list of fits

--- a/man/ggsurvplot_facet.Rd
+++ b/man/ggsurvplot_facet.Rd
@@ -59,10 +59,10 @@ function \link[grDevices]{palette}.}
 the names of the strata from the fit. Should be given in the same order as
 those strata.}
 
-\item{pval}{logical value, a numeric or a string. If logical and TRUE, the
-p-value is added on the plot. If numeric, than the computet p-value is
-substituted with the one passed with this parameter. If character, then the
-customized string appears on the plot. See examples - Example 3.}
+\item{pval}{logical value. If TRUE, a log-rank p-value is computed and
+displayed for each panel. Note that, unlike \code{\link{ggsurvplot}()},
+a numeric or character \code{pval} is not substituted here (there is one
+p-value per panel); such a value is ignored with a warning.}
 
 \item{pval.method}{whether to add a text with the test name used for
 calculating the pvalue, that corresponds to survival curves' comparison -

--- a/tests/testthat/test-facet-pval.R
+++ b/tests/testthat/test-facet-pval.R
@@ -1,0 +1,44 @@
+context("ggsurvplot_facet pval argument")
+
+# Regression test for #636: the docs (inherited from ggsurvplot()) claimed that
+# a numeric or character `pval` could be substituted, but ggsurvplot_facet()
+# computes a p-value per panel. A character `pval` crashed at `if(pval)` with
+# "argument is not interpretable as logical"; a numeric `pval` was silently
+# ignored. Now a non-FALSE pval draws the per-panel p-values and a
+# numeric/character value warns (rather than crashing); the docs are corrected.
+library(survival)
+
+test_that("character pval no longer errors, warns instead (#636)", {
+  fit <- survfit(Surv(time, status) ~ rx, data = colon)
+  expect_warning(
+    ggsurvplot_facet(fit, colon, facet.by = "sex", pval = "p = 0.03"),
+    "not substituted"
+  )
+})
+
+test_that("numeric pval warns that it is not substituted (#636)", {
+  fit <- survfit(Surv(time, status) ~ rx, data = colon)
+  expect_warning(
+    ggsurvplot_facet(fit, colon, facet.by = "sex", pval = 0.345),
+    "not substituted"
+  )
+})
+
+test_that("no-regression: pval = TRUE draws per-panel p-values without warning (#636)", {
+  fit <- survfit(Surv(time, status) ~ rx, data = colon)
+  w <- character(0)
+  p <- withCallingHandlers(
+    ggsurvplot_facet(fit, colon, facet.by = "sex", pval = TRUE),
+    warning = function(cnd) { w <<- c(w, conditionMessage(cnd)); invokeRestart("muffleWarning") }
+  )
+  expect_false(any(grepl("not substituted", w)))
+  # the p-value text layer is present
+  b <- ggplot2::ggplot_build(p)
+  labs <- unlist(lapply(b$data, function(d) if ("label" %in% names(d)) d$label))
+  expect_true(any(grepl("^p", labs)))
+})
+
+test_that("no-regression: pval = FALSE draws no p-value (#636)", {
+  fit <- survfit(Surv(time, status) ~ rx, data = colon)
+  expect_error(ggsurvplot_facet(fit, colon, facet.by = "sex", pval = FALSE), NA)
+})


### PR DESCRIPTION
## Summary

`ggsurvplot_facet()` computes and displays a p-value for **each panel**, so — unlike `ggsurvplot()` — a numeric or character `pval` cannot be substituted. But the documentation (inherited from `ggsurvplot()`) claimed it could, and:
- a **character** `pval` crashed at `if(pval)` with "argument is not interpretable as logical";
- a **numeric** `pval` was silently ignored.

Now any non-`FALSE` `pval` draws the per-panel p-values, and a numeric/character value **warns** ("… is not substituted. Use `pval = TRUE`.") instead of crashing. The `@param pval` docs are corrected.

## Gate

- `pval = TRUE` / `pval = FALSE` behaviour is byte-identical (same per-panel labels, no new warning) — verified via `ggplot_build`.
- `pval = "…"` / numeric now warn (no crash); edge cases `NA`/`NULL`/`""`/`0` don't crash.
- Docs regenerated (`man/ggsurvplot_facet.Rd`, `checkRd` clean); new `test-facet-pval.R`; suite green (`FAIL 0 | PASS 186`).
- Two independent adversarial pre-commit reviewers: both PASS. (The pre-existing `vctrs`/`bind_rows` deprecation warnings in the unchanged draw path are not from this diff.)

Fixes #636
