### PR TITLE
Draw pval.method in ggsurvplot_add_all() (#673)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 ## Bug fixes
 
+- Fix `ggsurvplot(..., add.all = TRUE, pval = TRUE, pval.method = TRUE)` drawing the p-value method (test name) as an empty string: the p-value is computed on the original fit and forwarded as text, so `ggsurvplot_core()` re-derived the method from the "all"-augmented fit and got `""`. The method is now drawn by `ggsurvplot_add_all()` (#673).
+
 - Fix `ggsurvplot_facet(..., panel.labs = ...)` failing with "cannot xtfrm data frames" when the data is a tibble: the panel-label code did `as.factor(data[, var])`, and `tibble[, var]` returns a one-column tibble rather than a vector. The data is now coerced to a plain data.frame at entry (#591).
 
 - Fix `ggadjustedcurves(..., fun = ...)` not transforming the curve: `fun` (e.g. `"event"`, `"cumhaz"`, `"pct"`) only changed the y-axis limits, while the plotted curve stayed the raw survival probability. The transformation is now applied to the curve (a no-op when `fun = NULL`, the default) (#287, #498, #660).

--- a/R/ggsurvplot_add_all.R
+++ b/R/ggsurvplot_add_all.R
@@ -66,15 +66,36 @@ ggsurvplot_add_all <- function(fit, data, legend.title = "Strata", legend.labs =
 
   # Visualize using core ggsurvplot
   if(is.null(legend.labs)) legend.labs <- c("all", strata.levels)
+  # The p-value must be computed on the ORIGINAL fit (comparing the real strata),
+  # not on newfit which contains the extra "all" curve; it is then passed to
+  # ggsurvplot_core() as pre-formatted text. get_coord = TRUE so we also get the
+  # method-annotation coordinates.
   pval <- surv_pvalue(fit,
                       method = .dots$log.rank.weights,
                       data = fit.ext$data.all,
                       pval = pval, pval.coord = .dots$pval.coord,
-                      pval.method.coord = .dots$pval.method.coord)
+                      pval.method.coord = .dots$pval.method.coord,
+                      get_coord = TRUE)
 
-  p <- ggsurvplot_core(newfit, data = data, legend = legend,
-                       legend.title = legend.title, legend.labs = legend.labs,
-                       pval = pval$pval.txt,  ...)
+  # Draw the p-value method (test name) here rather than in ggsurvplot_core:
+  # because the p-value is forwarded as text, core would re-derive the method
+  # from newfit and get an empty string, so pval.method was rendered blank (#673).
+  show.method <- isTRUE(.dots$pval.method)
+  .dots$pval.method <- NULL
+  p <- do.call(ggsurvplot_core,
+               c(list(newfit, data = data, legend = legend,
+                      legend.title = legend.title, legend.labs = legend.labs,
+                      pval = pval$pval.txt),
+                 .dots))
+
+  if(show.method && is.data.frame(pval) && "method" %in% colnames(pval) &&
+     length(pval$method) > 0 && nzchar(pval$method[1])){
+    method.size <- if(!is.null(.dots$pval.method.size)) .dots$pval.method.size
+                   else if(!is.null(.dots$pval.size)) .dots$pval.size else 5
+    p$plot <- p$plot +
+      ggplot2::annotate("text", x = pval$method.x[1], y = pval$method.y[1],
+                        label = pval$method[1], size = method.size, hjust = 0)
+  }
 
   p
 }

--- a/tests/testthat/test-addall-pvalmethod.R
+++ b/tests/testthat/test-addall-pvalmethod.R
@@ -1,0 +1,36 @@
+context("ggsurvplot add.all pval.method")
+
+# Regression test for #673: ggsurvplot(..., add.all = TRUE, pval = TRUE,
+# pval.method = TRUE) drew the p-value but rendered the pval.method (test name)
+# as an empty string. The p-value is pre-computed on the original fit and
+# forwarded to ggsurvplot_core() as text, so core re-derived the method from the
+# "all"-augmented fit and got "". The method is now drawn by ggsurvplot_add_all().
+library(survival)
+
+plot_labels <- function(p) {
+  b <- ggplot2::ggplot_build(p$plot)
+  labs <- unlist(lapply(b$data, function(d) if ("label" %in% names(d)) d$label))
+  labs[nzchar(trimws(labs))]
+}
+
+test_that("add.all draws the pval.method (test name), not an empty string (#673)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = colon)
+  p <- ggsurvplot(fit, data = colon, add.all = TRUE, pval = TRUE, pval.method = TRUE)
+  labs <- plot_labels(p)
+  expect_true(any(grepl("[Ll]og.?rank", labs)))   # method name present
+  expect_true(any(grepl("^p", labs)))             # p-value still present
+})
+
+test_that("no-regression: add.all + pval (no method) shows only the p-value (#673)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = colon)
+  p <- ggsurvplot(fit, data = colon, add.all = TRUE, pval = TRUE)
+  labs <- plot_labels(p)
+  expect_true(any(grepl("^p", labs)))
+  expect_false(any(grepl("[Ll]og.?rank", labs)))  # no method drawn
+})
+
+test_that("no-regression: add.all default still renders (#673)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = colon)
+  expect_error(ggplot2::ggplotGrob(
+    ggsurvplot(fit, data = colon, add.all = TRUE)$plot), NA)
+})


### PR DESCRIPTION
## Summary

`ggsurvplot(..., add.all = TRUE, pval = TRUE, pval.method = TRUE)` drew the p-value but rendered the **method** (test name) as an empty string. The p-value is computed on the *original* fit (the "all"-augmented refit would give a wrong comparison) and forwarded to `ggsurvplot_core()` as text; core then re-derived the method from the augmented fit and got `""`.

The method is now drawn by `ggsurvplot_add_all()` itself, using the method/coords from the original-fit `surv_pvalue(..., get_coord = TRUE)`. `pval.method` is pulled out of `...` so core no longer draws an empty one.

## Gate

- `add.all + pval + pval.method` now shows both `p = 0.61` and `Log-rank` (weighted methods show their own name); the p-value stays the **original-fit** value (0.61), not the augmented-fit 0.88.
- No-regression: `add.all + pval` (no method) and `add.all` alone are byte-identical to before; all `...` passthrough args (risk.table, conf.int, palette, legend, pval.coord/size, log.rank.weights, …) still forwarded correctly via `do.call` (no arg collisions).
- New `test-addall-pvalmethod.R`; full clean-session suite green (`FAIL 0 | PASS 191`).
- Two independent adversarial pre-commit reviewers: both PASS. (Minor non-blocking follow-up noted: the method annotation doesn't yet inherit a custom `font.family`.)

Fixes #673
