### PR TITLE
Give an actionable error when a fit's data is out of scope (#521)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
 
 ## Bug fixes
 
+- Improve the error message when `ggsurvplot(fit)` is called without `data =` for a model fitted in a non-global environment (e.g. inside a function or a `{targets}` pipeline). survminer re-derives the data from the fit's stored call, but the referenced object is then out of scope and a survfit stores no reference to its creation environment, so the data cannot be recovered. Instead of a cryptic `object '<name>' not found`, survminer now raises an actionable message telling the user to pass `data =` explicitly (e.g. `ggsurvplot(fit, data = mydata)`), while preserving the original error as context. Working inputs (data supplied, or a fit created in the global scope) are unchanged (#521).
+
 - Fix the "large dash" size not being changeable when `tables.y.text = FALSE`: `p$table <- p$table + theme(axis.text.y = ggtext::element_markdown(size = ...))` was silently reset to the default (50) because the dash styling is re-applied when the plot is printed. The re-application now keeps a user-set size; the default is unchanged (#642).
 
 - Fix `ggsurvplot(..., facet.by = , pval = TRUE)` erroring with "variable lengths differ" when the model was built from a `Surv` object created *outside* the data and used as the formula left-hand side (e.g. `Survival <- Surv(time, status); survfit(Survival ~ x, data = D)`, rather than `Surv(time, status) ~ x`). The per-panel p-value refit row-subset the data while the global response kept its full length; the response is now materialised once on the full data so it stays aligned under subsetting. In-formula fits are unchanged (#467).

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -143,7 +143,24 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
   if(is.null(data)){
     if (complain)
       warning ("The `data` argument is not provided. Data will be extracted from model fit.")
-    data <- eval(fit$call$data)
+    # Re-derive the data from the stored call. When the fit was created in a
+    # non-global environment (e.g. inside a function or a {targets} pipeline),
+    # the referenced object is out of scope at plot time and eval() throws a
+    # cryptic "object '<name>' not found". A survfit object stores no reference
+    # to its creation environment, so the data cannot be recovered here; turn
+    # the cryptic failure into an actionable message (keeping the original
+    # error as context) telling the user to pass `data` explicitly (#521).
+    data <- tryCatch(
+      eval(fit$call$data),
+      error = function(e) stop(
+        "The `data` used to fit the model could not be extracted automatically. ",
+        "This happens when the model was fitted in a non-global environment ",
+        "(e.g. inside a function or a {targets} pipeline). ",
+        "Please provide it explicitly, e.g. `ggsurvplot(fit, data = mydata)`.\n",
+        "Original error: ", conditionMessage(e),
+        call. = FALSE
+      )
+    )
     if (is.null(data))
       stop("The `data` argument should be provided either to ggsurvfit or survfit.")
   }

--- a/tests/testthat/test-get-data-nonglobal-env.R
+++ b/tests/testthat/test-get-data-nonglobal-env.R
@@ -1,0 +1,59 @@
+context("data auto-extraction message for non-global-environment fits")
+
+# Regression test for #521: ggsurvplot(fit) called WITHOUT an explicit `data=`
+# re-derives the data via eval(fit$call$data) in .get_data(). When the survfit
+# was created in a NON-global environment (e.g. inside a function or a {targets}
+# pipeline) the referenced object is out of scope at plot time, and eval() threw
+# a cryptic "object '<name>' not found". A survfit stores no reference to its
+# creation environment, so the data cannot be recovered here; the cryptic error
+# is now converted into an actionable message (telling the user to pass `data=`
+# explicitly) that also preserves the original error as context. Working inputs
+# (data supplied, or fit fitted in the global scope) are byte-identical.
+library(survival)
+
+test_that("no-regression: explicit data is returned unchanged (#521)", {
+  fit <- survfit(Surv(time, status) ~ 1, data = lung)
+  expect_identical(survminer:::.get_data(fit, data = lung), lung)
+})
+
+test_that("no-regression: global-scope fit still auto-extracts its data (#521)", {
+  # eval(fit$call$data) succeeds -> same data, same code path as before.
+  lungG <<- lung
+  fitG  <<- survfit(Surv(time, status) ~ sex, data = lungG)
+  on.exit(rm(list = c("lungG", "fitG"), envir = globalenv()), add = TRUE)
+  expect_identical(suppressWarnings(survminer:::.get_data(fitG)), lungG)
+})
+
+test_that("non-global-env fit without data gives an actionable message (#521)", {
+  envir <- new.env(parent = globalenv())
+  evalq({
+    test <- lung
+    survival <- survfit(Surv(time, status) ~ 1, data = test)
+  }, envir = envir)
+  fit <- get("survival", envir = envir)
+  rm(envir)  # ensure the `test` object is truly out of scope
+
+  msg <- tryCatch(suppressWarnings(survminer:::.get_data(fit)),
+                  error = function(e) conditionMessage(e))
+  # actionable guidance to pass data explicitly ...
+  expect_match(msg, "provide it explicitly", fixed = TRUE)
+  expect_match(msg, "data = mydata", fixed = TRUE)
+  # ... and the original error is preserved as context (not swallowed).
+  expect_match(msg, "Original error", fixed = TRUE)
+
+  # And the same holds end-to-end through ggsurvplot() (which calls .get_data
+  # with complain = FALSE, so previously the user saw only the cryptic error).
+  msg2 <- tryCatch(ggsurvplot(fit), error = function(e) conditionMessage(e))
+  expect_match(msg2, "could not be extracted automatically", fixed = TRUE)
+})
+
+test_that("non-global-env fit works when data is supplied explicitly (#521)", {
+  envir <- new.env(parent = globalenv())
+  evalq({
+    test <- lung
+    survival <- survfit(Surv(time, status) ~ 1, data = test)
+  }, envir = envir)
+  fit <- get("survival", envir = envir)
+  p <- ggsurvplot(fit, data = lung)
+  expect_s3_class(p, "ggsurvplot")
+})


### PR DESCRIPTION
Refs #521

## Summary
Improves the error `ggsurvplot(fit)` raises when called **without** `data =` for a model fitted in a **non-global environment** (e.g. inside a function or a `{targets}` pipeline).

survminer re-derives the data from the fit's stored call (`eval(fit$call$data)`), but the referenced object is out of scope at plot time and a `survfit` object stores **no** reference to its creation environment — so the data genuinely cannot be recovered. Previously the user got a cryptic `object '<name>' not found`; on the main `ggsurvplot()` path (which calls `.get_data(..., complain = FALSE)`) there wasn't even the "data will be extracted" warning, so the raw R error was all they saw.

`.get_data()` now wraps the `eval()` in `tryCatch()` and, on failure, raises an actionable message:

```
The `data` used to fit the model could not be extracted automatically.
This happens when the model was fitted in a non-global environment
(e.g. inside a function or a {targets} pipeline).
Please provide it explicitly, e.g. `ggsurvplot(fit, data = mydata)`.
Original error: object 'test' not found
```

The original error is preserved as context (nothing is swallowed).

## Scope — issue stays OPEN
This is a **message-only** improvement. The requested behaviour (auto-extraction *working* for non-global-env fits) is architecturally infeasible in survminer: a `survfit` stores no environment, and in a `{targets}` pipeline the object is destroyed before plot time — an upstream R/`survival` NSE limitation, same cluster as #533/#571/#644. So **#521 remains open** to track that aspirational fix; this PR only removes the papercut.

## Non-regression
- Byte-identical for all working inputs: (a) `data =` supplied → the block is skipped; (b) `data = NULL` with the fit in the global scope → `eval()` succeeds, same data returned; (c) a call whose `data` evaluates to `NULL` → the existing `stop("The \`data\` argument should be provided...")` still fires.
- `tryCatch` intercepts only the *error* path; the value path is untouched.
- Locale-safe: tests assert only the new English message, never the locale-dependent underlying error.
- New regression tests in `tests/testthat/test-get-data-nonglobal-env.R` (byte-identity + actionable-message + end-to-end `ggsurvplot()` + explicit-data-works).
- Full clean-session suite green (`Rscript --vanilla -e 'devtools::test()'`): 0 failures.
- Two independent adversarial reviewers cleared the diff (byte-identity, no error-masking, all `.get_data()` call sites, locale/CI parity, test hygiene).
