### PR TITLE
Render negative survival times like base R (no forced x-origin at 0) (#389)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 ## Bug fixes
 
+- Fix `ggsurvplot()` mis-rendering negative survival times: the x-axis was clipped at 0 (hiding the negative-time region) and a spurious vertical drop was drawn at `x = 0`. The plot now behaves like base `plot.survfit()` — the panel spans the true time range and each curve starts at survival = 1 from its first observed time, with no injected `(0, 1)` point. For all non-negative data (the common case) the output is byte-identical (the x-origin still resolves to exactly 0). The `#523` warning that negative survival times are likely invalid is retained (#389).
+
 - `ggadjustedcurves()`/`surv_adjustedcurves()` now warn when the default `method = "conditional"` is used with a grouping `variable` that is not in the Cox model: in that case every group's curve is identical (a single visible line), which silently confused users. The warning points to `method = "average"`/`"marginal"` (which are designed for a variable absent from the model). The computed curves are unchanged (message only), and no warning fires for the other methods or when the variable is in the model (#623).
 
 - Fix `ggforest()` clipping the bottom global-statistics caption (number of events, global p-value, AIC, concordance index) in short plots (small figure heights): too little space was reserved below the last row. Space is now reserved so the caption always renders; it is only added when the caption is drawn, so `global.stats = FALSE` is unchanged (#696).

--- a/R/ggsurvplot_core.R
+++ b/R/ggsurvplot_core.R
@@ -83,7 +83,7 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
   if(!is.null(fit$start.time)) d <- subset(d, d$time >= fit$start.time )
 
   # Axis limits
-   xmin <- ifelse(.is_cloglog(fun), min(c(1, d$time)), 0)
+   xmin <- ifelse(.is_cloglog(fun), min(c(1, d$time)), min(c(0, d$time), na.rm = TRUE))
    if(!is.null(fit$start.time)) xmin <- fit$start.time
    # Extend the upper x-limit to cover the largest event/censoring time, not
    # just the largest "nice" axis break. scales::extended_breaks() can return a

--- a/R/ggsurvplot_df.R
+++ b/R/ggsurvplot_df.R
@@ -195,7 +195,7 @@ ggsurvplot_df <- function(fit, fun = NULL,
                     by = break.y.by)
   }
   # Axis limits
-  xmin <- ifelse(.is_cloglog(fun), min(c(1, df$time)), 0)
+  xmin <- ifelse(.is_cloglog(fun), min(c(1, df$time)), min(c(0, df$time), na.rm = TRUE))
   if(is.null(xlim)) xlim <- c(xmin, max(df$time))
   if(is.null(ylim) & is.null(fun)) ylim <- c(0, 1)
 
@@ -358,8 +358,13 @@ ggsurvplot_df <- function(fit, fun = NULL,
   n.risk <- strata <- NULL
   # if("n.risk" %in% colnames(d)){d <- dplyr::arrange(d, dplyr::desc(n.risk))}
   origin <- d %>% dplyr::distinct(strata, .keep_all = TRUE)
-  origin[intersect(c('time', 'n.censor', 'std.err', "n.event"), colnames(origin))] <- 0
+  origin[intersect(c('n.censor', 'std.err', "n.event"), colnames(origin))] <- 0
   origin[c('surv', 'upper', 'lower')] <- 1.0
+  # Origin x-position: 0 for ordinary data (byte-identical), or the smallest
+  # observed time when negative, so each curve starts at the first time like
+  # base plot.survfit() instead of injecting a spurious (0, 1) point that would
+  # sort into the middle of negative-time data (#389).
+  origin['time'] <- min(c(0, d$time), na.rm = TRUE)
   dplyr::bind_rows(origin, d)
 }
 

--- a/R/ggsurvtable.R
+++ b/R/ggsurvtable.R
@@ -107,7 +107,7 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
 
   # Define time axis breaks
   #:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-  xmin <- ifelse(xlog, min(c(1, fit$time)), 0)
+  xmin <- ifelse(xlog, min(c(1, fit$time)), min(c(0, fit$time), na.rm = TRUE))
   if(is.null(xlim)) xlim <- c(xmin, max(fit$time))
   times <- .get_default_breaks(fit$time, .log = xlog)
   if(!is.null(break.time.by) &!xlog) times <- seq(0, max(c(fit$time, xlim)), by = break.time.by)

--- a/tests/testthat/test-ggsurvplot-negative-times-render.R
+++ b/tests/testthat/test-ggsurvplot-negative-times-render.R
@@ -1,0 +1,97 @@
+context("ggsurvplot negative survival times rendering")
+
+# Regression tests for #389: with negative survival times, ggsurvplot() used to
+# clip the x-axis at 0 (hiding the negative-time region) and inject a spurious
+# (0, 1) origin point that sorted into the middle of the curve. It now behaves
+# like base plot.survfit(): the panel spans the true time range and each curve
+# starts at S = 1 from its first observed time. The #523 negative-time warning is
+# retained (these tests suppress it). For all non-negative data the output is
+# byte-identical (see the explicit no-regression tests at the bottom).
+library(survival)
+
+neg_df <- data.frame(
+  time   = c(-10, -6, -3, 2, 5, 8, 12, 15),
+  status = c(1, 1, 1, 0, 1, 1, 0, 1),
+  grp    = rep(c("a", "b"), each = 4)
+)
+
+test_that("negative single-stratum: panel spans the true range, curve starts at first time (#389)", {
+  fit <- survfit(Surv(time, status) ~ 1, data = neg_df)
+  p <- suppressWarnings(ggsurvplot(fit, data = neg_df))
+  b <- ggplot2::ggplot_build(p$plot)
+
+  # panel left edge reaches at least the smallest observed time (not clipped at 0)
+  expect_lte(b$layout$panel_params[[1]]$x.range[1], min(neg_df$time))
+
+  ld <- b$data[[1]]
+  # the connected curve now begins at the smallest observed time...
+  expect_equal(min(ld$x, na.rm = TRUE), min(c(0, neg_df$time)))
+  # ...at survival = 1 (the origin sits at the true left edge, not at x = 0)
+  first <- ld[order(ld$x), ][1, ]
+  expect_equal(first$x, min(neg_df$time))
+  expect_equal(first$y, 1)
+  # no spurious back-jump to x = 0 injected into the middle of the curve
+  expect_false(any(ld$x == 0 & ld$y == 1))
+})
+
+test_that("negative multi-strata: every stratum starts at the shared global origin (#389)", {
+  fit <- survfit(Surv(time, status) ~ grp, data = neg_df)
+  p <- suppressWarnings(ggsurvplot(fit, data = neg_df))
+  b <- ggplot2::ggplot_build(p$plot)
+  origin <- min(c(0, neg_df$time))
+  per_group_min <- tapply(b$data[[1]]$x, b$data[[1]]$group, min, na.rm = TRUE)
+  expect_true(all(per_group_min == origin))
+})
+
+test_that("all-negative times: builds with a panel entirely below zero (#389)", {
+  df <- data.frame(time = c(-10, -8, -6, -4, -2), status = c(1, 1, 0, 1, 1))
+  fit <- survfit(Surv(time, status) ~ 1, data = df)
+  p <- suppressWarnings(ggsurvplot(fit, data = df))
+  b <- ggplot2::ggplot_build(p$plot)
+  expect_s3_class(p, "ggsurvplot")
+  expect_true(max(b$data[[1]]$x, na.rm = TRUE) < 0)
+  expect_true(b$layout$panel_params[[1]]$x.range[2] < 0)
+})
+
+test_that("conf.int ribbon begins at the origin with no gap in the negative region (#389)", {
+  fit <- survfit(Surv(time, status) ~ grp, data = neg_df)
+  p <- suppressWarnings(ggsurvplot(fit, data = neg_df, conf.int = TRUE))
+  b <- ggplot2::ggplot_build(p$plot)
+  rib <- b$data[[which(sapply(b$data, function(L) all(c("ymin", "ymax") %in% names(L))))[1]]]
+  origin <- min(c(0, neg_df$time))
+  # ribbon starts at the origin, at upper = lower = 1, for every group
+  by_g <- split(rib, rib$group)
+  for (g in by_g) {
+    gg <- g[order(g$x), ]
+    expect_equal(gg$x[1], origin)
+    expect_equal(gg$ymin[1], 1)
+    expect_equal(gg$ymax[1], 1)
+  }
+  # no NA gap anywhere in the negative-time region
+  neg_region <- rib[rib$x < 0, ]
+  expect_false(any(is.na(neg_region$ymin) | is.na(neg_region$ymax)))
+})
+
+test_that("risk.table x-range is aligned with the curve panel for negative times (#389)", {
+  fit <- survfit(Surv(time, status) ~ 1, data = neg_df)
+  p <- suppressWarnings(ggsurvplot(fit, data = neg_df, risk.table = TRUE))
+  curve_range <- ggplot2::ggplot_build(p$plot)$layout$panel_params[[1]]$x.range
+  table_range <- ggplot2::ggplot_build(p$table)$layout$panel_params[[1]]$x.range
+  expect_equal(curve_range, table_range)
+})
+
+# ---------------------------------------------------------------------------
+# No-regression: non-negative data must be unchanged (origin exactly 0).
+# ---------------------------------------------------------------------------
+
+test_that("no-regression: non-negative data keeps the x-origin at exactly 0 (#389)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  b <- ggplot2::ggplot_build(ggsurvplot(fit, data = lung)$plot)
+  # every stratum still starts at x = 0 with survival = 1 (min(c(0, time)) == 0
+  # for non-negative data, so the injected origin is unchanged)
+  first_x <- tapply(b$data[[1]]$x, b$data[[1]]$group, min, na.rm = TRUE)
+  expect_true(all(first_x == 0))
+  first_rows <- do.call(rbind, lapply(split(b$data[[1]], b$data[[1]]$group),
+                                      function(g) g[which.min(g$x), ]))
+  expect_true(all(first_rows$y == 1))
+})


### PR DESCRIPTION
## Summary

Fixes #389. When survival data contain negative times, `ggsurvplot()` clipped the x-axis at 0 (hiding the negative-time region) and drew a spurious vertical drop at `x = 0`, because the curve origin was always injected at `(0, 1)` and sorted into the middle of the data. Base R `plot.survfit()` instead spans the true time range and starts each curve at S = 1 from its first observed time.

## Change

Replace the hardcoded x-origin `0` with `min(c(0, <time>), na.rm = TRUE)` at the three `xmin` sites (`ggsurvplot_core`, `ggsurvplot_df`, `ggsurvtable`) and in `.connect2origin()`.

- **Non-negative data (the common case):** `min(c(0, positives)) == 0`, so `xmin`, `xlim`, and the injected origin are unchanged — output is byte-identical.
- **Negative data:** the origin extends down to the smallest observed time; each curve starts at `(min_time, 1)` like base R, with no injected `(0, 1)` point and no clipping.

The `#523` warning that negative survival times are likely invalid is retained.

## Verification

- Clean-session `devtools::test()` green before and after (FAIL 0 | PASS 275).
- New regression tests in `tests/testthat/test-ggsurvplot-negative-times-render.R` (negative single/multi-strata, all-negative, conf.int ribbon, risk-table alignment, non-negative no-regression).
- Byte-identity for non-negative data proven via before/after `ggplot_build` comparison (`all.equal == TRUE`).
- Two independent adversarial reviewers signed off on the exact diff.

### Before/after (mixed negative times) vs base R

survminer now matches base `plot.survfit()`: the panel spans `[-10, 15]`, each curve starts at S = 1 from its first observed time, and the risk table is aligned — no spurious drop at `x = 0`.
