### PR TITLE
Colour risk-table y labels with element_text() on ggplot2 4.x so the table stays customizable (#557)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 ## Bug fixes
 
+- Fix customizing the risk table failing under `ggplot2 >= 4.0` with "Can't merge the `axis.text.y` theme element" (e.g. `p$table + theme(axis.text.y = element_text(...))`, or `ggsave()`ing a customized table). In ggplot2 4.x theme elements are S7 objects and `ggtext::element_markdown()` (used to colour the risk-table y labels per strata) can no longer be merged with a user `element_text()`. On ggplot2 >= 4.0 the per-strata label colours are now applied with `element_text(colour = <vector>)` (native and mergeable); on older ggplot2 `element_markdown()` is kept (it merges fine there). The coloured labels are unchanged (#557).
+
 - Fix a factor **level** with a genuine trailing or leading space (e.g. `"Obs, "`) being parsed as `NA` in the grouping/facet columns. `survfit` right-pads level names in strata labels, so survminer must trim them; the trimmed value is now matched against the (also trimmed) factor levels while keeping the original levels, so such labels are recovered instead of dropped. Completes the strata special-character fixes (#616).
 
 - Fix `ggsurvplot(..., risk.table = TRUE)` erroring with "gridtext has encountered a tag that isn't supported yet: &lt;blockquote&gt;" when a strata label / `legend.labs` entry contains `<`, `>` or `&` (e.g. `"> 1 Risk factor"`). The risk-table y-axis labels are drawn with `ggtext::element_markdown()` (to colour them per strata), which parsed those characters as HTML tags; they are now HTML-escaped so they render literally. Ordinary labels are unchanged, and the plain-text path (`risk.table.y.text.col = FALSE`) is untouched (#532).

--- a/R/ggsurvtable.R
+++ b/R/ggsurvtable.R
@@ -248,11 +248,13 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
   yticklabs <- rev(levels(survsummary$strata))
   n_strata <- length(levels(survsummary$strata))
   if(!y.text) yticklabs <- rep("\\-", n_strata)
-  else if((is.logical(y.text.col) && isTRUE(y.text.col[1])) || is.character(y.text.col))
-    # These labels are rendered with ggtext::element_markdown() below (coloured
-    # per strata), so HTML-escape <, >, & to render them literally instead of as
-    # markdown/HTML tags (#532). No-op for ordinary labels; when y.text.col is
-    # FALSE the labels use plain element_text and are left untouched.
+  else if(!.ggplot2_ge_4() && ((is.logical(y.text.col) && isTRUE(y.text.col[1])) || is.character(y.text.col)))
+    # On ggplot2 < 4.0 these labels are rendered with ggtext::element_markdown()
+    # below (coloured per strata), so HTML-escape <, >, & to render them literally
+    # instead of as markdown/HTML tags (#532). No-op for ordinary labels; when
+    # y.text.col is FALSE the labels use plain element_text and are left untouched.
+    # On ggplot2 >= 4.0 we use element_text() (see below), which shows the label
+    # literally, so no escaping is needed (and would show "&gt;").
     yticklabs <- .escape_markdown(yticklabs)
 
   time <- strata <- label <- n.event <- cum.n.event  <- cum.n.censor<- NULL
@@ -322,13 +324,19 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
     p <- .set_large_dash_as_ytext(p)
   }
 
-  # Color table tick labels by strata
-  if(is.logical(y.text.col) & y.text.col[1] == TRUE){
-    cols <- .extract_ggplot_colors(p, grp.levels = legend.labs)
-    p <- p + theme(axis.text.y = ggtext::element_markdown(colour = rev(cols)))
+  # Color table tick labels by strata. On ggplot2 >= 4.0 use element_text() with a
+  # per-label colour vector (native, and mergeable with a user-supplied
+  # element_text() -- ggtext's element_markdown() is not, which broke risk-table
+  # customization under ggplot2 4.x, #557). On ggplot2 < 4.0, where element_text()
+  # does not accept a colour vector, keep element_markdown() (it merges fine there).
+  if((is.logical(y.text.col) & y.text.col[1] == TRUE) || is.character(y.text.col)){
+    ytext.cols <- if(is.character(y.text.col)) y.text.col
+                  else .extract_ggplot_colors(p, grp.levels = legend.labs)
+    # When y.text = FALSE the labels are an element_markdown() large dash (set
+    # above), so the colour must also be element_markdown() to merge; otherwise use
+    # element_text() on ggplot2 >= 4.0 for user-override compatibility (#557).
+    p <- .set_ytext_colour(p, rev(ytext.cols), markdown = !.ggplot2_ge_4() || !y.text)
   }
-  else if(is.character(y.text.col))
-    p <- p + theme(axis.text.y = ggtext::element_markdown(colour = rev(y.text.col)))
 
   p
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -20,6 +20,16 @@ is_pkg_version_sup<- function(pkg, version){
   cc
 }
 
+# TRUE for ggplot2 >= 4.0.0. In 4.x theme elements are S7 objects, and ggtext's
+# element_markdown() (still an old-style S3 element) can no longer be merged with
+# a user-supplied element_text() ("Can't merge the `axis.text.y` theme element",
+# #557). ggplot2 4.x does support a per-label colour vector in element_text(), so
+# on 4.x we colour risk-table y labels with element_text() instead of
+# element_markdown(); < 4.0 keeps element_markdown() (which merges fine there).
+.ggplot2_ge_4 <- function(){
+  utils::compareVersion(as.character(utils::packageVersion("ggplot2")), "4.0.0") >= 0
+}
+
 # Count the number of ggplots in a list
 .count_ggplots <- function(list.objects){
   nplot <- 0
@@ -379,6 +389,31 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
 .set_large_dash_as_ytext <- function(ggp){
   ggp + theme(axis.text.y = ggtext::element_markdown(size = 50, vjust = 0.5),
         axis.ticks.y = element_blank())
+}
+
+# Colour the (risk) table y tick labels per strata with a colour vector.
+# On ggplot2 >= 4.0 use element_text() -- it accepts a per-label colour vector and,
+# unlike ggtext's element_markdown(), can be merged with a user element_text() when
+# customizing the table (#557). ggplot2 4.x prints a one-time "Vectorized input to
+# element_text() is not officially supported" note at theme-assembly time; it is
+# muffled here so it doesn't reach users on every render (the assembled element is
+# stored and does not re-warn at draw time). On ggplot2 < 4.0, where element_text()
+# has no colour vector, keep element_markdown() (which merges fine there).
+# markdown = TRUE forces element_markdown() (used on ggplot2 < 4.0, and on 4.x when
+# y.text = FALSE where the labels are already an element_markdown() large dash that
+# an element_text() could not be merged onto).
+.set_ytext_colour <- function(ggp, colour, markdown = !.ggplot2_ge_4()){
+  if(markdown){
+    ggp + theme(axis.text.y = ggtext::element_markdown(colour = colour))
+  } else {
+    withCallingHandlers(
+      ggp + theme(axis.text.y = ggplot2::element_text(colour = colour)),
+      warning = function(w){
+        if(grepl("Vectorized input to", conditionMessage(w), fixed = TRUE))
+          invokeRestart("muffleWarning")
+      }
+    )
+  }
 }
 
 

--- a/tests/testthat/test-risktable-markdown-escape.R
+++ b/tests/testthat/test-risktable-markdown-escape.R
@@ -23,11 +23,17 @@ test_that("'>' in legend.labs with risk.table renders (was gridtext blockquote e
     legend.labs = c("≤ 1 Risk factor", "> 1 Risk factor"),
     risk.table = TRUE))
   expect_true(drew_ok(p))
-  # the built risk-table y labels carry the HTML-escaped form, which
-  # element_markdown/gridtext decodes back to a literal ">" at render time
   ylabs <- ggplot2::ggplot_build(p$table)$layout$panel_params[[1]]$y$get_labels()
-  expect_true(any(grepl("&gt;", ylabs, fixed = TRUE)))
-  expect_false(any(grepl(">", ylabs, fixed = TRUE)))  # no un-escaped ">" remains
+  if (survminer:::.ggplot2_ge_4()) {
+    # ggplot2 >= 4.0: labels use element_text() (coloured per strata via a colour
+    # vector), so the ">" is shown literally with no HTML escaping (#557).
+    expect_true(any(grepl("> 1 Risk factor", ylabs, fixed = TRUE)))
+  } else {
+    # ggplot2 < 4.0: labels use element_markdown(), so ">" is HTML-escaped and
+    # gridtext decodes "&gt;" back to a literal ">" at render time (#532).
+    expect_true(any(grepl("&gt;", ylabs, fixed = TRUE)))
+    expect_false(any(grepl(">", ylabs, fixed = TRUE)))
+  }
 })
 
 test_that("'>=' / '<' / '&' in labels with risk.table render (#532)", {

--- a/tests/testthat/test-risktable-theme-merge.R
+++ b/tests/testthat/test-risktable-theme-merge.R
@@ -1,0 +1,57 @@
+context("risk-table y-text theme is customizable (ggplot2 4.x)")
+
+# Regression test for #557: under ggplot2 4.x, theme elements are S7 objects and
+# ggtext::element_markdown() (used to colour the risk-table y labels per strata)
+# can no longer be merged with a user-supplied element_text(), so customizing the
+# risk table failed with "Can't merge the `axis.text.y` theme element". On
+# ggplot2 >= 4.0 the y labels are now coloured with element_text(colour = vector)
+# (native, mergeable); on < 4.0 element_markdown() is kept (it merges there).
+library(survival)
+
+drew_ok <- function(p) {
+  tmp <- tempfile(fileext = ".pdf")
+  grDevices::pdf(tmp)
+  on.exit({ grDevices::dev.off(); unlink(tmp) }, add = TRUE)
+  tryCatch({ suppressWarnings(grid::grid.draw(p)); TRUE }, error = function(e) FALSE)
+}
+
+test_that("a user element_text() override on the risk table merges and draws (#557)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  p <- suppressWarnings(ggsurvplot(fit, data = lung, risk.table = TRUE))
+  # This is the operation that errored under ggplot2 4.x with
+  # "Can't merge the `axis.text.y` theme element".
+  p$table <- p$table +
+    ggplot2::theme(axis.text.y = ggplot2::element_text(size = 14, face = "bold"))
+  expect_true(drew_ok(p))
+})
+
+test_that("risk-table y labels are still coloured per strata after the fix (#557)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  p <- suppressWarnings(ggsurvplot(fit, data = lung, risk.table = TRUE))
+  el <- p$table$theme$axis.text.y
+  # a per-label colour vector is carried (one colour per stratum), whichever
+  # element class is used for the running ggplot2 version
+  expect_length(el$colour, length(levels(surv_summary(fit, data = lung)$strata)))
+  expect_true(drew_ok(p))
+})
+
+test_that("no-regression: risk.table.y.text = FALSE (large dash) still draws (#557)", {
+  # The large-dash labels are an element_markdown(); the per-strata colouring must
+  # also stay element_markdown() so the two merge (element_text() on top would
+  # error "Can't merge the axis.text.y theme element" on ggplot2 4.x).
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  expect_true(drew_ok(suppressWarnings(
+    ggsurvplot(fit, data = lung, risk.table = TRUE, risk.table.y.text = FALSE))))
+  expect_true(drew_ok(suppressWarnings(
+    ggsurvplot(fit, data = lung, risk.table = TRUE, tables.y.text = FALSE,
+               cumcensor = TRUE))))
+})
+
+test_that("no-regression: risk.table.y.text.col = FALSE stays plain and customizable", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  p <- suppressWarnings(ggsurvplot(fit, data = lung, risk.table = TRUE,
+                                   risk.table.y.text.col = FALSE))
+  p$table <- p$table +
+    ggplot2::theme(axis.text.y = ggplot2::element_text(size = 12))
+  expect_true(drew_ok(p))
+})


### PR DESCRIPTION
## Summary

Fixes #557. Under `ggplot2 >= 4.0`, customizing the risk table failed with:

> Error: Can't merge the `axis.text.y` theme element. Only elements of the same class can be merged.

e.g. `p$table + theme(axis.text.y = element_text(...))`, or `ggsave()`-ing a customized table.

## Root cause

In ggplot2 4.x, theme elements are S7 objects. survminer colours the risk-table y-axis labels per strata with `ggtext::element_markdown()`, which is still an old-style S3 element and can no longer be merged with a user-supplied `element_text()`.

## Fix

- On `ggplot2 >= 4.0`, colour the labels with `element_text(colour = <vector>)` (native per-label colour, and mergeable with a user `element_text()`). ggplot2 emits a one-time "Vectorized input to `element_text()` is not officially supported" note at theme-assembly time; it is muffled at construction (it does not re-fire at draw, so nothing leaks to `print`/`ggsave`).
- On `ggplot2 < 4.0`, keep `element_markdown()` (it merges fine there) — behavior is byte-identical.
- The large-dash path (`y.text = FALSE`) keeps `element_markdown()` for the colour overlay too, so it merges with the `element_markdown()` dash (using `element_text` there would crash).
- The #532 HTML-escaping is applied only on the `element_markdown` path (`element_text` shows labels literally, so `>` renders correctly without escaping).

The coloured labels look unchanged.

## Verification

- New `tests/testthat/test-risktable-theme-merge.R` (user `element_text` override merges; per-strata colours preserved; `y.text = FALSE` still draws) + version-aware update to `test-risktable-markdown-escape.R`. Clean-session `devtools::test()`: **FAIL 0 | WARN 3 | PASS 322** (no new warnings — the vectorized note is muffled).
- Two independent adversarial reviewers signed off. An earlier revision crashed the `y.text = FALSE` default path (element_text over the element_markdown dash); that was caught in review, fixed, and cleared on a fresh two-reviewer round (every ggplot2 × y.text combination verified to never mix element classes).
