### PR TITLE
Fix ggcoxzph() fit-line x-scale for transform = 'log' (#454, #588)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 ## Bug fixes
 
+- Fix `ggcoxzph()` with `cox.zph(..., transform = "log")` drawing the fitted line on a different x-scale than the residual points (the line was squeezed to the far left): the fit line was drawn at `log(pred.x)` while the points and confidence bands were on the original time scale. The fit line now uses the same scale and the x-axis is log-scaled, matching `survival::plot.cox.zph(log = "x")` (#454, #588).
+
 - Fix `ggsurvplot(..., add.all = TRUE, pval = TRUE, pval.method = TRUE)` drawing the p-value method (test name) as an empty string: the p-value is computed on the original fit and forwarded as text, so `ggsurvplot_core()` re-derived the method from the "all"-augmented fit and got `""`. The method is now drawn by `ggsurvplot_add_all()` (#673).
 
 - Fix `ggsurvplot_facet(..., pval = "<string>")` erroring with "argument is not interpretable as logical", and clarify the documentation: `ggsurvplot_facet()` computes a p-value for each panel, so (unlike `ggsurvplot()`) a numeric or character `pval` cannot be substituted. Such a value is now ignored with a warning instead of crashing (#636).

--- a/R/ggcoxzph.R
+++ b/R/ggcoxzph.R
@@ -120,10 +120,17 @@ ggcoxzph <- function (fit, resid = TRUE, se = TRUE, df = 4, nsmo = 40, var,
         ylab(ylab[i]) +
         ylim(yr) -> gplot
     } else if (x$transform == "log") {
-      gplot + geom_line(aes(x=log(pred.x), y=yhat)) +
+      # pred.x is already on the original time scale (exp()-ed above), like the
+      # residual points (xx) and the SE bands. Draw the fit line on that same
+      # scale and put the axis on a log scale, instead of drawing the line at
+      # log(pred.x) (which put the fit line on a different x-scale than the
+      # points, squeezing it to the left); reproduces plot.cox.zph(log = "x")
+      # (#454, #588).
+      gplot + geom_line(aes(x=pred.x, y=yhat)) +
         xlab("Time") +
         ylab(ylab[i]) +
-        ylim(yr)  -> gplot
+        ylim(yr) +
+        scale_x_log10() -> gplot
     } else {
       gplot + geom_line(aes(x=pred.x, y=yhat)) +
         xlab("Time") +

--- a/tests/testthat/test-ggcoxzph-log.R
+++ b/tests/testthat/test-ggcoxzph-log.R
@@ -1,0 +1,35 @@
+context("ggcoxzph transform = log")
+
+# Regression test for #454 (and duplicate #588): with cox.zph(transform = "log"),
+# ggcoxzph() drew the fitted line at log(pred.x) while the residual points and
+# the SE bands were on the original (exp-ed) time scale, so the fit line was
+# squeezed to the far left, mismatched with the points. The fit line now uses
+# the same scale as the points and the axis is log-scaled (like
+# survival::plot.cox.zph(log = "x")).
+library(survival)
+
+layer_xranges <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  lapply(b$data, function(d) if ("x" %in% names(d)) range(d$x, na.rm = TRUE))
+}
+
+test_that("fit line and residual points share the x-scale for transform='log' (#454)", {
+  fit <- coxph(Surv(time, status) ~ age + sex, data = lung)
+  zph <- cox.zph(fit, transform = "log")
+  p   <- ggcoxzph(zph)[[1]]
+  xr  <- layer_xranges(p)
+  # layer 1 = fit line (geom_line), layer 2 = points (geom_point)
+  expect_equal(xr[[1]], xr[[2]], tolerance = 1e-6)
+  # x-axis is log-scaled
+  b <- ggplot2::ggplot_build(p)
+  expect_match(b$layout$panel_scales_x[[1]]$trans$name, "log")
+  expect_error(ggplot2::ggplotGrob(p), NA)
+})
+
+test_that("no-regression: identity and km transforms still render (#454)", {
+  fit <- coxph(Surv(time, status) ~ age + sex, data = lung)
+  for (tr in c("identity", "km")) {
+    zph <- cox.zph(fit, transform = tr)
+    expect_error(ggplot2::ggplotGrob(ggcoxzph(zph)[[1]]), NA)
+  }
+})


### PR DESCRIPTION
## Summary

With `cox.zph(transform = "log")`, `ggcoxzph()` drew the residual points and confidence bands on the original (exp-ed) time scale but the **fitted line at `log(pred.x)`** — a different x-scale — so the fit line was squeezed to the far left, misaligned with the points.

The fit line is now drawn on the same scale as the points/bands, and the x-axis is log-scaled via `scale_x_log10()`, matching `survival::plot.cox.zph(log = "x")`.

## Gate

- All four layers (fit line, points, upper/lower SE bands) now share the x-range; x-axis is log10; the plot matches `plot.cox.zph()`.
- `Beta(t)` (y) values are unchanged — only the x aesthetic + scale changed.
- **No-regression:** `transform = "identity"` and `"km"` branches are textually unchanged and byte-identical to master; `se=FALSE`/`resid=FALSE`/factor covariates render.
- New `test-ggcoxzph-log.R`; full clean-session suite green (`FAIL 0 | PASS 209`).
- Two independent adversarial pre-commit reviewers: both PASS.

Fixes #454
Fixes #588
