### PR TITLE
Add fun argument to surv_adjustedcurves() (#630)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Minor changes
 
+- `surv_adjustedcurves()` gains a `fun` argument (matching `ggadjustedcurves()`) to transform the returned survival column — e.g. `fun = "event"` for cumulative events, `"cumhaz"`, or `"pct"`. Default `NULL` leaves the survival probabilities unchanged (#630).
+
 - `arrange_ggsurvplots()` gains a `layout_matrix` argument (forwarded to `gridExtra::marrangeGrob()`) to control the position/order of the plots — e.g. `layout_matrix = matrix(seq_along(splots), nrow = nrow, byrow = TRUE)` orders them by row. Default is unchanged (plots fill column-wise) (#300).
 
 - `ggforest()` gains a `global.stats` argument. Set `global.stats = FALSE` to omit the bottom caption reporting the global statistics (number of events, global log-rank p-value, AIC, concordance index) — useful when arranging several forest plots in a panel. Default is `TRUE` (unchanged) (#392).

--- a/R/ggadjustedcurves.R
+++ b/R/ggadjustedcurves.R
@@ -30,6 +30,13 @@ NULL
 #'@param method a character, describes how the expected survival curves shall be calculated. Possible options:
 #' 'single' (average for population), 'average' (averages for subpopulations), 'marginal', 'conditional' (averages for subpopulations after rebalancing). See the Details section  for further information.
 #'@param variable a character, name of the grouping variable to be plotted. If not supplied then it will be extracted from the model formula from the \code{strata()} component. If there is no \code{strata()} component then only a single curve will be plotted - average for the thole population.
+#'@param fun an arbitrary function defining a transformation of the survival
+#'  curve. Often used transformations can be specified with a character argument:
+#'  "event" plots cumulative events (f(y) = 1-y), "cumhaz" plots the cumulative
+#'  hazard function (f(y) = -log(y)), and "pct" for survival probability in
+#'  percentage. For \code{surv_adjustedcurves()} the transformation is applied to
+#'  the returned survival column; the default \code{NULL} leaves the survival
+#'  probabilities unchanged.
 #'@param ylab a label for oy axis.
 #'@param size the curve size.
 #'@param ggtheme function, ggplot2 theme name. Allowed values include ggplot2 official themes: see \code{\link[ggplot2]{theme}}.
@@ -136,6 +143,7 @@ surv_adjustedcurves <- function(fit,
                              data = NULL,
                              reference = NULL,
                              method = "conditional",
+                             fun = NULL,
                              size = 1,
                              ...) {
   stopifnot(method %in% c("marginal", "average", "conditional", "single"))
@@ -196,6 +204,12 @@ surv_adjustedcurves <- function(fit,
                   conditional = ggadjustedcurves.conditional(data, fit, variable, size = size),
                   marginal = ggadjustedcurves.marginal(data, fit, variable, reference, size = size))
 
+  # Apply the transformation requested via `fun` (e.g. "event", "cumhaz", "pct")
+  # to the returned survival column, so the data helper matches what
+  # ggadjustedcurves() plots. No-op when fun = NULL (the default), so existing
+  # results are unchanged (#630). ggadjustedcurves() keeps fun in its own scope
+  # and does not pass it here, so the transform is never applied twice.
+  curve <- .apply_surv_func(curve, fun = fun)
   curve
 }
 

--- a/man/ggadjustedcurves.Rd
+++ b/man/ggadjustedcurves.Rd
@@ -25,6 +25,7 @@ surv_adjustedcurves(
   data = NULL,
   reference = NULL,
   method = "conditional",
+  fun = NULL,
   size = 1,
   ...
 )
@@ -42,10 +43,12 @@ surv_adjustedcurves(
 'single' (average for population), 'average' (averages for subpopulations), 'marginal', 'conditional' (averages for subpopulations after rebalancing). See the Details section  for further information.}
 
 \item{fun}{an arbitrary function defining a transformation of the survival
-curve.  Often used transformations can be specified with a character
-argument: "event" plots cumulative events (f(y) = 1-y), "cumhaz" plots the
-cumulative hazard function (f(y) = -log(y)), and "pct" for survival
-probability in percentage.}
+curve. Often used transformations can be specified with a character argument:
+"event" plots cumulative events (f(y) = 1-y), "cumhaz" plots the cumulative
+hazard function (f(y) = -log(y)), and "pct" for survival probability in
+percentage. For \code{surv_adjustedcurves()} the transformation is applied to
+the returned survival column; the default \code{NULL} leaves the survival
+probabilities unchanged.}
 
 \item{palette}{the color palette to be used. Allowed values include "hue" for
 the default hue color scale; "grey" for grey color palettes; brewer palettes

--- a/tests/testthat/test-surv-adjustedcurves-fun.R
+++ b/tests/testthat/test-surv-adjustedcurves-fun.R
@@ -1,0 +1,47 @@
+context("surv_adjustedcurves fun argument")
+
+# Feature test for #630: surv_adjustedcurves() gains a `fun` argument (matching
+# ggadjustedcurves()) that transforms the returned survival column. The default
+# (fun = NULL) leaves the output unchanged.
+library(survival)
+
+test_that("surv_adjustedcurves(fun=) transforms the survival column (#630)", {
+  fit <- coxph(Surv(time, status) ~ sex + age, data = lung)
+  base <- surv_adjustedcurves(fit, variable = "sex", data = lung, method = "average")
+
+  ev <- surv_adjustedcurves(fit, variable = "sex", data = lung, method = "average",
+                            fun = "event")
+  expect_equal(ev$surv, 1 - base$surv)
+
+  pct <- surv_adjustedcurves(fit, variable = "sex", data = lung, method = "average",
+                             fun = "pct")
+  expect_equal(pct$surv, 100 * base$surv)
+
+  ch <- surv_adjustedcurves(fit, variable = "sex", data = lung, method = "average",
+                            fun = "cumhaz")
+  expect_equal(ch$surv, -log(base$surv))
+
+  # only the survival column changes; time/variable columns are untouched
+  expect_identical(ev[setdiff(names(ev), "surv")],
+                   base[setdiff(names(base), "surv")])
+})
+
+test_that("no-regression: surv_adjustedcurves() default (fun = NULL) is unchanged (#630)", {
+  fit <- coxph(Surv(time, status) ~ sex + age, data = lung)
+  d1 <- surv_adjustedcurves(fit, variable = "sex", data = lung, method = "average")
+  d2 <- surv_adjustedcurves(fit, variable = "sex", data = lung, method = "average",
+                            fun = NULL)
+  expect_identical(d1, d2)
+  expect_true(all(d1$surv >= 0 & d1$surv <= 1))
+})
+
+test_that("no-regression: ggadjustedcurves(fun=) is not double-transformed (#630)", {
+  # ggadjustedcurves() applies `fun` itself and does NOT forward it to
+  # surv_adjustedcurves(), so the transform must be applied exactly once.
+  fit <- coxph(Surv(time, status) ~ sex + age, data = lung)
+  raw <- surv_adjustedcurves(fit, variable = "sex", data = lung, method = "average")
+  p <- ggadjustedcurves(fit, variable = "sex", data = lung, method = "average",
+                        fun = "event")
+  y <- ggplot2::ggplot_build(p)$data[[1]]$y
+  expect_equal(range(y), range(1 - raw$surv))  # once, not 1-(1-y)
+})


### PR DESCRIPTION
## Summary

Fixes #630. The plotting function `ggadjustedcurves()` already supports `fun = "event"` / `"cumhaz"` / `"pct"` (via #734), but the data helper `surv_adjustedcurves()` had no way to transform its output — it always returned raw adjusted survival probabilities.

## Change

`surv_adjustedcurves()` gains a `fun` argument (matching `ggadjustedcurves()`), applied to the returned survival column via the existing `.apply_surv_func()` helper.

- Default `fun = NULL` → no transformation → **byte-identical** to before (verified across the single/average/conditional methods).
- `ggadjustedcurves()` keeps `fun` in its own scope and does not forward it to `surv_adjustedcurves()`, so the transform is **never applied twice**.

```r
library(survival); library(survminer)
fit <- coxph(Surv(time, status) ~ sex + age, data = lung)
surv_adjustedcurves(fit, variable = "sex", data = lung, method = "average", fun = "event")
#> returns cumulative-event values (1 - survival)
```

## Verification

- New `tests/testthat/test-surv-adjustedcurves-fun.R` (event/pct/cumhaz correctness, default byte-identity, and no-double-transform via `ggadjustedcurves`). Clean-session `devtools::test()`: **FAIL 0 | PASS 329**.
- Two independent adversarial reviewers signed off (byte-identical default; no positional-arg breakage in-repo; `fun` not forwarded so no double transform).
