### PR TITLE
Label ggforest() global p-value as likelihood ratio test, not log-rank (#640)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 ## Bug fixes
 
+- Fix `ggforest()` mislabeling the global p-value in the bottom caption as "Log-Rank": the value shown (`broom::glance()$p.value.log`) is the p-value of the *likelihood ratio test* (`survival` stores it in `logtest`), not the score/log-rank test (`p.value.sc`/`sctest`). The caption now reads "Global p-value (Likelihood ratio test)". The value itself is unchanged — only the label is corrected (#640).
+
 - Fix `ggsurvplot()` mis-rendering negative survival times: the x-axis was clipped at 0 (hiding the negative-time region) and a spurious vertical drop was drawn at `x = 0`. The plot now behaves like base `plot.survfit()` — the panel spans the true time range and each curve starts at survival = 1 from its first observed time, with no injected `(0, 1)` point. For all non-negative data (the common case) the output is byte-identical (the x-origin still resolves to exactly 0). The `#523` warning that negative survival times are likely invalid is retained (#389).
 
 - `ggadjustedcurves()`/`surv_adjustedcurves()` now warn when the default `method = "conditional"` is used with a grouping `variable` that is not in the Cox model: in that case every group's curve is identical (a single visible line), which silently confused users. The warning points to `method = "average"`/`"marginal"` (which are designed for a variable absent from the model). The computed curves are unchanged (message only), and no warning fires for the other methods or when the variable is in the model (#623).

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -10,9 +10,9 @@
 #' @param refLabel label for reference levels of factor variables.
 #' @param noDigits number of digits for estimates and p-values in the plot.
 #' @param global.stats logical value. Default is TRUE. If FALSE, the bottom
-#'   caption reporting the global statistics (number of events, global log-rank
-#'   p-value, AIC and concordance index) is omitted. Useful when arranging
-#'   several forest plots in a panel.
+#'   caption reporting the global statistics (number of events, global
+#'   likelihood-ratio-test p-value, AIC and concordance index) is omitted. Useful
+#'   when arranging several forest plots in a panel.
 #'
 #' @return returns a ggplot2 object (invisibly)
 #'
@@ -219,10 +219,14 @@ ggforest <- function(model, data = NULL,
       hjust = -0.2,  fontface = "italic")
   # Global statistics caption (# events, global p-value, AIC, concordance).
   # Optional: set global.stats = FALSE to omit it (e.g. panels of forest plots).
+  # `broom::glance()$p.value.log` is the p-value of the *likelihood ratio test*
+  # (survival stores it in `logtest`); the score/log-rank test is `p.value.sc`
+  # (`sctest`). The caption previously mislabeled this value as "Log-Rank"; it now
+  # names the test correctly. The value shown is unchanged (#640).
   if (global.stats)
     p <- p +
     annotate(geom = "text", x = 0.5, y = exp(y_variable),
-      label = paste0("# Events: ", gmodel$nevent, "; Global p-value (Log-Rank): ",
+      label = paste0("# Events: ", gmodel$nevent, "; Global p-value (Likelihood ratio test): ",
         format.pval(gmodel$p.value.log, eps = ".001"), " \nAIC: ", round(gmodel$AIC,2),
         "; Concordance Index: ", round(gmodel$concordance,2)),
       size = annot_size_mm, hjust = 0, vjust = 1.2,  fontface = "italic") +

--- a/man/ggforest.Rd
+++ b/man/ggforest.Rd
@@ -32,9 +32,9 @@ will be extracted from 'fit' object.}
 \item{noDigits}{number of digits for estimates and p-values in the plot.}
 
 \item{global.stats}{logical value. Default is TRUE. If FALSE, the bottom caption
-reporting the global statistics (number of events, global log-rank p-value, AIC
-and concordance index) is omitted. Useful when arranging several forest plots in
-a panel.}
+reporting the global statistics (number of events, global likelihood-ratio-test
+p-value, AIC and concordance index) is omitted. Useful when arranging several
+forest plots in a panel.}
 }
 \value{
 returns a ggplot2 object (invisibly)

--- a/tests/testthat/test-ggforest-lrt-pvalue-label.R
+++ b/tests/testthat/test-ggforest-lrt-pvalue-label.R
@@ -1,0 +1,47 @@
+context("ggforest global p-value label")
+
+# Regression test for #640: ggforest() labeled its global p-value as "Log-Rank",
+# but the value shown (broom::glance()$p.value.log) is the likelihood-ratio test
+# p-value (survival stores it in `logtest`); the score/log-rank test is
+# `p.value.sc` (`sctest`). The caption now names the test correctly and the value
+# it reports is unchanged.
+library(survival)
+
+# Collect all text labels drawn in the assembled forest grob (ggforest() returns
+# ggpubr::as_ggplot(gtable); the forest lives in a single GeomCustomAnn layer).
+caption_labels <- function(g) {
+  grob <- g$layers[[1]]$geom_params$grob
+  labels <- character(0)
+  rec <- function(x) {
+    if (!is.null(x$label)) labels <<- c(labels, unlist(x$label))
+    if (!is.null(x$grobs)) lapply(x$grobs, rec)
+    if (!is.null(x$children)) lapply(x$children, rec)
+    invisible(NULL)
+  }
+  rec(grob)
+  labels
+}
+
+test_that("ggforest() labels the global p-value as the likelihood ratio test (#640)", {
+  cm <- coxph(Surv(time, status) ~ age + sex + ph.ecog, data = lung)
+  labs <- caption_labels(ggforest(cm, data = lung))
+  caption <- labs[grepl("Global p-value", labs)]
+  expect_length(caption, 1)
+  expect_match(caption, "Likelihood ratio test", fixed = TRUE)
+  # the old, incorrect "Log-Rank" wording must be gone
+  expect_false(any(grepl("Log-Rank", labs, fixed = TRUE)))
+})
+
+test_that("ggforest() global p-value value equals the likelihood-ratio-test p-value, not the log-rank p-value (#640)", {
+  cm <- coxph(Surv(time, status) ~ age + sex + ph.ecog, data = lung)
+  labs <- caption_labels(ggforest(cm, data = lung))
+  caption <- labs[grepl("Global p-value", labs)]
+
+  # the printed value matches broom's p.value.log == summary()$logtest (LRT),
+  # and is distinguishable from the score/log-rank p-value here
+  g <- broom::glance(cm)
+  s <- summary(cm)
+  expect_equal(unname(g$p.value.log), unname(s$logtest["pvalue"]))
+  shown <- format.pval(g$p.value.log, eps = ".001")
+  expect_match(caption, shown, fixed = TRUE)
+})


### PR DESCRIPTION
## Summary

Fixes #640. `ggforest()` drew a bottom caption reading **"Global p-value (Log-Rank)"** but the value printed there is `broom::glance()$p.value.log`, which is the p-value of the **likelihood ratio test** (`survival` stores the statistic in `logtest`). The score/log-rank test is `p.value.sc` (`sctest`). So the label was wrong.

## Change (relabel only — value unchanged)

- Caption: `"Global p-value (Log-Rank)"` → `"Global p-value (Likelihood ratio test)"` in `R/ggforest.R`.
- Matching wording in the roxygen doc and `man/ggforest.Rd`.
- NEWS entry (#640).

The **reported number is unchanged** — only the label is corrected (renaming, not re-computing, avoids silently altering a value users may have cited). "Likelihood ratio test" matches `survival`'s own `print.coxph` terminology.

## Verification

- Empirically confirmed: `broom::glance(m)$p.value.log == summary(m)$logtest["pvalue"]` (LRT) and `p.value.sc == sctest["pvalue"]` (log-rank), so the old label was genuinely wrong.
- Clean-session `devtools::test()` green (FAIL 0 | PASS 280); new regression tests in `tests/testthat/test-ggforest-lrt-pvalue-label.R` (asserts the new label, the absence of "Log-Rank", and that the shown value equals the LRT p-value).
- Rendered the forest plot at several widths — the longer label fits, no clipping.
- Two independent adversarial reviewers signed off on the exact diff.

```r
library(survival); library(survminer)
m <- coxph(Surv(time, status) ~ age + sex + ph.ecog, data = lung)
ggforest(m, data = lung)
#> caption now reads: "# Events: 164; Global p-value (Likelihood ratio test): 1.0828e-06"
```
