### PR TITLE
ggforest(): omit non-finite (non-converged) coefficient rows, clear message (#406)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
 
 ## Bug fixes
 
+- Improve `ggforest()` handling of a non-converged Cox model (complete / quasi-complete separation), whose coefficient has a hazard ratio or confidence limit that overflows to `Inf` (or underflows to 0). Such a row can't be placed on the log axis; it previously produced a misleading full-width interval and a cryptic "log-10 transformation introduced infinite values" warning. `ggforest()` now emits a clear message naming the affected term(s), omits those rows from the drawn point/interval (they still appear in the table with their numeric labels), and sizes the axis from the finite rows. Converged models are unchanged (#406).
+
 - Fix customizing the risk table failing under `ggplot2 >= 4.0` with "Can't merge the `axis.text.y` theme element" (e.g. `p$table + theme(axis.text.y = element_text(...))`, or `ggsave()`ing a customized table). In ggplot2 4.x theme elements are S7 objects and `ggtext::element_markdown()` (used to colour the risk-table y labels per strata) can no longer be merged with a user `element_text()`. On ggplot2 >= 4.0 the per-strata label colours are now applied with `element_text(colour = <vector>)` (native and mergeable); on older ggplot2 `element_markdown()` is kept (it merges fine there). The coloured labels are unchanged (#557).
 
 - Fix a factor **level** with a genuine trailing or leading space (e.g. `"Obs, "`) being parsed as `NA` in the grouping/facet columns. `survfit` right-pads level names in strata labels, so survminer must trim them; the trimmed value is now matched against the (also trimmed) factor levels while keeping the original levels, so such labels are recovered instead of dropped. Completes the strata special-character fixes (#616).

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -46,7 +46,7 @@ ggforest <- function(model, data = NULL,
   main = "Hazard ratio", cpositions=c(0.02, 0.22, 0.4),
   fontsize = 0.7, refLabel = "reference", noDigits=2,
   global.stats = TRUE) {
-  conf.high <- conf.low <- estimate <- NULL
+  conf.high <- conf.low <- estimate <- .row <- NULL
   stopifnot(inherits(model, "coxph"))
 
   # get data and variables/terms from cox model
@@ -131,6 +131,21 @@ ggforest <- function(model, data = NULL,
   toShowExpClean$stars[is.na(toShowExpClean$estimate)] = ""
   toShowExpClean$ci[is.na(toShowExpClean$estimate)] = ""
   toShowExpClean$estimate[is.na(toShowExpClean$estimate)] = 0
+  # Rows whose hazard ratio or a confidence limit is non-finite on the drawn
+  # (exp / log10) scale come from a Cox model that did not converge -- usually
+  # complete/quasi-complete separation. The stored coefficient may be a large but
+  # finite log value whose exp() overflows to Inf (upper limit) or underflows to
+  # 0 (lower limit); either way it cannot be placed on the log axis, and drawing
+  # it yields a misleading full-width interval plus a "log-10 transformation
+  # introduced infinite values" warning. Flag these rows (tested on the exp'd
+  # values) so the point/error-bar layers skip them; the row still appears in the
+  # table with its numeric labels. NA (reference) levels are NOT flagged -- their
+  # exp'd coordinates are NA, guarded below -- so they are still drawn at HR = 1.
+  # Converged models have no such rows -> no-op, output unchanged (#406).
+  .undrawable <- function(v){ v <- exp(v); !is.na(v) & (!is.finite(v) | v <= 0) }
+  toShowExpClean$.nonfinite <- .undrawable(toShowExpClean$estimate) |
+    .undrawable(toShowExpClean$conf.low) | .undrawable(toShowExpClean$conf.high)
+  nonfinite_terms <- unique(as.character(toShowExpClean$var)[toShowExpClean$.nonfinite])
   toShowExpClean$var = as.character(toShowExpClean$var)
   toShowExpClean$var[duplicated(toShowExpClean$var)] = ""
   # make label strings:
@@ -138,8 +153,33 @@ ggforest <- function(model, data = NULL,
 
   #flip order
   toShowExpClean <- toShowExpClean[nrow(toShowExpClean):1, ]
+  # Stable row index for the drawn layers, so that subsetting the point/error-bar
+  # data to finite rows does not renumber x (the geoms otherwise use
+  # seq_along(var), which would misalign a subset from the rects/annotations).
+  toShowExpClean$.row <- seq_len(nrow(toShowExpClean))
+  if (length(nonfinite_terms) > 0)
+    warning("ggforest: the hazard ratio / confidence interval for term(s) ",
+            paste(nonfinite_terms, collapse = ", "), " is non-finite -- the Cox ",
+            "model likely did not converge (e.g. complete/quasi-complete ",
+            "separation). Those rows are listed in the table but not drawn as a ",
+            "point/interval.", call. = FALSE)
 
-  rangeb <- range(toShowExpClean$conf.low, toShowExpClean$conf.high, na.rm = TRUE)
+  # Axis range from the DRAWABLE rows only (a non-finite row is not plotted, so it
+  # must not stretch the axis). For converged models no row is dropped, so this is
+  # identical to the previous range over all rows. Fall back to the full range (the
+  # clamp below then bounds it to a finite window) when the drawable rows give no
+  # finite range -- e.g. a single factor covariate whose only drawable row is the
+  # NA-CI reference level, or every row non-finite -- so axisTicks() never receives
+  # an empty/inverted range.
+  .drawable <- !toShowExpClean$.nonfinite
+  # suppressWarnings: when the drawable subset is empty / all-NA (e.g. a single
+  # separated factor covariate whose only drawable row is the NA-CI reference),
+  # range(na.rm=TRUE) warns "no non-missing arguments to min"; the fallback below
+  # then supplies a finite range, so that warning is just noise.
+  rangeb <- suppressWarnings(range(toShowExpClean$conf.low[.drawable],
+                                   toShowExpClean$conf.high[.drawable], na.rm = TRUE))
+  if (!all(is.finite(rangeb)))
+    rangeb <- range(toShowExpClean$conf.low, toShowExpClean$conf.high, na.rm = TRUE)
   # (Quasi-)complete separation in the Cox model yields near-infinite
   # coefficients, whose exp()-ed confidence limits overflow and make
   # axisTicks() error with "'at' creation, _LARGE_ range". Clamp the (log-scale)
@@ -178,8 +218,10 @@ ggforest <- function(model, data = NULL,
       ymin = exp(rangeplot[1]), ymax = exp(rangeplot[2]),
       fill = ordered(seq_along(var) %% 2 + 1))) +
     scale_fill_manual(values = c("#FFFFFF33", "#00000033"), guide = "none") +
-    geom_point(pch = 15, size = 4) +
-    geom_errorbar(aes(ymin = exp(conf.low), ymax = exp(conf.high)), width = 0.15) +
+    geom_point(data = toShowExpClean[!toShowExpClean$.nonfinite, , drop = FALSE],
+      aes(x = .row, y = exp(estimate)), pch = 15, size = 4) +
+    geom_errorbar(data = toShowExpClean[!toShowExpClean$.nonfinite, , drop = FALSE],
+      aes(x = .row, ymin = exp(conf.low), ymax = exp(conf.high)), width = 0.15) +
     geom_hline(yintercept = 1, linetype = 3) +
     coord_flip(ylim = exp(rangeplot)) +
     ggtitle(main) +

--- a/tests/testthat/test-ggforest-nonfinite-rows.R
+++ b/tests/testthat/test-ggforest-nonfinite-rows.R
@@ -1,0 +1,78 @@
+context("ggforest omits non-finite (non-converged) rows from the drawn layers")
+
+# Regression test for #406: a Cox model that did not converge (complete /
+# quasi-complete separation) has a coefficient whose exp()-ed hazard ratio or
+# confidence limit overflows to Inf / underflows to 0. Such a row cannot be
+# placed on the log axis; drawing it produced a misleading full-width interval
+# and a "log-10 transformation introduced infinite values" warning. ggforest()
+# now (a) emits a clear message naming the term(s), (b) omits those rows from the
+# point/error-bar layers (so no Inf reaches the log scale -> no log-10 warning),
+# while (c) keeping them in the table. Converged models are unchanged.
+#
+# ggforest() returns ggpubr::as_ggplot(gtable), i.e. one wrapper grob, so the
+# inner layers are inspected via the grob tree, and the row-dropping is asserted
+# behaviourally through the absence of the log-10 warning.
+library(survival)
+
+sep_model <- function() {
+  d <- lung
+  d$sep <- ifelse(d$status == 2, "A", "B")   # perfectly predicts the event
+  suppressWarnings(coxph(Surv(time, status) ~ age + sep, data = d))
+}
+
+collect_warnings <- function(expr) {
+  w <- character(0)
+  withCallingHandlers(expr,
+    warning = function(cnd) { w <<- c(w, conditionMessage(cnd)); invokeRestart("muffleWarning") })
+  w
+}
+
+# All text labels drawn anywhere in the assembled forest grob.
+grob_labels <- function(g) {
+  grob <- g$layers[[1]]$geom_params$grob
+  labels <- character(0)
+  rec <- function(x) {
+    if (!is.null(x$label)) labels <<- c(labels, unlist(x$label))
+    if (!is.null(x$grobs)) lapply(x$grobs, rec)
+    if (!is.null(x$children)) lapply(x$children, rec)
+    invisible(NULL)
+  }
+  rec(grob)
+  labels
+}
+
+test_that("a non-finite term triggers a clear message and no log-10 warning (#406)", {
+  d <- lung; d$sep <- ifelse(d$status == 2, "A", "B")
+  m <- sep_model()
+  w <- collect_warnings(print(ggforest(m, data = d)))
+  expect_true(any(grepl("did not converge", w)))    # clear, specific message
+  expect_true(any(grepl("sep", w, fixed = TRUE)))    # names the offending term
+  expect_false(any(grepl("infinite values", w)))     # no residual log-10 warning
+  # (the log-10 warning would fire iff an Inf/0 coordinate still reached the
+  # log scale, i.e. iff the non-finite row were still drawn -> its absence is the
+  # behavioural proof the row was dropped from the point/error-bar layers.)
+})
+
+test_that("the non-finite row is still shown in the table (#406)", {
+  d <- lung; d$sep <- ifelse(d$status == 2, "A", "B")
+  m <- sep_model()
+  labs <- grob_labels(suppressWarnings(ggforest(m, data = d)))
+  expect_true(any(grepl("Inf", labs)))               # the "(0.00 - Inf)" CI text
+  expect_true(any(grepl("sep", labs, fixed = TRUE))) # the term name
+})
+
+test_that("a single separated factor covariate still renders (no axisTicks crash) (#406)", {
+  # Regression guard: when the only drawable row is the NA-CI reference level
+  # (single factor covariate, its other level non-finite), the axis range must
+  # fall back so axisTicks() does not receive an empty/inverted range.
+  d <- lung; d$sep <- ifelse(d$status == 2, "A", "B")
+  m <- suppressWarnings(coxph(Surv(time, status) ~ sep, data = d))
+  expect_error(suppressWarnings(ggplot2::ggplotGrob(ggforest(m, data = d))), NA)
+})
+
+test_that("no-regression: a converged model renders without the new message (#406)", {
+  m <- coxph(Surv(time, status) ~ age + sex + ph.ecog, data = lung)
+  w <- collect_warnings(print(ggforest(m, data = lung)))
+  expect_false(any(grepl("did not converge|infinite values", w)))
+  expect_error(ggplot2::ggplotGrob(ggforest(m, data = lung)), NA)
+})


### PR DESCRIPTION
## Summary

Improves `ggforest()` handling of a **non-converged** Cox model (complete / quasi-complete separation), addressing #406.

When a term does not converge, its coefficient has a hazard ratio or confidence limit that overflows to `Inf` (or underflows to 0) on the exp/log scale. Such a row can't be placed on the log axis. Previously `ggforest()` drew it as a **misleading full-width interval** and ggplot2 emitted a cryptic `"log-10 transformation introduced infinite values"` warning.

## Fix

- Flag rows whose exp'd HR/CI is non-finite (helper `.undrawable`). **Reference levels** (CI = `NA`) are *not* flagged and still draw at HR = 1.
- Emit **one clear message** naming the affected term(s) ("… did not converge (e.g. complete/quasi-complete separation) … not drawn as a point/interval").
- **Omit** those rows from the point/error-bar layers (via a stable `.row` index so the remaining rows stay aligned with the table), while keeping them in the table with their numeric labels.
- Size the axis from the drawable rows, with a finite fallback so a single separated factor covariate still renders (no `axisTicks` crash).

Converged models have no such rows → **byte-identical output** (verified before/after).

## Verification

- New `tests/testthat/test-ggforest-nonfinite-rows.R` (clear message + no log-10 warning; row kept in table; single-covariate `~sep` renders; converged no-regression). Clean-session `devtools::test()`: **FAIL 0 | PASS 337**.
- Two independent adversarial reviewers signed off; a first round caught a real regression (single separated factor covariate crashed `axisTicks`) which was fixed with a finite range-fallback and re-reviewed. Converged models confirmed byte-identical (PNG/grob-identical); row alignment confirmed with a non-finite term in the middle/first position.
