### PR TITLE
Use anyNA() for the missing-grouping-value check in pairwise_survdiff()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Minor changes
 
+- `pairwise_survdiff()` now uses `anyNA()` for its internal missing-grouping-value check instead of a row-wise `NA %in% .row`, which is faster and clearer. Results are unchanged for the usual factor/character grouping variables; the only difference is a purely numeric grouping column containing `NaN`, whose row is now dropped as missing (previously it formed a spurious `"NaN"` group). Contributed by @MichaelChirico (#635).
+
 - `ggsurvplot_facet()` gains a `labeller` argument (forwarded to `ggplot2::facet_wrap()`/`facet_grid()`) to control how the panel strip labels are formatted — e.g. `labeller = ggplot2::label_both` or `labeller = ggplot2::as_labeller(c("1" = "Obs", "2" = "Lev", "3" = "Lev+5FU"))`. Default `NULL` keeps the current labels (unchanged); when supplied it takes precedence over `short.panel.labs` and composes with `panel.labs`. Idea contributed by @B0ydT (#667, #668).
 
 - `surv_adjustedcurves()` gains a `fun` argument (matching `ggadjustedcurves()`) to transform the returned survival column — e.g. `fun = "event"` for cumulative events, `"cumhaz"`, or `"pct"`. Default `NULL` leaves the survival probabilities unchanged (#630).

--- a/R/pairwise_survdiff.R
+++ b/R/pairwise_survdiff.R
@@ -66,7 +66,7 @@ pairwise_survdiff <- function(formula, data, p.adjust.method = "BH", na.action, 
   # Removing missing value
   # ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   .is.na <- data[, group_var, drop = FALSE] %>%
-    apply(1, function(.row){NA %in% .row})
+    apply(MARGIN = 1L, anyNA)
   data <- data[!.is.na, ]
 
   # Grouping variables

--- a/tests/testthat/test-pairwise_survdiff.R
+++ b/tests/testthat/test-pairwise_survdiff.R
@@ -37,3 +37,37 @@ test_that("a formula with only strata() terms errors clearly (#648)", {
     "at least one grouping variable"
   )
 })
+
+test_that("rows with a missing grouping value are dropped (#635)", {
+  # pairwise_survdiff() removes rows with NA in any grouping column before the
+  # pairwise tests. This locks that behavior after switching the row-wise check
+  # to anyNA() (byte-identical to the previous `NA %in% .row` for grouping
+  # variables). A run with NAs must match a run on the NA-free subset.
+  d <- colon
+  set.seed(42)
+  na_idx <- sample(nrow(d), 20)
+  d$rx[na_idx] <- NA
+  res_na  <- pairwise_survdiff(Surv(time, status) ~ rx, data = d)
+  res_cc  <- pairwise_survdiff(Surv(time, status) ~ rx, data = d[!is.na(d$rx), ])
+  expect_equal(res_na$p.value, res_cc$p.value)
+  # NA is not carried in as a spurious extra group
+  expect_false(anyNA(rownames(res_na$p.value)))
+  expect_false(any(c("NA", NA) %in% rownames(res_na$p.value)))
+})
+
+test_that("rows with a missing value in ANY of several grouping vars are dropped (#635)", {
+  # The drop matters most for the multiple-grouping-variable path: an undropped
+  # NA would form a spurious combined strata() level. NAs seeded into different
+  # rows of two grouping columns must give the same result as the complete-case
+  # run, with no NA-bearing combined group.
+  d <- colon
+  set.seed(7)
+  d$rx[sample(nrow(d), 15)]     <- NA
+  d$adhere[sample(nrow(d), 15)] <- NA
+  res_na <- pairwise_survdiff(Surv(time, status) ~ rx + adhere, data = d)
+  cc <- d[!is.na(d$rx) & !is.na(d$adhere), ]
+  res_cc <- pairwise_survdiff(Surv(time, status) ~ rx + adhere, data = cc)
+  expect_equal(res_na$p.value, res_cc$p.value)
+  expect_false(any(grepl("NA", rownames(res_na$p.value))))
+  expect_false(any(grepl("NA", colnames(res_na$p.value))))
+})


### PR DESCRIPTION
Adopts @MichaelChirico's suggestion from #635: replace the row-wise `apply(1, function(.row){NA %in% .row})` in `pairwise_survdiff()` with `apply(MARGIN = 1L, anyNA)` — faster and clearer.

## Non-regression
- Byte-identical for the usual factor/character grouping variables (verified old-vs-new logical vectors across single/multi/no-NA/numeric cases, and full `$p.value` equality on colon with injected NAs vs complete-case).
- Only difference: a purely numeric grouping column containing `NaN` now drops that row as missing, instead of the old behaviour of keeping it and forming a spurious `"NaN"` group — an improvement, documented in NEWS.
- Regression tests added (single- and multi-grouping-variable NA drop).
- Full clean-session suite green; two independent adversarial reviewers cleared the diff.

Contributed by @MichaelChirico (#635). Refs #635.