### PR TITLE
Add hjust argument to ggsurvtable() (#629)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 - `surv_pvalue()` gains a `pval.digits` argument controlling the number of significant digits used to format the p-value in `pval.txt` (default `2`, unchanged; e.g. `pval.digits = 3` gives `"p = 0.00131"`). Requested for journals that report p-values to 3 digits (#343).
 
+- `ggsurvtable()` gains an `hjust` argument to control the horizontal justification of the table text (passed to `geom_text`). Default is `0.5` (centered, unchanged); use e.g. `hjust = 0` for left-aligned counts (#629).
+
 ## Bug fixes
 
 - Fix `ggsurvplot_facet(..., pval = "<string>")` erroring with "argument is not interpretable as logical", and clarify the documentation: `ggsurvplot_facet()` computes a p-value for each panel, so (unlike `ggsurvplot()`) a numeric or character `pval` cannot be substituted. Such a value is now ignored with a warning instead of crashing (#636).

--- a/R/ggsurvtable.R
+++ b/R/ggsurvtable.R
@@ -33,6 +33,8 @@ NULL
 #'  labels will be colored by strata.
 #'@param fontsize text font size.
 #'@param font.family character vector specifying text element font family, e.g.: font.family = "Courier New".
+#'@param hjust horizontal justification of the table text (passed to
+#'  \code{geom_text}). Default is 0.5 (centered); use e.g. 0 for left-aligned.
 #'@param ... other arguments passed to the function \code{\link{ggsurvtable}} and \code{\link[ggpubr]{ggpar}}.
 #'@return a ggplot.
 #'@author Alboukadel Kassambara, \email{alboukadel.kassambara@@gmail.com}
@@ -89,7 +91,7 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
                          xlog = FALSE, legend = "top",
                          legend.title = "Strata", legend.labs = NULL,
                          y.text = TRUE, y.text.col = TRUE,
-                         fontsize = 4.5, font.family = "",
+                         fontsize = 4.5, font.family = "", hjust = 0.5,
                          axes.offset = TRUE,
                          ggtheme = theme_survminer(),
                          tables.theme = ggtheme, ...)
@@ -132,7 +134,7 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
     title = title, xlab = xlab, ylab = ylab, xlog = xlog,
     legend = legend, legend.title = legend.title, legend.labs = legend.labs,
     y.text = y.text, y.text.col = y.text.col,
-    fontsize = fontsize, font.family = font.family,
+    fontsize = fontsize, font.family = font.family, hjust = hjust,
     axes.offset = axes.offset,
     ggtheme = ggtheme, tables.theme = tables.theme,...)
 
@@ -185,7 +187,7 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
                          xlog = FALSE, legend = "top",
                          legend.title = "Strata", legend.labs = NULL,
                          y.text = TRUE, y.text.col = TRUE, fontsize = 4.5,
-                         font.family = "",
+                         font.family = "", hjust = 0.5,
                          axes.offset = TRUE,
                          ggtheme = theme_survminer(), tables.theme = ggtheme,
                           ...)
@@ -290,7 +292,7 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
 
   p <- ggplot(survsummary, mapping) +
     scale_shape_manual(values = 1:length(levels(survsummary$strata)))+
-    ggpubr::geom_exec(geom_text, data = survsummary, size = fontsize, color = color, family = font.family) +
+    ggpubr::geom_exec(geom_text, data = survsummary, size = fontsize, color = color, family = font.family, hjust = hjust) +
     ggtheme +
     scale_y_discrete(breaks = as.character(levels(survsummary$strata)),labels = yticklabs ) +
     coord_cartesian(xlim = xlim) +

--- a/man/ggsurvtable.Rd
+++ b/man/ggsurvtable.Rd
@@ -44,6 +44,7 @@ ggsurvtable(
   y.text.col = TRUE,
   fontsize = 4.5,
   font.family = "",
+  hjust = 0.5,
   axes.offset = TRUE,
   ggtheme = theme_survminer(),
   tables.theme = ggtheme,
@@ -133,6 +134,9 @@ labels will be colored by strata.}
 \item{fontsize}{text font size.}
 
 \item{font.family}{character vector specifying text element font family, e.g.: font.family = "Courier New".}
+
+\item{hjust}{horizontal justification of the table text (passed to
+\code{geom_text}). Default is 0.5 (centered); use e.g. 0 for left-aligned.}
 
 \item{axes.offset}{logical value. Default is TRUE. If FALSE, set the plot axes
 to start at the origin.}

--- a/tests/testthat/test-ggsurvtable-hjust.R
+++ b/tests/testthat/test-ggsurvtable-hjust.R
@@ -1,0 +1,27 @@
+context("ggsurvtable hjust")
+
+# Regression test for #629: ggsurvtable() gains an hjust argument so the table
+# text can be justified (e.g. left-aligned). Default is 0.5 (centered),
+# reproducing the previous output.
+library(survival)
+
+table_hjust <- function(p) {
+  b  <- ggplot2::ggplot_build(p)
+  ly <- which(vapply(b$plot$layers,
+                     function(l) inherits(l$geom, "GeomText"), logical(1)))
+  b$plot$layers[[ly[1]]]$aes_params$hjust
+}
+
+test_that("hjust is applied to the table text (#629)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  p0  <- ggsurvtable(fit, data = lung, survtable = "risk.table")
+  pL  <- ggsurvtable(fit, data = lung, survtable = "risk.table", hjust = 0)
+  expect_equal(table_hjust(p0), 0.5)   # default centered (unchanged)
+  expect_equal(table_hjust(pL), 0)     # left-aligned
+  expect_error(ggplot2::ggplotGrob(pL), NA)
+})
+
+test_that("no-regression: default table renders unchanged (#629)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  expect_error(ggsurvtable(fit, data = lung, survtable = "cumevents"), NA)
+})


### PR DESCRIPTION
## Summary

`ggsurvtable()` gains an `hjust` argument, forwarded to the `geom_text()` that draws the table counts, so the table text can be justified — e.g. `hjust = 0` for left-aligned counts. Default is `0.5` (centered), which is `geom_text()`'s own default, so existing output is unchanged.

## Gate

- `hjust = 0` left-aligns the text for all three tables (`risk.table`, `cumevents`, `cumcensor`); default `0.5` is **byte-identical** to before (verified against master's built `GeomText` layer).
- `ggsurvplot(risk.table = TRUE)` and the main survival plot are unaffected (hjust defaults through the internal table path; no leak to the curve).
- Docs added (`man/ggsurvtable.Rd`, `checkRd` clean, signature order); new `test-ggsurvtable-hjust.R`; suite green (`FAIL 0 | PASS 195`).
- Two independent adversarial pre-commit reviewers: both PASS.

Fixes #629
