### PR TITLE
Report complete-case sample size in ggforest() (#597)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 ## Bug fixes
 
+- Fix `ggforest()` reporting a sample size that includes subjects with missing values: `coxph()` drops rows with a missing value in any model variable (`na.action = na.omit`), but `ggforest()` counted all rows of `data`, overstating the per-term/level `N`. The reported `N` now reflects the complete cases the model actually used (`model$n`). Models fit on data without missing values are unaffected (#597).
+
 - Fix `ggsurvplot(fit, facet.by = "X")` erroring with "subscript out of bounds" when every variable of the survival formula is also a `facet.by` variable, e.g. a null model `Surv(...) ~ 1` faceted by `X`, or `Surv(...) ~ X` faceted by `X`. Each panel then shows a single curve with no within-panel grouping, so there is no extra strata to build; this case no longer calls the strata builder with zero variables (#304).
 
 - Fix the percentage at risk (`pct.risk`, used in `risk.table = "percentage"`/`"abs_pct"`) exceeding 100% for a weighted `survfit()`: it was computed as `n.risk * 100 / fit$n`, but `fit$n` is the unweighted subject count while `n.risk` is weighted. When the weighting makes `n.risk` exceed `fit$n`, the denominator now falls back to the weighted number at risk at the origin. Unweighted fits (for which `n.risk` never exceeds `fit$n`) keep `fit$n`, so their output is unchanged (#561).

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -51,6 +51,18 @@ ggforest <- function(model, data = NULL,
 
   # get data and variables/terms from cox model
   data  <- .get_data(model, data = data)
+
+  # coxph() drops rows with missing values in any model variable
+  # (na.action = na.omit by default), so counting all rows of `data` would
+  # overstate the sample size reported per term/level. Restrict `data` to the
+  # complete cases the model actually used, matching model$n. Models fit on data
+  # with no missing values are unaffected (the subset is a no-op) (#597).
+  .model.vars <- intersect(all.vars(stats::terms(model)), colnames(data))
+  if (length(.model.vars) > 0) {
+    .complete <- stats::complete.cases(data[, .model.vars, drop = FALSE])
+    if (any(!.complete)) data <- data[.complete, , drop = FALSE]
+  }
+
   terms <- attr(model$terms, "dataClasses")[-1]
 # removed as requested in #388
 #  terms <- terms[intersect(names(terms),

--- a/tests/testthat/test-ggforest-complete-n.R
+++ b/tests/testthat/test-ggforest-complete-n.R
@@ -1,0 +1,46 @@
+context("ggforest sample size excludes missing values")
+
+# Regression test for #597: ggforest() reported a sample size counting all rows
+# of `data`, but coxph() drops rows with missing values in any model variable
+# (na.action = na.omit). The reported N now reflects the complete cases the model
+# actually used (model$n).
+library(survival)
+
+# Collect all text labels drawn in a ggforest plot.
+.ggforest_labels <- function(p) {
+  g <- grid::grid.force(ggplot2::ggplotGrob(p))
+  out <- character(0)
+  walk <- function(gr) {
+    if (!is.null(gr$children)) for (ch in gr$children) walk(ch)
+    if (!is.null(gr$label)) out[[length(out) + 1]] <<- paste(gr$label, collapse = "|")
+  }
+  walk(g)
+  unlist(out)
+}
+
+test_that("ggforest N reflects complete cases used by the model (#597)", {
+  data(cancer, package = "survival")
+  d <- subset(colon, select = c(sex, adhere, time, status))
+  set.seed(1)
+  d$adhere[sample(nrow(d), 200)] <- NA
+  m <- coxph(Surv(time, status) ~ factor(sex) + factor(adhere), data = d)
+  expect_true(m$n < nrow(d))                    # coxph dropped the NA rows
+
+  labs <- .ggforest_labels(ggforest(m, data = d))
+  # complete-case per-level counts (sum to model$n = 1658)
+  expect_true(any(grepl("N=800", labs)))
+  expect_true(any(grepl("N=858", labs)))
+  # the old full-data counts (nrow = 1858; sex 890/968) must NOT appear
+  expect_false(any(grepl("N=890", labs)))
+  expect_false(any(grepl("N=968", labs)))
+  expect_false(any(grepl("N=1858", labs)))
+})
+
+test_that("no-regression: ggforest N unchanged when there are no missing values (#597)", {
+  m <- coxph(Surv(time, status) ~ factor(sex) + factor(adhere), data = colon)
+  expect_equal(m$n, nrow(colon))                # nothing dropped
+  labs <- .ggforest_labels(ggforest(m, data = colon))
+  # full-data per-level counts appear unchanged (sex 890/968)
+  expect_true(any(grepl("N=890", labs)))
+  expect_true(any(grepl("N=968", labs)))
+})


### PR DESCRIPTION
## Problem

`ggforest()` reported a per-term/level sample size (`(N=...)`) counting **all** rows of `data`. But `coxph()` drops rows with a missing value in any model variable (`na.action = na.omit` by default), so the reported N overstated the sample the model actually used.

```r
library(survival); library(survminer)
d <- subset(colon, select = c(sex, adhere, time, status))
d$adhere[sample(nrow(d), 200)] <- NA           # inject missing values
m <- coxph(Surv(time, status) ~ sex + adhere, data = d)
m$n          # 1658 (complete cases used)
nrow(d)      # 1858 -> ggforest used to show this
```

## Fix

Restrict `data` to the complete cases the model used before computing N:

```r
.model.vars <- intersect(all.vars(stats::terms(model)), colnames(data))
if (length(.model.vars) > 0) {
  .complete <- stats::complete.cases(data[, .model.vars, drop = FALSE])
  if (any(!.complete)) data <- data[.complete, , drop = FALSE]
}
```

Now the per-level N sums to `model$n` (sex 800/858, adhere 1418/240 → 1658).

## No-regression

- `data` is used **only** for the N computation (factor `table()` and `nrow()`); coefficients, CIs, and the global-stats caption come from `model`/`glance(model)`.
- For models with **no** missing values `any(!.complete)` is FALSE, so `data` is untouched and output is byte-identical.
- `complete.cases(all.vars(terms(model)))` verified to equal `model$n` for factor/strata/log/I()/interaction/pspline/ns terms and NA-in-response.
- New `test-ggforest-complete-n.R` (grob-walk N extraction; incl. no-NA no-regression). Full suite green.
- Two independent adversarial reviewers signed off (residual limitations only for `subset=`/post-transform-NaN, always in the safe overcount direction).

Fixes #597