### PR TITLE
Let ggcoxzph() accept a coxph model directly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Minor changes
 
+- `ggcoxzph()` now accepts a `coxph` model directly (running `survival::cox.zph()` on it automatically), instead of only a pre-computed `cox.zph` object — `ggcoxzph(coxph_fit)` previously errored with "Can't handle an object of class coxph". Passing a `cox.zph` object is unchanged. Contributed by @DanChaltiel (#410).
+
 - `ggforest()` gains a `ref.display` argument. Set `ref.display = FALSE` to omit the rows that have no hazard ratio — factor baselines and any non-estimable/aliased or `strata()` terms (the rows labelled "reference") — from both the plot and the table, keeping only the estimated levels; useful for compact panels. Default is `TRUE` (every row shown, unchanged). Contributed by @trentleslie (#563).
 
 - `pairwise_survdiff()` now uses `anyNA()` for its internal missing-grouping-value check instead of a row-wise `NA %in% .row`, which is faster and clearer. Results are unchanged for the usual factor/character grouping variables; the only difference is a purely numeric grouping column containing `NaN`, whose row is now dropped as missing (previously it formed a spurious `"NaN"` group). Contributed by @MichaelChirico (#635).

--- a/R/ggcoxzph.R
+++ b/R/ggcoxzph.R
@@ -1,7 +1,9 @@
 #'Graphical Test of Proportional Hazards with ggplot2
 #'@description Displays a graph of the scaled Schoenfeld residuals, along with a
 #'  smooth curve using \pkg{ggplot2}. Wrapper around \link[survival]{plot.cox.zph}.
-#'@param fit an object of class \link[survival]{cox.zph}.
+#'@param fit an object of class \link[survival]{cox.zph}, or a
+#'  \link[survival]{coxph} model, in which case \code{\link[survival]{cox.zph}()}
+#'  is run on it automatically.
 #'@param resid	a logical value, if TRUE the residuals are included on the plot,
 #'  as well as the smooth fit.
 #'@param se a logical value, if TRUE, confidence bands at two standard errors
@@ -50,6 +52,11 @@ ggcoxzph <- function (fit, resid = TRUE, se = TRUE, df = 4, nsmo = 40, var,
                       ggtheme = theme_survminer(), ...){
 
   x <- fit
+  # Accept a coxph model directly and run the proportional-hazards test on it, so
+  # users don't have to call survival::cox.zph() first. A cox.zph object (the
+  # previous input) is not a coxph, so it takes the unchanged path (#410).
+  if(methods::is(x, "coxph"))
+    x <- survival::cox.zph(x)
   if(!methods::is(x, "cox.zph"))
     stop("Can't handle an object of class ", class(x))
 

--- a/man/ggcoxzph.Rd
+++ b/man/ggcoxzph.Rd
@@ -24,7 +24,9 @@ ggcoxzph(
 \method{print}{ggcoxzph}(x, ..., newpage = TRUE)
 }
 \arguments{
-\item{fit}{an object of class \link[survival]{cox.zph}.}
+\item{fit}{an object of class \link[survival]{cox.zph}, or a
+\link[survival]{coxph} model, in which case \code{\link[survival]{cox.zph}()} is
+run on it automatically.}
 
 \item{resid}{a logical value, if TRUE the residuals are included on the plot,
 as well as the smooth fit.}

--- a/tests/testthat/test-ggcoxzph-accept-coxph.R
+++ b/tests/testthat/test-ggcoxzph-accept-coxph.R
@@ -1,0 +1,40 @@
+context("ggcoxzph accepts a coxph object")
+
+# Regression test for #410: ggcoxzph() now accepts a coxph model directly and
+# runs survival::cox.zph() on it, instead of erroring "Can't handle an object of
+# class coxph". Passing a cox.zph object (the previous input) is unchanged.
+library(survival)
+
+fit <- coxph(Surv(futime, fustat) ~ age + ecog.ps + rx, data = ovarian)
+zph <- cox.zph(fit)
+
+drew_ok <- function(p) {
+  tmp <- tempfile(fileext = ".pdf"); grDevices::pdf(tmp)
+  on.exit({ grDevices::dev.off(); unlink(tmp) }, add = TRUE)
+  tryCatch({ print(p); TRUE }, error = function(e) FALSE)
+}
+
+test_that("ggcoxzph() accepts a coxph model (#410)", {
+  expect_error(p <- ggcoxzph(fit), NA)
+  expect_s3_class(p, "ggcoxzph")
+  expect_true(drew_ok(p))
+})
+
+test_that("a coxph model gives the same panels as its cox.zph (#410)", {
+  p_coxph <- ggcoxzph(fit)
+  p_zph   <- ggcoxzph(zph)
+  expect_identical(names(p_coxph), names(p_zph))
+  expect_identical(length(p_coxph), length(p_zph))
+})
+
+test_that("no-regression: a cox.zph object still works and is unchanged (#410)", {
+  # the coxph branch must not fire for a cox.zph input (it is not a coxph)
+  expect_false(methods::is(zph, "coxph"))
+  p <- ggcoxzph(zph)
+  expect_s3_class(p, "ggcoxzph")
+  expect_true(drew_ok(p))
+})
+
+test_that("a non-coxph, non-cox.zph object still errors clearly (#410)", {
+  expect_error(ggcoxzph(lm(1 ~ 1)), "Can't handle an object of class")
+})


### PR DESCRIPTION
Re-implements the core of @DanChaltiel's #410 (ggcoxzph part). `ggcoxzph()` now accepts a `coxph` model directly and runs `survival::cox.zph()` on it, instead of erroring `Can't handle an object of class coxph`. Users no longer need to call `cox.zph()` first.

## Behaviour
- `ggcoxzph(coxph_fit)` now works (previously errored).
- A `cox.zph` object — the previous input — is **not** a `coxph`, so it takes the unchanged path (byte-identical). Verified: a coxph and its explicit `cox.zph` produce the same panels.
- A non-coxph/non-cox.zph object still errors clearly.

## Scope
This is the safe, default-preserving core of #410. The other ideas in that PR — a \beta reference line on each Schoenfeld panel, `var_pval` filtering, `zph.transform` — are deferred as follow-ups (the \beta line adds a visual element with default colour/size choices worth deciding separately). Tracked on #410; credit to @DanChaltiel.

## Non-regression
- Regression tests added (coxph accepted; same panels as its cox.zph; cox.zph unchanged; clear error for other classes).
- Full clean-session suite green; `tools::checkRd()` clean.

Contributed by @DanChaltiel (#410). Refs #410.