### PR TITLE
Support strata() terms in pairwise_survdiff() (#648)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 ## Bug fixes
 
+- Fix `pairwise_survdiff()` erroring with "undefined columns selected" when the formula contains a `strata()` term (e.g. `~ rx + strata(sex)`): `strata(sex)` is not a data column, so it could not be used to group/subset. `strata()` terms are now separated from the grouping variable and kept in the `survdiff` formula, giving a stratified pairwise test (#648).
+
 - Fix `ggsurvplot(..., add.all = TRUE, pval = TRUE, pval.method = TRUE)` drawing the p-value method (test name) as an empty string: the p-value is computed on the original fit and forwarded as text, so `ggsurvplot_core()` re-derived the method from the "all"-augmented fit and got `""`. The method is now drawn by `ggsurvplot_add_all()` (#673).
 
 - Fix `ggsurvplot_facet(..., pval = "<string>")` erroring with "argument is not interpretable as logical", and clarify the documentation: `ggsurvplot_facet()` computes a p-value for each panel, so (unlike `ggsurvplot()`) a numeric or character `pval` cannot be substituted. Such a value is now ignored with a warning instead of crashing (#636).

--- a/R/pairwise_survdiff.R
+++ b/R/pairwise_survdiff.R
@@ -44,7 +44,17 @@ pairwise_survdiff <- function(formula, data, p.adjust.method = "BH", na.action, 
 
 {
   if(missing(na.action)) na.action <- options()$na.action
-  group_var <- attr(stats::terms(formula), "term.labels")
+  all_terms <- attr(stats::terms(formula), "term.labels")
+  # Separate strata() terms (an adjustment, not a grouping variable): they are
+  # not data columns, so using them to subset/group crashed with "undefined
+  # columns selected". They are kept in the survdiff formula so the pairwise
+  # test is stratified (#648).
+  is_strata <- grepl("^strata\\(", all_terms)
+  strata_terms <- all_terms[is_strata]
+  group_var <- all_terms[!is_strata]
+  if(length(group_var) == 0)
+    stop("The formula must contain at least one grouping variable ",
+         "(besides strata() terms).", call. = FALSE)
   surv_obj <- deparse(formula[[2]])
 
   DNAME <- paste(deparse(substitute(data)), "and", .collapse(group_var, sep = " + " ))
@@ -63,15 +73,18 @@ pairwise_survdiff <- function(formula, data, p.adjust.method = "BH", na.action, 
   # ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   if(length(group_var) == 1){
     group <- unlist(data[, group_var])
+    rhs <- group_var
   }
-  else if(length(group_var) >1){
-    # Create strata with multiple variables and add it in the data
+  else {
+    # Create strata with multiple grouping variables and add it in the data
     group <- data[, group_var] %>%
       survival::strata()
     data <- data %>% mutate(..group.. = group)
-    # update formula
-    formula <- .build_formula(surv_obj, "..group..")
+    rhs <- "..group.."
   }
+  # Rebuild the formula from the grouping variable, keeping any strata() terms
+  # so the pairwise comparison is stratified (#648).
+  formula <- .build_formula(surv_obj, paste(c(rhs, strata_terms), collapse = " + "))
   if(!is.factor(group)) group <- as.factor(group)
   group <- droplevels(group)
 

--- a/tests/testthat/test-pairwise_survdiff.R
+++ b/tests/testthat/test-pairwise_survdiff.R
@@ -1,0 +1,39 @@
+context("pairwise_survdiff")
+
+# Regression test for #648: pairwise_survdiff() errored with "undefined columns
+# selected" when the formula contained a strata() term (e.g. ~ rx + strata(sex)),
+# because strata(sex) is not a data column. strata() terms are now separated
+# from the grouping variable and kept in the survdiff formula (a stratified
+# pairwise test).
+library(survival)
+
+test_that("pairwise_survdiff() works with a strata() term (#648)", {
+  expect_error(
+    res <- pairwise_survdiff(Surv(time, status) ~ rx + strata(sex), data = colon),
+    NA
+  )
+  expect_s3_class(res, "pairwise.htest")
+  # the comparison is over the grouping variable rx (3 levels -> 2x2 matrix)
+  expect_equal(rownames(res$p.value), c("Lev", "Lev+5FU"))
+  expect_equal(colnames(res$p.value), c("Obs", "Lev"))
+})
+
+test_that("no-regression: single grouping variable is unchanged (#648)", {
+  res <- pairwise_survdiff(Surv(time, status) ~ rx, data = colon)
+  expect_s3_class(res, "pairwise.htest")
+  # Lev vs Obs is not significant; Lev+5FU vs Obs is highly significant
+  expect_gt(res$p.value["Lev", "Obs"], 0.5)
+  expect_lt(res$p.value["Lev+5FU", "Obs"], 1e-6)
+})
+
+test_that("no-regression: two grouping variables still work (#648)", {
+  expect_error(
+    pairwise_survdiff(Surv(time, status) ~ rx + adhere, data = colon), NA)
+})
+
+test_that("a formula with only strata() terms errors clearly (#648)", {
+  expect_error(
+    pairwise_survdiff(Surv(time, status) ~ strata(sex), data = colon),
+    "at least one grouping variable"
+  )
+})


### PR DESCRIPTION
## Summary

`pairwise_survdiff()` treated every term label as a grouping variable and did `data[, group_var]`, which crashed with **"undefined columns selected"** when the formula contained a `strata()` term (e.g. `~ rx + strata(sex)`) — `strata(sex)` is not a data column.

`strata()` terms are now separated from the grouping variable(s) and kept in the `survdiff` formula, so the pairwise comparison is **stratified**. A formula containing only `strata()` terms errors clearly.

## Gate

- `~ rx + strata(sex)` now returns a `pairwise.htest`; each p-value equals a direct stratified `survdiff()` on the pair-subset (df correctly = 1, not inflated by the number of strata).
- **No-regression:** `~ rx` and `~ rx + adhere` p-value matrices are **byte-identical** to master.
- Edge cases: only-strata formula errors; a column literally named like `stratahat` is not mis-detected (regex `^strata\(`); multiple strata terms, `rho = 1` (Peto), custom `na.action` all work.
- New `test-pairwise_survdiff.R`; full clean-session suite green (`FAIL 0 | PASS 204`).
- Two independent adversarial pre-commit reviewers: both PASS (statistical correctness verified against `survdiff`).

Fixes #648
