### PR TITLE
Add labeller argument to ggsurvplot_facet()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 ## Minor changes
 
-- `ggsurvplot_facet()` gains a `labeller` argument (forwarded to `ggplot2::facet_wrap()`/`facet_grid()`) to control how the panel strip labels are formatted — e.g. `labeller = ggplot2::label_both` or `labeller = ggplot2::as_labeller(c("1" = "Obs", "2" = "Lev", "3" = "Lev+5FU"))`. Default `NULL` keeps the current labels (unchanged); when supplied it takes precedence over `short.panel.labs` and composes with `panel.labs` (#667).
+- `ggsurvplot_facet()` gains a `labeller` argument (forwarded to `ggplot2::facet_wrap()`/`facet_grid()`) to control how the panel strip labels are formatted — e.g. `labeller = ggplot2::label_both` or `labeller = ggplot2::as_labeller(c("1" = "Obs", "2" = "Lev", "3" = "Lev+5FU"))`. Default `NULL` keeps the current labels (unchanged); when supplied it takes precedence over `short.panel.labs` and composes with `panel.labs`. Idea contributed by @B0ydT (#667, #668).
 
 - `surv_adjustedcurves()` gains a `fun` argument (matching `ggadjustedcurves()`) to transform the returned survival column — e.g. `fun = "event"` for cumulative events, `"cumhaz"`, or `"pct"`. Default `NULL` leaves the survival probabilities unchanged (#630).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Minor changes
 
+- `ggsurvplot_facet()` gains a `labeller` argument (forwarded to `ggplot2::facet_wrap()`/`facet_grid()`) to control how the panel strip labels are formatted — e.g. `labeller = ggplot2::label_both` or `labeller = ggplot2::as_labeller(c("1" = "Obs", "2" = "Lev", "3" = "Lev+5FU"))`. Default `NULL` keeps the current labels (unchanged); when supplied it takes precedence over `short.panel.labs` and composes with `panel.labs` (#667).
+
 - `surv_adjustedcurves()` gains a `fun` argument (matching `ggadjustedcurves()`) to transform the returned survival column — e.g. `fun = "event"` for cumulative events, `"cumhaz"`, or `"pct"`. Default `NULL` leaves the survival probabilities unchanged (#630).
 
 - `arrange_ggsurvplots()` gains a `layout_matrix` argument (forwarded to `gridExtra::marrangeGrob()`) to control the position/order of the plots — e.g. `layout_matrix = matrix(seq_along(splots), nrow = nrow, byrow = TRUE)` orders them by row. Default is unchanged (plots fill column-wise) (#300).

--- a/R/ggsurvplot_facet.R
+++ b/R/ggsurvplot_facet.R
@@ -23,6 +23,13 @@ NULL
 #'  the labels for the "sex" variable. For two grouping variables, you can use
 #'  for example panel.labs = list(sex = c("Male", "Female"), rx = c("Obs",
 #'  "Lev", "Lev2") ).
+#'@param labeller a labeller function/specification, as in
+#'  \code{\link[ggplot2]{facet_wrap}} (e.g. \code{ggplot2::label_both} or
+#'  \code{ggplot2::as_labeller(c(...))}), controlling how the panel strip labels
+#'  are formatted. Default \code{NULL} keeps the current labels. When supplied it
+#'  takes precedence over \code{short.panel.labs}; it composes with
+#'  \code{panel.labs} (which renames the underlying data levels, so the labeller
+#'  sees the renamed values).
 #'@param panel.labs.background a list to customize the background of panel
 #'  labels. Should contain the combination of the following elements: \itemize{
 #'  \item \code{color, linetype, size}: background line color, type and size
@@ -64,6 +71,7 @@ ggsurvplot_facet <- function(fit, data, facet.by,
                              nrow = NULL, ncol = NULL,
                              scales = "fixed",
                              short.panel.labs = FALSE, panel.labs = NULL,
+                             labeller = NULL,
                              panel.labs.background = list(color = NULL, fill = NULL),
                              panel.labs.font = list(face = NULL, color = NULL, size = NULL, angle = NULL),
                              panel.labs.font.x = panel.labs.font,
@@ -183,7 +191,8 @@ ggsurvplot_facet <- function(fit, data, facet.by,
               panel.labs.background = panel.labs.background,
               panel.labs.font = panel.labs.font,
               panel.labs.font.x =panel.labs.font.x,
-              panel.labs.font.y = panel.labs.font.y)
+              panel.labs.font.y = panel.labs.font.y,
+              labeller = labeller)
 
   # Pvalues
   #:::::::::::::::::::::::::::::::::::::::::
@@ -267,7 +276,8 @@ ggsurvplot_facet <- function(fit, data, facet.by,
                    panel.labs.background = list(color = NULL, fill = NULL),
                    panel.labs.font = list(face = NULL, color = NULL, size = NULL, angle = NULL),
                    panel.labs.font.x = panel.labs.font,
-                   panel.labs.font.y = panel.labs.font
+                   panel.labs.font.y = panel.labs.font,
+                   labeller = NULL
                    )
 {
 
@@ -277,6 +287,9 @@ ggsurvplot_facet <- function(fit, data, facet.by,
 
   .labeller <- "label_value"
   if(!short.panel.labs) .labeller <- label_both
+  # A user-supplied labeller takes precedence over the short.panel.labs choice
+  # (both control the strip-label formatting). Default NULL -> unchanged (#667).
+  if(!is.null(labeller)) .labeller <- labeller
 
   if(length(facet.by) == 1){
     facet.formula <- paste0("~", facet.by) %>% stats::as.formula()

--- a/man/ggsurvplot_facet.Rd
+++ b/man/ggsurvplot_facet.Rd
@@ -21,6 +21,7 @@ ggsurvplot_facet(
   scales = "fixed",
   short.panel.labs = FALSE,
   panel.labs = NULL,
+  labeller = NULL,
   panel.labs.background = list(color = NULL, fill = NULL),
   panel.labs.font = list(face = NULL, color = NULL, size = NULL, angle = NULL),
   panel.labs.font.x = panel.labs.font,
@@ -91,6 +92,14 @@ text. For example, panel.labs = list(sex = c("Male", "Female")) specifies
 the labels for the "sex" variable. For two grouping variables, you can use
 for example panel.labs = list(sex = c("Male", "Female"), rx = c("Obs",
 "Lev", "Lev2") ).}
+
+\item{labeller}{a labeller function/specification, as in
+\code{\link[ggplot2]{facet_wrap}} (e.g. \code{ggplot2::label_both} or
+\code{ggplot2::as_labeller(c(...))}), controlling how the panel strip labels
+are formatted. Default \code{NULL} keeps the current labels. When supplied it
+takes precedence over \code{short.panel.labs}; it composes with
+\code{panel.labs} (which renames the underlying data levels, so the labeller
+sees the renamed values).}
 
 \item{panel.labs.background}{a list to customize the background of panel
 labels. Should contain the combination of the following elements: \itemize{

--- a/tests/testthat/test-facet-labeller.R
+++ b/tests/testthat/test-facet-labeller.R
@@ -1,0 +1,99 @@
+context("ggsurvplot_facet custom labeller")
+
+# Regression tests for #667: ggsurvplot_facet() gains a `labeller` argument,
+# forwarded to ggplot2 facet_wrap()/facet_grid(), so the panel strip labels can
+# be formatted (e.g. ggplot2::label_both, ggplot2::as_labeller(...)). Default
+# NULL keeps the current labels (byte-identical). A supplied labeller takes
+# precedence over short.panel.labs and composes with panel.labs.
+library(survival)
+
+# Collect the text drawn in the facet strip grobs of a rendered plot.
+strip_text <- function(p) {
+  g <- ggplot2::ggplotGrob(p)
+  idx <- which(grepl("strip", g$layout$name))
+  labs <- character(0)
+  collect <- function(gr) {
+    if (inherits(gr, "text")) labs <<- c(labs, gr$label)
+    if (!is.null(gr$children)) lapply(gr$children, collect)
+    if (!is.null(gr$grobs)) lapply(gr$grobs, collect)
+    invisible(NULL)
+  }
+  for (i in idx) collect(g$grobs[[i]])
+  labs[!is.na(labs)]
+}
+
+drew_ok <- function(p) {
+  tmp <- tempfile(fileext = ".pdf")
+  grDevices::pdf(tmp)
+  on.exit({ grDevices::dev.off(); unlink(tmp) }, add = TRUE)
+  tryCatch({ suppressWarnings(print(p)); TRUE }, error = function(e) FALSE)
+}
+
+fit  <- survfit(Surv(time, status) ~ sex, data = colon)
+fit2 <- survfit(Surv(time, status) ~ sex, data = colon)
+
+test_that("no-regression: default labeller is unchanged (label_both) (#667)", {
+  p <- ggsurvplot_facet(fit, colon, facet.by = "rx")
+  # By default short.panel.labs = FALSE -> label_both; the stored facet labeller
+  # must be byte-identical to what it was before the new argument existed.
+  expect_true(identical(p$facet$params$labeller, ggplot2::label_both))
+  # And the strips still read "rx: <level>".
+  st <- strip_text(p)
+  expect_true(length(st) > 0)
+  expect_true(all(grepl("^rx: ", st)))
+})
+
+test_that("no-regression: short.panel.labs = TRUE still uses label_value (#667)", {
+  p <- ggsurvplot_facet(fit, colon, facet.by = "rx", short.panel.labs = TRUE)
+  expect_true(identical(p$facet$params$labeller, ggplot2::label_value))
+})
+
+test_that("a custom as_labeller() renames the strips for facet_wrap (#667)", {
+  lab <- ggplot2::as_labeller(c("Obs" = "Observation",
+                                "Lev" = "Levamisole",
+                                "Lev+5FU" = "Lev + 5-FU"))
+  p <- ggsurvplot_facet(fit, colon, facet.by = "rx", labeller = lab)
+  expect_true(identical(p$facet$params$labeller, lab))
+  st <- strip_text(p)
+  expect_true("Observation" %in% st)
+  expect_true("Levamisole"  %in% st)
+  expect_true("Lev + 5-FU"  %in% st)
+  # and it takes precedence over short.panel.labs (still renamed, not "rx: ...")
+  expect_false(any(grepl("^rx: ", st)))
+})
+
+test_that("labeller overrides short.panel.labs (#667)", {
+  # short.panel.labs = FALSE would give label_both ("rx: Obs"); a supplied
+  # labeller must win.
+  p <- ggsurvplot_facet(fit, colon, facet.by = "rx",
+                        short.panel.labs = FALSE,
+                        labeller = ggplot2::label_value)
+  expect_true(identical(p$facet$params$labeller, ggplot2::label_value))
+  st <- strip_text(p)
+  expect_false(any(grepl("^rx: ", st)))
+  expect_true("Obs" %in% st)
+})
+
+test_that("labeller works for two faceting variables (facet_grid) (#667)", {
+  p <- ggsurvplot_facet(fit, colon, facet.by = c("rx", "adhere"),
+                        labeller = ggplot2::label_value)
+  expect_true(identical(p$facet$params$labeller, ggplot2::label_value))
+  expect_true(drew_ok(p))
+})
+
+test_that("labeller composes with panel.labs (renamed levels reach the labeller) (#667)", {
+  # panel.labs renames the underlying data levels; label_both then prefixes with
+  # the (renamed) variable label. The labeller sees the renamed values.
+  p <- ggsurvplot_facet(fit, colon, facet.by = "rx",
+                        panel.labs = list(rx = c("A", "B", "C")),
+                        labeller = ggplot2::label_value)
+  st <- strip_text(p)
+  expect_true(all(c("A", "B", "C") %in% st))
+})
+
+test_that("labeller does not break per-panel pval (#667)", {
+  p <- suppressWarnings(
+    ggsurvplot_facet(fit2, colon, facet.by = "rx", pval = TRUE,
+                     labeller = ggplot2::label_value))
+  expect_true(drew_ok(p))
+})


### PR DESCRIPTION
Fixes #667

## Summary
Exposes ggplot2's `facet_wrap()`/`facet_grid()` `labeller` argument on `ggsurvplot_facet()`, so users can reformat the panel strip labels (e.g. `ggplot2::label_both`, `ggplot2::as_labeller(c(...))`).

## Behaviour
- `labeller = NULL` (default) keeps the current labels — byte-identical for all existing usage. The new `if(!is.null(labeller)) .labeller <- labeller` guard never fires for the default, and the `facet_wrap`/`facet_grid` calls already passed `.labeller`.
- When supplied, `labeller` takes precedence over `short.panel.labs` and composes with `panel.labs` (which renames the underlying data levels, so the labeller sees the renamed values).
- Forwarded to both the 1-variable (`facet_wrap`) and 2-variable (`facet_grid`) paths.

## Non-regression
- Default facet labeller remains `identical()` to `label_both`; `short.panel.labs = TRUE` remains `label_value`.
- New regression tests in `tests/testthat/test-facet-labeller.R` (16 assertions): default byte-identity, short.panel.labs unchanged, custom `as_labeller` renames strips, precedence over short.panel.labs, 2-var `facet_grid`, composition with `panel.labs`, and labeller + per-panel `pval`.
- Full clean-session suite green (`Rscript --vanilla -e 'devtools::test()'`): 0 failures.
- Two independent adversarial reviewers cleared the diff (byte-identity + threading + doc/Rd + test soundness).

## Docs
- roxygen `@param labeller` added; `man/ggsurvplot_facet.Rd` hand-edited in signature order (`tools::checkRd()` clean).
- `NEWS.md` entry under Minor changes referencing (#667).
