### PR TITLE
Derive break.y.by axis breaks from the displayed y-range (#378, #442)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 ## Bug fixes
 
+- Fix `break.y.by` producing wrong axis breaks for transformed survival curves (`fun = "cloglog"`, `"event"`, `"cumhaz"`) or a custom `ylim` outside [0, 1]: the y breaks were computed as `seq(0, 1, by = break.y.by)`, so values outside [0, 1] had no breaks. They are now derived from the displayed y-range (the default survival plot is unchanged) (#378, #442).
+
 - Fix `pairwise_survdiff()` erroring with "undefined columns selected" when the formula contains a `strata()` term (e.g. `~ rx + strata(sex)`): `strata(sex)` is not a data column, so it could not be used to group/subset. `strata()` terms are now separated from the grouping variable and kept in the `survdiff` formula, giving a stratified pairwise test (#648).
 
 - Fix `ggsurvplot(..., add.all = TRUE, pval = TRUE, pval.method = TRUE)` drawing the p-value method (test name) as an empty string: the p-value is computed on the original fit and forwarded as text, so `ggsurvplot_core()` re-derived the method from the "all"-augmented fit and got `""`. The method is now drawn by `ggsurvplot_add_all()` (#673).

--- a/R/ggsurvplot_df.R
+++ b/R/ggsurvplot_df.R
@@ -174,7 +174,21 @@ ggsurvplot_df <- function(fit, fun = NULL,
   xlog <- .is_cloglog(fun)
 
   y.breaks <- ggplot2::waiver()
-  if(!is.null(break.y.by)) y.breaks <- seq(0, 1, by = break.y.by)
+  if(!is.null(break.y.by)){
+    # Derive the break range from the displayed y-range instead of the hardcoded
+    # 0..1: for transformed curves (fun = "cloglog"/"event"/"cumhaz", or a custom
+    # ylim) the y-values fall outside [0, 1], so seq(0, 1, ...) produced too few
+    # (or no) breaks (#378, #442). The default survival plot (fun = NULL, no
+    # ylim) still uses 0..1, so its breaks are unchanged.
+    y.range <- ylim
+    if(is.null(y.range) && is.null(fun)) y.range <- c(0, 1)
+    if(is.null(y.range)) y.range <- range(df$surv, na.rm = TRUE)
+    # round the endpoints out to multiples of break.y.by so the breaks are on a
+    # clean grid; breaks that fall outside the axis limits are dropped by ggplot2
+    y.breaks <- seq(floor(min(y.range) / break.y.by) * break.y.by,
+                    ceiling(max(y.range) / break.y.by) * break.y.by,
+                    by = break.y.by)
+  }
   # Axis limits
   xmin <- ifelse(.is_cloglog(fun), min(c(1, df$time)), 0)
   if(is.null(xlim)) xlim <- c(xmin, max(df$time))

--- a/tests/testthat/test-break-y-by.R
+++ b/tests/testthat/test-break-y-by.R
@@ -1,0 +1,34 @@
+context("break.y.by outside [0, 1]")
+
+# Regression test for #378 (and #442): break.y.by computed the y breaks as
+# seq(0, 1, by = break.y.by), so for transformed curves (fun = "cloglog" /
+# "event" / "cumhaz") or a custom ylim outside [0, 1] the breaks were wrong
+# (only 0 and 1, missing the negative / >1 range). The breaks are now derived
+# from the displayed y-range.
+library(survival)
+
+y_breaks <- function(p) {
+  bk <- ggplot2::ggplot_build(p$plot)$layout$panel_params[[1]]$y$breaks
+  bk[!is.na(bk)]
+}
+
+test_that("cloglog break.y.by covers the negative range (#378)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  p   <- ggsurvplot(fit, data = lung, fun = "cloglog", break.y.by = 1)
+  bk  <- y_breaks(p)
+  expect_true(any(bk < 0))          # negative breaks now present
+  expect_true(all(bk == round(bk))) # on a clean integer grid
+})
+
+test_that("fun='event' with ylim > 1 breaks reach the top (#442)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  p   <- ggsurvplot(fit, data = lung, fun = "event", ylim = c(0, 2),
+                    break.y.by = 0.5)
+  expect_equal(y_breaks(p), c(0, 0.5, 1, 1.5, 2))
+})
+
+test_that("no-regression: default survival break.y.by is unchanged (#378)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  p   <- ggsurvplot(fit, data = lung, break.y.by = 0.25)
+  expect_equal(y_breaks(p), c(0, 0.25, 0.5, 0.75, 1))
+})


### PR DESCRIPTION
## Summary

`break.y.by` computed the y-axis breaks as `seq(0, 1, by = break.y.by)`, so for transformed survival curves (`fun = "cloglog"`/`"event"`/`"cumhaz"`) or a custom `ylim` outside `[0, 1]`, the breaks were wrong — only `0` and `1`, missing the negative or `> 1` range.

The breaks are now derived from the **displayed y-range** (`ylim` if given, else `c(0, 1)` for the default survival plot, else the range of the transformed values), rounded out to a clean grid.

## Gate

- `fun = "cloglog", break.y.by = 1` → `-4, -3, …, 1`; `fun = "event", ylim = c(0, 2), break.y.by = 0.5` → `0, 0.5, 1, 1.5, 2`; `fun = "cumhaz"` covers `> 1`.
- **No-regression:** the default survival plot's visible breaks are byte-identical to master for every `break.y.by` (an out-of-`[0,1]` break from the rounding is dropped by the axis limits); `break.y.by = NULL` still auto.
- New `test-break-y-by.R`; full clean-session suite green (`FAIL 0 | PASS 208`).
- Two independent adversarial pre-commit reviewers: both PASS.

Fixes #378
Fixes #442
