### PR TITLE
Add linejoin argument to ggsurvplot() (#653)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 - `ggsurvtable()` gains an `hjust` argument to control the horizontal justification of the table text (passed to `geom_text`). Default is `0.5` (centered, unchanged); use e.g. `hjust = 0` for left-aligned counts (#629).
 
+- `ggsurvplot()` gains a `linejoin` argument controlling the line join of the survival curve. Default is `"round"` (unchanged); use `linejoin = "mitre"` for sharp corners that mark event times precisely (requires a `ggplot2` version that passes `linejoin` through `geom_step()`). Previously `linejoin` passed via `...` was silently dropped (#653).
+
 ## Bug fixes
 
 - Fix `ggsurvplot(fit, facet.by = "X")` erroring with "subscript out of bounds" when every variable of the survival formula is also a `facet.by` variable, e.g. a null model `Surv(...) ~ 1` faceted by `X`, or `Surv(...) ~ X` faceted by `X`. Each panel then shows a single curve with no within-panel grouping, so there is no extra strata to build; this case no longer calls the strata builder with zero variables (#304).

--- a/R/ggsurvplot_df.R
+++ b/R/ggsurvplot_df.R
@@ -21,6 +21,10 @@ NULL
 #'  end of confidence interval }
 #' @param surv.geom survival curve style. Is the survival curve entered a step
 #'  function (\link[ggplot2]{geom_step}) or a smooth function (\link[ggplot2]{geom_line}).
+#' @param linejoin line join style for the survival curve, passed to the survival
+#'  geom. Default is \code{"round"} (unchanged). Use \code{"mitre"} for sharp,
+#'  precisely-marked corners at event times (requires a \pkg{ggplot2} version that
+#'  passes \code{linejoin} through \code{\link[ggplot2]{geom_step}}).
 #'
 #' @examples
 #' library(survival)
@@ -68,6 +72,7 @@ ggsurvplot_df <- function(fit, fun = NULL,
                           color = NULL, palette = NULL, linetype = 1,
                           break.x.by = NULL, break.time.by = NULL, break.y.by = NULL,
                           surv.scale = c("default", "percent"), surv.geom = geom_step,
+                          linejoin = "round",
                           xscale = 1,
                           conf.int = FALSE, conf.int.fill = "gray", conf.int.style = "ribbon",
                           conf.int.alpha = 0.3,
@@ -202,8 +207,21 @@ ggsurvplot_df <- function(fit, fun = NULL,
   #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   df[, .strata.var] <- factor( df[, .strata.var], levels = .levels(.strata), labels = legend.labs)
 
+  surv.layer <- ggpubr::geom_exec(surv.geom, data = df, linewidth = size, color = color, linetype = linetype, ...)
+  # ggpubr::geom_exec() does not forward `linejoin` to the step geom, so set it
+  # directly on the built layer. The default "round" reproduces geom_step()'s own
+  # default, so the curve is byte-identical unless the user opts into another join
+  # such as "mitre", which marks event-time corners precisely (#653). Guarded so
+  # the default path never touches the layer, and so a custom surv.geom without a
+  # linejoin parameter is left untouched.
+  if (!identical(linejoin, "round") &&
+      !is.null(surv.layer$geom_params) &&
+      "linejoin" %in% names(surv.layer$geom_params)) {
+    surv.layer$geom_params$linejoin <- linejoin
+  }
+
   p <- ggplot2::ggplot(df, ggplot2::aes(x = !!sym("time"), y = !!sym("surv"))) +
-    ggpubr::geom_exec(surv.geom, data = df, linewidth = size, color = color, linetype = linetype, ...) +
+    surv.layer +
     ggplot2::scale_y_continuous(breaks = y.breaks, labels = scale_labels, limits = ylim, expand = .expand) +
     ggplot2::coord_cartesian(xlim = xlim)+
     ggtheme

--- a/man/ggsurvplot_df.Rd
+++ b/man/ggsurvplot_df.Rd
@@ -15,6 +15,7 @@ ggsurvplot_df(
   break.y.by = NULL,
   surv.scale = c("default", "percent"),
   surv.geom = geom_step,
+  linejoin = "round",
   xscale = 1,
   conf.int = FALSE,
   conf.int.fill = "gray",
@@ -84,6 +85,11 @@ is NULL.}
 
 \item{surv.geom}{survival curve style. Is the survival curve entered a step
 function (\link[ggplot2]{geom_step}) or a smooth function (\link[ggplot2]{geom_line}).}
+
+\item{linejoin}{line join style for the survival curve, passed to the survival
+geom. Default is \code{"round"} (unchanged). Use \code{"mitre"} for sharp,
+precisely-marked corners at event times (requires a \pkg{ggplot2} version that
+passes \code{linejoin} through \code{\link[ggplot2]{geom_step}}).}
 
 \item{xscale}{numeric or character value specifying x-axis scale. \itemize{
 \item If numeric, the value is used to divide the labels on the x axis. For

--- a/tests/testthat/test-ggsurvplot-linejoin.R
+++ b/tests/testthat/test-ggsurvplot-linejoin.R
@@ -1,0 +1,28 @@
+context("ggsurvplot linejoin argument")
+
+# Feature test for #653: ggsurvplot() gains a `linejoin` argument passed to the
+# survival geom. Default "round" reproduces geom_step()'s own default (curve
+# unchanged); "mitre" gives sharp corners at event times.
+library(survival)
+
+fit <- survfit(Surv(time, status) ~ sex, data = lung)
+
+.surv_linejoin <- function(p) p$plot$layers[[1]]$geom_params$linejoin
+
+test_that("default linejoin is 'round' and unchanged (#653)", {
+  p <- ggsurvplot(fit, data = lung)
+  expect_identical(.surv_linejoin(p), "round")
+  expect_error(ggplot2::ggplotGrob(p$plot), NA)
+})
+
+test_that("linejoin = 'mitre' is applied to the survival curve (#653)", {
+  p <- ggsurvplot(fit, data = lung, linejoin = "mitre")
+  expect_identical(.surv_linejoin(p), "mitre")
+  expect_error(ggplot2::ggplotGrob(p$plot), NA)
+})
+
+test_that("linejoin also works with a smooth (geom_line) survival curve (#653)", {
+  p <- ggsurvplot(fit, data = lung, surv.geom = ggplot2::geom_line, linejoin = "mitre")
+  expect_identical(.surv_linejoin(p), "mitre")
+  expect_error(ggplot2::ggplotGrob(p$plot), NA)
+})


### PR DESCRIPTION
## Request

The survival curve is drawn with `geom_step()`'s default `linejoin = "round"`, which rounds the corners at event times. #653 asks for `"mitre"` so event-time corners are marked precisely. A `linejoin` passed through `...` was silently dropped by `ggpubr::geom_exec()`.

## Change (maintainer-approved: add argument, keep default)

`ggsurvplot_df()` gains a `linejoin` argument (default `"round"`, unchanged). Because `geom_exec()` does not forward `linejoin`, it is set directly on the built survival layer, and only when it differs from the default:

```r
surv.layer <- ggpubr::geom_exec(surv.geom, data = df, linewidth = size, color = color, linetype = linetype, ...)
if (!identical(linejoin, "round") &&
    !is.null(surv.layer$geom_params) &&
    "linejoin" %in% names(surv.layer$geom_params)) {
  surv.layer$geom_params$linejoin <- linejoin
}
```

Usage: `ggsurvplot(fit, linejoin = "mitre")` (needs a `ggplot2` version that passes `linejoin` through `geom_step()`).

## No-regression

- Default `"round"` never touches the layer (the guard short-circuits), so existing plots are **byte-identical** — verified by two reviewers comparing `ggplot_build()` output against master (identical, incl. conf.int/censor/palette/facets).
- The new formal is inserted between named-only call sites (`ggsurvplot_core`/`ggsurvplot_combine` pass everything by name), so no positional shift.
- New `test-ggsurvplot-linejoin.R`; `man/ggsurvplot_df.Rd` updated (checkRd clean). Full suite green.
- Two independent adversarial reviewers signed off.

Fixes #653