### PR TITLE
Allow changing the risk-table large-dash size with tables.y.text = FALSE (#642)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
 
 ## Bug fixes
 
+- Fix the "large dash" size not being changeable when `tables.y.text = FALSE`: `p$table <- p$table + theme(axis.text.y = ggtext::element_markdown(size = ...))` was silently reset to the default (50) because the dash styling is re-applied when the plot is printed. The re-application now keeps a user-set size; the default is unchanged (#642).
+
 - Fix `ggsurvplot(..., facet.by = , pval = TRUE)` erroring with "variable lengths differ" when the model was built from a `Surv` object created *outside* the data and used as the formula left-hand side (e.g. `Survival <- Surv(time, status); survfit(Survival ~ x, data = D)`, rather than `Surv(time, status) ~ x`). The per-panel p-value refit row-subset the data while the global response kept its full length; the response is now materialised once on the full data so it stays aligned under subsetting. In-formula fits are unchanged (#467).
 
 - Improve `ggforest()` handling of a non-converged Cox model (complete / quasi-complete separation), whose coefficient has a hazard ratio or confidence limit that overflows to `Inf` (or underflows to 0). Such a row can't be placed on the log axis; it previously produced a misleading full-width interval and a cryptic "log-10 transformation introduced infinite values" warning. `ggforest()` now emits a clear message naming the affected term(s), omits those rows from the drawn point/interval (they still appear in the table with their numeric labels), and sizes the axis from the finite rows. Converged models are unchanged (#406).

--- a/R/ggsurvtable.R
+++ b/R/ggsurvtable.R
@@ -321,7 +321,7 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
   p <- p + tables.theme
 
   if(!y.text) {
-    p <- .set_large_dash_as_ytext(p)
+    p <- .set_large_dash_as_ytext(p, size = 50)
   }
 
   # Color table tick labels by strata. On ggplot2 >= 4.0 use element_text() with a

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -386,8 +386,18 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
 # Each dash corresponds to a strata
 # This is used for tables under the main survival plots
 #
-.set_large_dash_as_ytext <- function(ggp){
-  ggp + theme(axis.text.y = ggtext::element_markdown(size = 50, vjust = 0.5),
+.set_large_dash_as_ytext <- function(ggp, size = NULL){
+  # `size = 50` is passed when the table is first built (ggsurvtable), giving the
+  # large dash. When re-applied at print time (print.ggsurvplot) `size` is omitted,
+  # so the size already on the element is kept -- otherwise a user's
+  # `p$table <- p$table + theme(axis.text.y = element_markdown(size = ...))` would
+  # be overwritten back to 50 (#642). A non-customized table still carries the
+  # build-time 50, so the default is byte-identical.
+  if(is.null(size)){
+    size <- ggp$theme$axis.text.y$size
+    if(is.null(size)) size <- 50
+  }
+  ggp + theme(axis.text.y = ggtext::element_markdown(size = size, vjust = 0.5),
         axis.ticks.y = element_blank())
 }
 

--- a/tests/testthat/test-risktable-dash-size.R
+++ b/tests/testthat/test-risktable-dash-size.R
@@ -1,0 +1,43 @@
+context("risk-table large-dash size is customizable")
+
+# Regression test for #642: with tables.y.text = FALSE the risk-table y-axis
+# shows a large dash per stratum (size 50). Users could not change its size
+# (`p$table <- p$table + theme(axis.text.y = element_markdown(size = ...))` was
+# overwritten back to 50 when .set_large_dash_as_ytext() is re-applied at print).
+# The dash is now built with size = 50 but the print-time re-application keeps a
+# user-set size. The default (no customization) is unchanged.
+library(survival)
+
+dash_size <- function(g) g$theme$axis.text.y$size
+
+test_that(".set_large_dash_as_ytext keeps a user-set size, defaults to 50 (#642)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  p <- suppressWarnings(ggsurvplot(fit, data = lung, risk.table = TRUE,
+                                   tables.y.text = FALSE))
+  # default table is built with the large dash (size 50)
+  expect_equal(dash_size(p$table), 50)
+  # re-applying (as print does) keeps 50 -> byte-identical default
+  expect_equal(dash_size(survminer:::.set_large_dash_as_ytext(p$table)), 50)
+  # forcing a size (as the build does) sets it
+  expect_equal(dash_size(survminer:::.set_large_dash_as_ytext(p$table, size = 50)), 50)
+})
+
+test_that("a user-set dash size survives the print-time re-application (#642)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  p <- suppressWarnings(ggsurvplot(fit, data = lung, risk.table = TRUE,
+                                   tables.y.text = FALSE))
+  p$table <- p$table + theme(axis.text.y = ggtext::element_markdown(size = 10))
+  # the print path calls .set_large_dash_as_ytext(x$table) with no size -> keep 10
+  expect_equal(dash_size(survminer:::.set_large_dash_as_ytext(p$table)), 10)
+  # and the whole thing still draws
+  tmp <- tempfile(fileext = ".pdf"); grDevices::pdf(tmp)
+  on.exit({ grDevices::dev.off(); unlink(tmp) }, add = TRUE)
+  expect_error(suppressWarnings(print(p)), NA)
+})
+
+test_that("no-regression: cumevents/cumcensor default dash size is 50 (#642)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  p <- suppressWarnings(ggsurvplot(fit, data = lung, risk.table = TRUE,
+                                   cumcensor = TRUE, tables.y.text = FALSE))
+  expect_equal(dash_size(p$ncensor.plot), 50)
+})


### PR DESCRIPTION
## Summary

Fixes #642. With `tables.y.text = FALSE`, the risk-table y-axis shows a large "dash" per stratum, and its size couldn't be changed — `p$table <- p$table + theme(axis.text.y = ggtext::element_markdown(size = ...))` was silently reset to the default 50.

## Root cause

The dash styling (`.set_large_dash_as_ytext()`, hardcoded `size = 50`) is applied when the table is built **and re-applied when the compound plot is printed** (`print.ggsurvplot`). The print-time re-application overwrote the user's size back to 50 (`face`/`colour` survived because the function didn't set them).

## Fix

`.set_large_dash_as_ytext(ggp, size = NULL)`:
- The **build-time** call (`ggsurvtable`) passes `size = 50` → the large dash.
- The **print-time** re-application omits `size` → it keeps the size already on the element.

A non-customized table still carries the build-time 50, so the **default is byte-identical** (verified across `$table`, `$cumevents`, `$ncensor.plot`); a user-set size now survives printing. (Note: override with `ggtext::element_markdown(size = )` — the dash element is markdown, so `element_text` would hit ggplot2 4.x's element-merge error, pre-existing #557.)

## Verification

- New `tests/testthat/test-risktable-dash-size.R` (default size 50 across all three tables; a user `element_markdown(size = 10)` override survives the print re-application; renders). Clean-session `devtools::test()`: **FAIL 0 | PASS 351**.
- Two independent adversarial reviewers signed off: default byte-identical across all three tables (master-compared), the build-time `size = 50` is load-bearing and present, coloured-dash (#557) + size override renders cleanly.
