### PR TITLE
Reserve space for ggforest() global-stats caption in short plots (#696)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 ## Bug fixes
 
+- Fix `ggforest()` clipping the bottom global-statistics caption (number of events, global p-value, AIC, concordance index) in short plots (small figure heights): too little space was reserved below the last row. Space is now reserved so the caption always renders; it is only added when the caption is drawn, so `global.stats = FALSE` is unchanged (#696).
+
 - Fix `ggforest()` reporting a sample size that includes subjects with missing values: `coxph()` drops rows with a missing value in any model variable (`na.action = na.omit`), but `ggforest()` counted all rows of `data`, overstating the per-term/level `N`. The reported `N` now reflects the complete cases the model actually used (`model$n`). Models fit on data without missing values are unaffected (#597).
 
 - Fix `ggsurvplot(fit, facet.by = "X")` erroring with "subscript out of bounds" when every variable of the survival formula is also a `facet.by` variable, e.g. a null model `Surv(...) ~ 1` faceted by `X`, or `Surv(...) ~ X` faceted by `X`. Each panel then shows a single curve with no within-panel grouping, so there is no extra strata to build; this case no longer calls the strata builder with zero variables (#304).

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -225,7 +225,15 @@ ggforest <- function(model, data = NULL,
       label = paste0("# Events: ", gmodel$nevent, "; Global p-value (Log-Rank): ",
         format.pval(gmodel$p.value.log, eps = ".001"), " \nAIC: ", round(gmodel$AIC,2),
         "; Concordance Index: ", round(gmodel$concordance,2)),
-      size = annot_size_mm, hjust = 0, vjust = 1.2,  fontface = "italic")
+      size = annot_size_mm, hjust = 0, vjust = 1.2,  fontface = "italic") +
+    # The caption sits just below the first row (x = 0.5) and, in short plots, the
+    # default axis expansion leaves too little room so the two-line caption is cut
+    # off (#696). Reserve about one row-height of space below the last row (and a
+    # little extra bottom margin) so the caption always fits, whatever the plot
+    # height. Only applied when the caption is drawn, so global.stats = FALSE is
+    # unchanged.
+    scale_x_continuous(expand = expansion(mult = c(0.05, 0.05), add = c(1, 0))) +
+    theme(plot.margin = grid::unit(c(0.5, 0.5, 1, 0.5), "lines"))
   # switch off clipping for p-vals, bottom annotation:
   gt <- ggplot_gtable(ggplot_build(p))
   gt$layout$clip[gt$layout$name == "panel"] <- "off"

--- a/tests/testthat/test-ggforest-caption-clip.R
+++ b/tests/testthat/test-ggforest-caption-clip.R
@@ -1,0 +1,41 @@
+context("ggforest global-stats caption not clipped")
+
+# Regression test for #696: the global-statistics caption (# events, global
+# p-value, AIC, concordance) drawn at the bottom of ggforest() was cut off in
+# short plots. Space is now reserved below the last row (only when the caption is
+# drawn), so it renders. Hard to assert "not clipped" from grobs, so we lock in
+# that (a) short/tall plots render without error, (b) the caption is present when
+# global.stats = TRUE and absent when FALSE.
+library(survival)
+
+.ggforest_labels <- function(p) {
+  g <- grid::grid.force(ggplot2::ggplotGrob(p))
+  out <- character(0)
+  walk <- function(gr) {
+    if (!is.null(gr$children)) for (ch in gr$children) walk(ch)
+    if (!is.null(gr$label)) out[[length(out) + 1]] <<- paste(gr$label, collapse = "|")
+  }
+  walk(g)
+  unlist(out)
+}
+
+test_that("short ggforest renders and shows the global-stats caption (#696)", {
+  m <- coxph(Surv(time, status) ~ sex, data = lung)     # 1 variable -> short plot
+  p <- ggforest(m, data = lung)
+  expect_error(ggplot2::ggplotGrob(p), NA)
+  expect_true(any(grepl("# Events", .ggforest_labels(p))))
+})
+
+test_that("tall ggforest still renders with the caption (#696)", {
+  m <- coxph(Surv(time, status) ~ sex + ph.ecog + age + wt.loss, data = lung)
+  p <- ggforest(m, data = lung)
+  expect_error(ggplot2::ggplotGrob(p), NA)
+  expect_true(any(grepl("# Events", .ggforest_labels(p))))
+})
+
+test_that("no-regression: global.stats = FALSE draws no caption (#696)", {
+  m <- coxph(Surv(time, status) ~ sex, data = lung)
+  p <- ggforest(m, data = lung, global.stats = FALSE)
+  expect_error(ggplot2::ggplotGrob(p), NA)
+  expect_false(any(grepl("# Events", .ggforest_labels(p))))
+})


### PR DESCRIPTION
## Problem

The bottom global-statistics caption (# events, global p-value, AIC, concordance index) is clipped in short `ggforest()` plots (small figure heights, e.g. a univariable model rendered 3-8 inches tall). It renders fine only in tall plots.

## Fix (maintainer-approved)

The caption is drawn (via `annotate()`) only when `global.stats = TRUE`. Inside that same branch, reserve about one row-height of space below the last row:

```r
scale_x_continuous(expand = expansion(mult = c(0.05, 0.05), add = c(1, 0))) +
theme(plot.margin = grid::unit(c(0.5, 0.5, 1, 0.5), "lines"))
```

(`x` is the row index; under `coord_flip` the lower-x expansion is the bottom, where the caption sits. The `mult = 0.05` matches the previous default, so the top spacing is unchanged.)

## No-regression

- The additions are inside `if (global.stats)`, so `global.stats = FALSE` is **byte-identical** (verified by reviewers: same md5).
- Tall/multivariable plots: rows, HR points/error bars, stripes, and axes unchanged — only a row-height of space added at the bottom.
- No "Scale for x is already present" warning (the prior scale was implicit).
- `R CMD check` clean; the #597 complete-case N fix is undisturbed.
- New `test-ggforest-caption-clip.R`. Full suite green.
- Two independent adversarial reviewers signed off (one ran `R CMD check`: 0 errors/0 warnings).

Fixes #696