### PR TITLE
Add ref.display argument to ggforest()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 ## Minor changes
 
-- `ggforest()` gains a `ref.display` argument. Set `ref.display = FALSE` to omit the reference-level rows of factor variables (the baselines, which have no hazard ratio) from both the plot and the table, keeping only the compared levels — useful for compact panels. Default is `TRUE` (every level shown, unchanged). Contributed by @trentleslie (#563).
+- `ggforest()` gains a `ref.display` argument. Set `ref.display = FALSE` to omit the rows that have no hazard ratio — factor baselines and any non-estimable/aliased or `strata()` terms (the rows labelled "reference") — from both the plot and the table, keeping only the estimated levels; useful for compact panels. Default is `TRUE` (every row shown, unchanged). Contributed by @trentleslie (#563).
 
 - `pairwise_survdiff()` now uses `anyNA()` for its internal missing-grouping-value check instead of a row-wise `NA %in% .row`, which is faster and clearer. Results are unchanged for the usual factor/character grouping variables; the only difference is a purely numeric grouping column containing `NaN`, whose row is now dropped as missing (previously it formed a spurious `"NaN"` group). Contributed by @MichaelChirico (#635).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Minor changes
 
+- `ggforest()` gains a `ref.display` argument. Set `ref.display = FALSE` to omit the reference-level rows of factor variables (the baselines, which have no hazard ratio) from both the plot and the table, keeping only the compared levels — useful for compact panels. Default is `TRUE` (every level shown, unchanged). Contributed by @trentleslie (#563).
+
 - `pairwise_survdiff()` now uses `anyNA()` for its internal missing-grouping-value check instead of a row-wise `NA %in% .row`, which is faster and clearer. Results are unchanged for the usual factor/character grouping variables; the only difference is a purely numeric grouping column containing `NaN`, whose row is now dropped as missing (previously it formed a spurious `"NaN"` group). Contributed by @MichaelChirico (#635).
 
 - `ggsurvplot_facet()` gains a `labeller` argument (forwarded to `ggplot2::facet_wrap()`/`facet_grid()`) to control how the panel strip labels are formatted — e.g. `labeller = ggplot2::label_both` or `labeller = ggplot2::as_labeller(c("1" = "Obs", "2" = "Lev", "3" = "Lev+5FU"))`. Default `NULL` keeps the current labels (unchanged); when supplied it takes precedence over `short.panel.labs` and composes with `panel.labs`. Idea contributed by @B0ydT (#667, #668).

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -13,10 +13,11 @@
 #'   caption reporting the global statistics (number of events, global
 #'   likelihood-ratio-test p-value, AIC and concordance index) is omitted. Useful
 #'   when arranging several forest plots in a panel.
-#' @param ref.display logical value. Default is TRUE. If FALSE, the reference
-#'   level rows of factor variables (the baselines, which have no hazard ratio)
-#'   are omitted from both the plot and the table, keeping only the compared
-#'   levels. Default TRUE shows every level (unchanged).
+#' @param ref.display logical value. Default is TRUE. If FALSE, the rows that
+#'   have no hazard ratio -- factor baselines, and any non-estimable / aliased or
+#'   \code{strata()} terms, i.e. the rows labelled \code{refLabel} ("reference")
+#'   -- are omitted from both the plot and the table, keeping only the estimated
+#'   levels. Default TRUE shows every row (unchanged).
 #'
 #' @return returns a ggplot2 object (invisibly)
 #'
@@ -125,12 +126,13 @@ ggforest <- function(model, data = NULL,
   toShowExpClean <- data.frame(toShow,
     pvalue = signif(toShow[,4],noDigits+1),
     toShowExp)
-  # ref.display = FALSE drops the reference-level rows (factor baselines) from the
-  # forest -- both the drawn point and the table row -- keeping only the compared
-  # levels. A reference level is exactly a row with an NA estimate (a baseline has
-  # no hazard ratio); this is a precise marker, since a non-converged coefficient
-  # is Inf/huge rather than NA, so no genuine estimate is dropped. Default TRUE
-  # keeps every row, so existing plots are unchanged (#563).
+  # ref.display = FALSE drops the rows with no hazard ratio -- factor baselines,
+  # plus any non-estimable / aliased or strata() terms -- from both the drawn
+  # point and the table, keeping only the estimated levels. These are exactly the
+  # rows with an NA estimate, i.e. the ones already labelled refLabel ("reference")
+  # below, so the drop is self-consistent with the default display. A non-converged
+  # (separation) coefficient is a large finite value, not NA, so no genuine
+  # estimate is dropped. Default TRUE keeps every row -> existing plots unchanged (#563).
   if (!ref.display)
     toShowExpClean <- toShowExpClean[!is.na(toShowExpClean$estimate), , drop = FALSE]
   toShowExpClean$stars <- paste0(round(toShowExpClean$p.value, noDigits+1), " ",

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -13,6 +13,10 @@
 #'   caption reporting the global statistics (number of events, global
 #'   likelihood-ratio-test p-value, AIC and concordance index) is omitted. Useful
 #'   when arranging several forest plots in a panel.
+#' @param ref.display logical value. Default is TRUE. If FALSE, the reference
+#'   level rows of factor variables (the baselines, which have no hazard ratio)
+#'   are omitted from both the plot and the table, keeping only the compared
+#'   levels. Default TRUE shows every level (unchanged).
 #'
 #' @return returns a ggplot2 object (invisibly)
 #'
@@ -45,7 +49,7 @@
 ggforest <- function(model, data = NULL,
   main = "Hazard ratio", cpositions=c(0.02, 0.22, 0.4),
   fontsize = 0.7, refLabel = "reference", noDigits=2,
-  global.stats = TRUE) {
+  global.stats = TRUE, ref.display = TRUE) {
   conf.high <- conf.low <- estimate <- .row <- NULL
   stopifnot(inherits(model, "coxph"))
 
@@ -121,6 +125,14 @@ ggforest <- function(model, data = NULL,
   toShowExpClean <- data.frame(toShow,
     pvalue = signif(toShow[,4],noDigits+1),
     toShowExp)
+  # ref.display = FALSE drops the reference-level rows (factor baselines) from the
+  # forest -- both the drawn point and the table row -- keeping only the compared
+  # levels. A reference level is exactly a row with an NA estimate (a baseline has
+  # no hazard ratio); this is a precise marker, since a non-converged coefficient
+  # is Inf/huge rather than NA, so no genuine estimate is dropped. Default TRUE
+  # keeps every row, so existing plots are unchanged (#563).
+  if (!ref.display)
+    toShowExpClean <- toShowExpClean[!is.na(toShowExpClean$estimate), , drop = FALSE]
   toShowExpClean$stars <- paste0(round(toShowExpClean$p.value, noDigits+1), " ",
     ifelse(toShowExpClean$p.value < 0.05, "*",""),
     ifelse(toShowExpClean$p.value < 0.01, "*",""),

--- a/man/ggforest.Rd
+++ b/man/ggforest.Rd
@@ -12,7 +12,8 @@ ggforest(
   fontsize = 0.7,
   refLabel = "reference",
   noDigits = 2,
-  global.stats = TRUE
+  global.stats = TRUE,
+  ref.display = TRUE
 )
 }
 \arguments{
@@ -35,6 +36,11 @@ will be extracted from 'fit' object.}
 reporting the global statistics (number of events, global likelihood-ratio-test
 p-value, AIC and concordance index) is omitted. Useful when arranging several
 forest plots in a panel.}
+
+\item{ref.display}{logical value. Default is TRUE. If FALSE, the reference level
+rows of factor variables (the baselines, which have no hazard ratio) are omitted
+from both the plot and the table, keeping only the compared levels. Default TRUE
+shows every level (unchanged).}
 }
 \value{
 returns a ggplot2 object (invisibly)

--- a/man/ggforest.Rd
+++ b/man/ggforest.Rd
@@ -37,10 +37,11 @@ reporting the global statistics (number of events, global likelihood-ratio-test
 p-value, AIC and concordance index) is omitted. Useful when arranging several
 forest plots in a panel.}
 
-\item{ref.display}{logical value. Default is TRUE. If FALSE, the reference level
-rows of factor variables (the baselines, which have no hazard ratio) are omitted
-from both the plot and the table, keeping only the compared levels. Default TRUE
-shows every level (unchanged).}
+\item{ref.display}{logical value. Default is TRUE. If FALSE, the rows that have
+no hazard ratio -- factor baselines, and any non-estimable / aliased or
+\code{strata()} terms, i.e. the rows labelled \code{refLabel} ("reference") --
+are omitted from both the plot and the table, keeping only the estimated levels.
+Default TRUE shows every row (unchanged).}
 }
 \value{
 returns a ggplot2 object (invisibly)

--- a/tests/testthat/test-ggforest-ref-display.R
+++ b/tests/testthat/test-ggforest-ref-display.R
@@ -1,0 +1,58 @@
+context("ggforest ref.display argument")
+
+# Regression test for #563: ggforest() gains a `ref.display` argument. When FALSE,
+# the reference-level rows of factor variables (baselines, which have no hazard
+# ratio) are dropped from both the plot and the table, keeping only the compared
+# levels. Default TRUE shows every level (unchanged). The reference rows are
+# identified precisely by an NA estimate, so genuine estimates are never dropped.
+library(survival)
+
+# Collect all text drawn in a rendered ggforest (labels live in text grobs).
+forest_text <- function(p) {
+  g <- ggplot2::ggplotGrob(p)
+  labs <- character(0)
+  collect <- function(gr) {
+    if (inherits(gr, "text")) labs <<- c(labs, gr$label)
+    if (!is.null(gr$children)) lapply(gr$children, collect)
+    if (!is.null(gr$grobs)) lapply(gr$grobs, collect)
+    invisible(NULL)
+  }
+  collect(g)
+  labs[!is.na(labs)]
+}
+
+fit <- coxph(Surv(time, status) ~ sex + factor(ph.ecog) + age, data = lung)
+
+test_that("no-regression: ref.display = TRUE (default) shows reference rows (#563)", {
+  p <- ggforest(fit, data = lung)
+  txt <- forest_text(p)
+  # the factor(ph.ecog) baseline (level 0) is shown as a 'reference' row
+  expect_true(any(grepl("reference", txt)))
+})
+
+test_that("ref.display = FALSE drops the reference rows (#563)", {
+  p <- ggforest(fit, data = lung, ref.display = FALSE)
+  txt <- forest_text(p)
+  expect_false(any(grepl("reference", txt)))
+  # the compared factor levels are still present
+  expect_true(any(grepl("2.47", txt)))   # ph.ecog level 2 hazard ratio
+  # and the plot still draws
+  expect_error(ggplot2::ggplotGrob(p), NA)
+})
+
+test_that("ref.display = FALSE does not drop continuous-only estimates (#563)", {
+  # a model with no factor (no reference rows): output should be the same with
+  # ref.display TRUE or FALSE (nothing to drop).
+  fit_num <- coxph(Surv(time, status) ~ age + wt.loss, data = lung)
+  p_on  <- ggforest(fit_num, data = lung)
+  p_off <- ggforest(fit_num, data = lung, ref.display = FALSE)
+  expect_setequal(forest_text(p_on), forest_text(p_off))
+})
+
+test_that("no-regression: ref.display = FALSE keeps a non-reference row whose CI is wide (#563)", {
+  # ph.ecog level 3 (N=1) has a very wide but finite interval -- a real estimate,
+  # not a reference -- so it must survive the drop.
+  p <- ggforest(fit, data = lung, ref.display = FALSE)
+  txt <- forest_text(p)
+  expect_true(any(grepl("7.06", txt)))   # ph.ecog level 3 hazard ratio
+})

--- a/tests/testthat/test-ggforest-ref-display.R
+++ b/tests/testthat/test-ggforest-ref-display.R
@@ -49,6 +49,22 @@ test_that("ref.display = FALSE does not drop continuous-only estimates (#563)", 
   expect_setequal(forest_text(p_on), forest_text(p_off))
 })
 
+test_that("ref.display = FALSE also drops aliased/non-estimable (NA-estimate) terms (#563)", {
+  # Documented behavior: the drop targets rows with no hazard ratio (NA estimate),
+  # which is a superset of factor baselines -- it also includes aliased/collinear
+  # terms that coxph sets to NA. These are already shown as "reference" in the
+  # default plot (they have no plottable HR), so dropping them is self-consistent.
+  d <- lung
+  d$age2 <- 2 * d$age                       # perfectly collinear -> coxph aliases it
+  fit_alias <- suppressWarnings(coxph(Surv(time, status) ~ age + age2, data = d))
+  # sanity: age2 is aliased to an NA estimate
+  expect_true(is.na(broom::tidy(fit_alias)$estimate[broom::tidy(fit_alias)$term == "age2"]))
+  # default shows it (as a "reference"-labelled row); ref.display = FALSE drops it
+  expect_true(any(grepl("reference", forest_text(suppressWarnings(ggforest(fit_alias, data = d))))))
+  expect_false(any(grepl("reference",
+                         forest_text(suppressWarnings(ggforest(fit_alias, data = d, ref.display = FALSE))))))
+})
+
 test_that("no-regression: ref.display = FALSE keeps a non-reference row whose CI is wide (#563)", {
   # ph.ecog level 3 (N=1) has a very wide but finite interval -- a real estimate,
   # not a reference -- so it must survive the drop.


### PR DESCRIPTION
Re-implements @trentleslie's #563. Adds a `ref.display` argument to `ggforest()`: set `ref.display = FALSE` to omit the reference-level rows of factor variables (baselines, which have no hazard ratio) from both the plot and the table, keeping only the compared levels — useful for compact panels.

## Behaviour
- Default `ref.display = TRUE` shows every level — **byte-identical to before** (the guard `if (!ref.display)` never fires).
- Reference rows are identified precisely by an `NA` estimate (a factor baseline). This is deliberate rather than a blanket `na.omit()`: a non-converged coefficient is `Inf`/huge, not `NA`, so genuine estimates (including wide-CI separation rows) are never dropped. The var label correctly moves to the first remaining level.

## Non-regression
- Regression tests added: default shows reference rows; `FALSE` drops them and still draws; continuous-only models are identical either way; a wide-CI non-reference row survives the drop.
- Full clean-session suite green; `tools::checkRd()` clean.

Contributed by @trentleslie (#563). Refs #563.