### PR TITLE
Harden #521 test against a devtools search-path collision

### DIFF
--- a/tests/testthat/test-get-data-nonglobal-env.R
+++ b/tests/testthat/test-get-data-nonglobal-env.R
@@ -27,11 +27,11 @@ test_that("no-regression: global-scope fit still auto-extracts its data (#521)",
 test_that("non-global-env fit without data gives an actionable message (#521)", {
   envir <- new.env(parent = globalenv())
   evalq({
-    test <- lung
-    survival <- survfit(Surv(time, status) ~ 1, data = test)
+    dat521 <- lung
+    survival <- survfit(Surv(time, status) ~ 1, data = dat521)
   }, envir = envir)
   fit <- get("survival", envir = envir)
-  rm(envir)  # ensure the `test` object is truly out of scope
+  rm(envir)  # ensure the `dat521` object is truly out of scope
 
   msg <- tryCatch(suppressWarnings(survminer:::.get_data(fit)),
                   error = function(e) conditionMessage(e))
@@ -50,8 +50,8 @@ test_that("non-global-env fit without data gives an actionable message (#521)", 
 test_that("non-global-env fit works when data is supplied explicitly (#521)", {
   envir <- new.env(parent = globalenv())
   evalq({
-    test <- lung
-    survival <- survfit(Surv(time, status) ~ 1, data = test)
+    dat521 <- lung
+    survival <- survfit(Surv(time, status) ~ 1, data = dat521)
   }, envir = envir)
   fit <- get("survival", envir = envir)
   p <- ggsurvplot(fit, data = lung)


### PR DESCRIPTION
Test-only robustness fix (no package code changed).

`tests/testthat/test-get-data-nonglobal-env.R` named its data object `test`. When the suite is run with **`devtools` attached** (`library(devtools); devtools::test()`), `eval(fit$call$data)` resolves the symbol `test` to `devtools::test` on the search path instead of erroring, so `.get_data()` returns that function and the actionable-message assertion fails. Renaming the object to `dat521` removes the collision.

- Reproduced before: with `devtools` attached, the actionable-message block errored (`object must be a character vector, not a function`).
- After: passes both `--vanilla` (CI parity) and `devtools`-attached invocations (7/7).
- Unchanged under CI / `R CMD check` (they run `--vanilla`); full clean-session suite green.

Refs #521.