### PR TITLE
Warn when ggadjustedcurves() conditional method gets a variable not in the model (#623)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 ## Bug fixes
 
+- `ggadjustedcurves()`/`surv_adjustedcurves()` now warn when the default `method = "conditional"` is used with a grouping `variable` that is not in the Cox model: in that case every group's curve is identical (a single visible line), which silently confused users. The warning points to `method = "average"`/`"marginal"` (which are designed for a variable absent from the model). The computed curves are unchanged (message only), and no warning fires for the other methods or when the variable is in the model (#623).
+
 - Fix `ggforest()` clipping the bottom global-statistics caption (number of events, global p-value, AIC, concordance index) in short plots (small figure heights): too little space was reserved below the last row. Space is now reserved so the caption always renders; it is only added when the caption is drawn, so `global.stats = FALSE` is unchanged (#696).
 
 - Fix `ggforest()` reporting a sample size that includes subjects with missing values: `coxph()` drops rows with a missing value in any model variable (`na.action = na.omit`), but `ggforest()` counted all rows of `data`, overstating the per-term/level `N`. The reported `N` now reflects the complete cases the model actually used (`model$n`). Models fit on data without missing values are unaffected (#597).

--- a/R/ggadjustedcurves.R
+++ b/R/ggadjustedcurves.R
@@ -172,6 +172,24 @@ surv_adjustedcurves <- function(fit,
     }
   }
 
+  # With the default method = "conditional", the curves are built from the
+  # fitted model's predictions. If the grouping `variable` is NOT in the Cox
+  # model it never enters the linear predictor, so every group gets an identical
+  # curve (a single visible line) with no error -- a common source of confusion
+  # (#623). Warn and point to method = "average"/"marginal", which are the
+  # methods meant for a grouping variable absent from the model. Message-only:
+  # the returned curves are unchanged. Not triggered for "average"/"marginal"/
+  # "single", nor when the variable is in the model (incl. via a transform such
+  # as strata()/ns(), which all.vars() still resolves to the underlying name).
+  if (method == "conditional" && !is.null(variable) &&
+      !(variable %in% all.vars(stats::formula(fit))))
+    warning("method = \"conditional\" (the default) builds each group's curve ",
+            "from the Cox model, but the grouping variable '", variable,
+            "' is not in the model, so the curves for all groups are identical. ",
+            "Use method = \"average\" or \"marginal\" to draw distinct curves for ",
+            "a variable that is not in the model, or add '", variable,
+            "' to the Cox model.", call. = FALSE)
+
   curve <- switch(method,
                   single = ggadjustedcurves.single(data, fit, size = size),
                   average =  ggadjustedcurves.average(data, fit, variable, size = size),

--- a/README.Rmd
+++ b/README.Rmd
@@ -80,7 +80,7 @@ The main functions, in the package, are organized in different categories as fol
 
 - **ggforest**(): Draws forest plot for CoxPH model.
    
-- **ggcoxadjustedcurves**(): Plots adjusted survival curves for coxph model.
+- **ggadjustedcurves**(): Plots adjusted survival curves for coxph model.
    
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ categories as follow.
 
 -   **ggforest**(): Draws forest plot for CoxPH model.
 
--   **ggcoxadjustedcurves**(): Plots adjusted survival curves for coxph
+-   **ggadjustedcurves**(): Plots adjusted survival curves for coxph
     model.
 
 <br/>

--- a/tests/testthat/test-ggadjustedcurves-conditional-warn.R
+++ b/tests/testthat/test-ggadjustedcurves-conditional-warn.R
@@ -1,0 +1,52 @@
+context("ggadjustedcurves conditional-method warning")
+
+# #623: with the default method = "conditional", if the grouping variable is not
+# in the Cox model the per-group curves come out identical (one visible line)
+# with no error. surv_adjustedcurves()/ggadjustedcurves() now warn in exactly
+# that case and point to method = "average"/"marginal". Message-only: the
+# returned curves are unchanged, and no warning fires for the other methods or
+# when the variable is in the model.
+library(survival)
+
+lung2 <- lung
+lung2$age3 <- cut(lung2$age, c(35, 55, 65, 85))
+lung2 <- lung2[!is.na(lung2$age3), ]
+
+fit_out <- coxph(Surv(time, status) ~ sex + ph.ecog + age, data = lung2)  # age3 NOT in model
+fit_in  <- coxph(Surv(time, status) ~ sex + age3, data = lung2)           # age3 IN model
+
+.warns_conditional <- function(expr) {
+  hit <- FALSE
+  withCallingHandlers(
+    expr,
+    warning = function(w) {
+      if (grepl("conditional", conditionMessage(w))) hit <<- TRUE
+      invokeRestart("muffleWarning")
+    }
+  )
+  hit
+}
+
+test_that("warns for conditional method when variable is not in the model (#623)", {
+  expect_true(.warns_conditional(
+    surv_adjustedcurves(fit_out, data = lung2, variable = "age3", method = "conditional")))
+  # default method is "conditional", so it warns too
+  expect_true(.warns_conditional(
+    surv_adjustedcurves(fit_out, data = lung2, variable = "age3")))
+})
+
+test_that("no warning when the variable IS in the model, or for average/marginal (#623)", {
+  expect_false(.warns_conditional(
+    surv_adjustedcurves(fit_in, data = lung2, variable = "age3", method = "conditional")))
+  expect_false(.warns_conditional(
+    surv_adjustedcurves(fit_out, data = lung2, variable = "age3", method = "average")))
+  expect_false(.warns_conditional(
+    surv_adjustedcurves(fit_out, data = lung2, variable = "age3", method = "marginal")))
+})
+
+test_that("no-regression: the returned curves are unchanged (message-only) (#623)", {
+  a <- suppressWarnings(surv_adjustedcurves(fit_out, data = lung2, variable = "age3", method = "conditional"))
+  b <- suppressWarnings(surv_adjustedcurves(fit_out, data = lung2, variable = "age3", method = "conditional"))
+  expect_identical(a, b)
+  expect_true(all(c("time", "surv", "variable") %in% names(a)))
+})


### PR DESCRIPTION
## Problem

With the default `method = "conditional"`, `ggadjustedcurves()` builds each group's curve from the fitted Cox model. If the grouping `variable` is **not in the model**, it never enters the linear predictor, so every group's curve is **identical** (one visible line) — with no error. This silently confuses users (the cheatsheet's "not necessary to include the grouping factor" refers to the *marginal* methods).

## Change (maintainer-approved behaviour change; message-only)

`surv_adjustedcurves()` now warns in exactly that case:

```r
if (method == "conditional" && !is.null(variable) &&
    !(variable %in% all.vars(stats::formula(fit))))
  warning("method = 'conditional' ... grouping variable '", variable,
          "' is not in the model, so the curves for all groups are identical. ",
          "Use method = 'average' or 'marginal' ...", call. = FALSE)
```

The warning is **message-only** — the computed curves are unchanged.

## No-regression

- Fires only for `conditional` (incl. the default) + variable-not-in-model. Silent for `average`/`marginal`/`single`, and when the variable is in the model — verified across `factor()`, `strata()`, `ns()`, `bs()`, `poly()`, `I()`, `log()`, interactions, `pspline()`, `frailty()`, backtick names (no false positives).
- `stats::formula(fit)` reconstructs the formula from the model terms, so it is robust to symbol-stored / scoped fits (the #436/#533 cluster) — no new error path.
- Returned curves byte-identical (message-only); full suite green; new `test-ggadjustedcurves-conditional-warn.R`.
- Also fixes a stale README reference to the removed `ggcoxadjustedcurves()` → `ggadjustedcurves()`.
- Two independent adversarial reviewers signed off.

Fixes #623