### PR TITLE
Fix ggsurvplot facet.by when all formula variables are faceted (#304)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 ## Bug fixes
 
+- Fix `ggsurvplot(fit, facet.by = "X")` erroring with "subscript out of bounds" when every variable of the survival formula is also a `facet.by` variable, e.g. a null model `Surv(...) ~ 1` faceted by `X`, or `Surv(...) ~ X` faceted by `X`. Each panel then shows a single curve with no within-panel grouping, so there is no extra strata to build; this case no longer calls the strata builder with zero variables (#304).
+
 - Fix `break.y.by` producing wrong axis breaks for transformed survival curves (`fun = "cloglog"`, `"event"`, `"cumhaz"`) or a custom `ylim` outside [0, 1]: the y breaks were computed as `seq(0, 1, by = break.y.by)`, so values outside [0, 1] had no breaks. They are now derived from the displayed y-range (the default survival plot is unchanged) (#378, #442).
 
 - Fix `ggcoxzph()` with `cox.zph(..., transform = "log")` drawing the fitted line on a different x-scale than the residual points (the line was squeezed to the far left): the fit line was drawn at `log(pred.x)` while the points and confidence bands were on the original time scale. The fit line now uses the same scale and the x-axis is log-scaled, matching `survival::plot.cox.zph(log = "x")` (#454, #588).

--- a/R/ggsurvplot_facet.R
+++ b/R/ggsurvplot_facet.R
@@ -122,7 +122,17 @@ ggsurvplot_facet <- function(fit, data, facet.by,
       surv_fit(., data = data)
   }
 
-  if(length(vars.notin.groupby) == 1){
+  if(length(vars.notin.groupby) == 0){
+    # All the survival-formula variables are used for faceting, e.g. a null model
+    # `~ 1` faceted by X, or `~ X` faceted by X. Each panel then holds a single
+    # curve with no extra within-panel grouping, so there is nothing to combine
+    # into a `.strata.` column (calling .create_strata() with no variable errors
+    # with "subscript out of bounds"). `fit` has already been (re)built above as
+    # `Surv ~ facet.by`, giving one stratum per panel (#304).
+    if(is.null(color)) color <- "strata"
+    .survformula <- .build_formula(surv.obj, "1")
+  }
+  else if(length(vars.notin.groupby) == 1){
     if(is.null(color)) color <- vars.notin.groupby
     .survformula <- .build_formula(surv.obj, vars.notin.groupby)
   }

--- a/tests/testthat/test-facet-vars-in-groupby.R
+++ b/tests/testthat/test-facet-vars-in-groupby.R
@@ -1,0 +1,43 @@
+context("ggsurvplot facet.by with all variables in facet.by")
+
+# Regression test for #304: ggsurvplot(fit, facet.by = "X") errored with
+# "subscript out of bounds" when every variable of the survival formula is also
+# a facet.by variable -- a null model (~ 1) faceted, or ~ X faceted by X. In that
+# case there is no within-panel grouping to build into a .strata. column, so
+# .create_strata() was called with zero variables and crashed.
+library(survival)
+
+x <- data.frame(
+  Time = c(10, 20, 20, 20),
+  Dead = c(TRUE, FALSE, FALSE, FALSE),
+  X = c(1, 1, 2, 2),
+  Q = c(1, 1, 1, 1)
+)
+
+test_that("facet.by works for a null model ~ 1 (#304)", {
+  p <- ggsurvplot(survfit(Surv(Time, Dead) ~ 1, x), data = x, facet.by = "X")
+  expect_error(ggplot2::ggplotGrob(p), NA)
+  # The plot data must carry the faceting variable and show the correct
+  # per-panel subgroup curves: X = 1 drops to 0.5 (one event at t = 10),
+  # X = 2 stays at 1.0 (no events).
+  pd <- p$data
+  expect_true("X" %in% colnames(pd))
+  expect_equal(min(pd$surv[pd$X == 1]), 0.5)
+  expect_equal(min(pd$surv[pd$X == 2]), 1.0)
+})
+
+test_that("facet.by works when the grouping variable equals facet.by (#304)", {
+  p <- ggsurvplot(survfit(Surv(Time, Dead) ~ X, x), data = x, facet.by = "X")
+  expect_error(ggplot2::ggplotGrob(p), NA)
+})
+
+test_that("no-regression: facet.by with an extra grouping variable still works (#304)", {
+  # length(vars.notin.groupby) == 1 branch
+  fit1 <- survfit(Surv(time, status) ~ sex, data = colon)
+  p1 <- ggsurvplot(fit1, data = colon, facet.by = "rx")
+  expect_error(ggplot2::ggplotGrob(p1), NA)
+  # length(vars.notin.groupby) >= 2 branch (.strata. combination)
+  fit2 <- survfit(Surv(time, status) ~ sex + adhere, data = colon)
+  p2 <- ggsurvplot(fit2, data = colon, facet.by = "rx")
+  expect_error(ggplot2::ggplotGrob(p2), NA)
+})


### PR DESCRIPTION
## Problem

`ggsurvplot(fit, facet.by = "X")` errored with `subscript out of bounds` whenever every variable of the survival formula is also a `facet.by` variable:

```r
x <- data.frame(Time = c(10,20,20,20), Dead = c(TRUE,FALSE,FALSE,FALSE), X = c(1,1,2,2))
ggsurvplot(survfit(Surv(Time, Dead) ~ 1, x), data = x, facet.by = "X")   # error
ggsurvplot(survfit(Surv(Time, Dead) ~ X, x), data = x, facet.by = "X")   # error
```

`vars.notin.groupby <- setdiff(all.variables, facet.by)` is then `character(0)`, and the code fell into the `.strata.`-combination branch, calling the strata builder with zero variables (`survival::strata()` on a 0-column data frame → `allf[[1]]` subscript out of bounds).

## Fix

Add a `length(vars.notin.groupby) == 0` branch to `ggsurvplot_facet()`. In this case each panel holds a single curve (no within-panel grouping), and `fit` has already been refit above as `Surv ~ facet.by` (one stratum per panel), so no `.strata.` column is needed. The existing length-1 and length-≥2 branches are unchanged.

Result — the two panels now render correctly (X=1 steps down at t=10, X=2 flat at 1.0), matching the reporter's expected output.

## No-regression

- The length-1 and length-≥2 branches are untouched; a reviewer confirmed the resulting plot `$data` is byte-identical to master for normal facets (`~sex` facet rx, `~sex+adhere` facet rx).
- `color = "strata"` does not hit the single-group literal-colour crash (#298): the fit carries `$strata` in both sub-cases.
- Faceting by a constant variable still errors (as it did on master; a degenerate input).
- New `test-facet-vars-in-groupby.R` (7 assertions incl. per-panel curve values). Full suite green.
- Two independent adversarial reviewers signed off on this exact diff.

Fixes #304