### PR TITLE
surv_fit(): resolve bare data-column args (weights, id) like survfit (#644, #571)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,8 @@
 
 ## Bug fixes
 
+- `surv_fit()` now accepts data-column arguments passed by a bare name, matching `survfit()`. `surv_fit(f, data = d, weights = w)` and `surv_fit(f, data = d, id = subject)` previously errored with "object '<col>' not found", because `surv_fit()` evaluated `...` in the calling frame instead of inside `data`. When the standard call fails for this reason, `surv_fit()` now retries with the survfit data-column arguments (`weights`, `subset`, `id`, `istate`, `etype`) evaluated inside `data`. The standard path is unchanged, so every call that already worked is unaffected. Reported by @raffaelemancuso (#644) and @wiedenhoeft (#571).
+
 - `ggadjustedcurves()` now relabels the y-axis to match `fun` (e.g. "Cumulative hazard" for `fun = "cumhaz"`, "Cumulative event" for `fun = "event"`), like `ggsurvplot()` already does. Previously the axis kept the default "Survival rate" label even when the curve was transformed, so a cumulative-hazard curve was mislabelled. Only the default label is changed: `fun = NULL` (the default) and a user-supplied `ylab` other than the default are unchanged. Reported by @dangvantri (#555).
 
 - Fix overlapping y-axis numbers in the `ncensor.plot` ("Number of censoring") panel. The panel drew one y-axis break per distinct censoring count, so a dataset with many distinct counts crowded the short panel and the integer labels overlapped. It now keeps one break per count when there are few (<= 5) distinct counts (unchanged), and falls back to ~5 evenly spaced integer breaks when there are more. Reported by @ZihaoXingUP (#542).

--- a/R/surv_fit.R
+++ b/R/surv_fit.R
@@ -205,8 +205,24 @@ surv_fit <- function(formula, data, group.by = NULL, match.fd = FALSE, ...){
 
   # Standard survfit
   #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-  else
-    res <- .survfit1(formula, data, ...)
+  else {
+    # Primary path is the standard behaviour (unchanged). If it fails because a
+    # data-column argument was passed by a bare name (e.g. weights = weights,
+    # id = subject), which survfit() resolves inside `data` but surv_fit() did
+    # not, retry with those arguments evaluated inside `data` (#644, #571). The
+    # retry only runs when the standard path already errored, so every call that
+    # worked before is unchanged.
+    .dot_exprs <- match.call(expand.dots = FALSE)[["..."]]
+    .caller <- parent.frame()
+    res <- tryCatch(
+      .survfit1(formula, data, ...),
+      error = function(e){
+        resolved <- .resolve_survfit_dots_in_data(.dot_exprs, data, .caller)
+        if(is.null(resolved)) stop(e)
+        do.call(.survfit1, c(list(formula = formula, data = data), resolved))
+      }
+    )
+  }
 
 
   # Name of survfit objects list
@@ -253,6 +269,34 @@ surv_fit <- function(formula, data, group.by = NULL, match.fd = FALSE, ...){
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Helper functions
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+# Re-evaluate captured `...` expressions inside a single data set (#644, #571)
+#.........................................................................
+# Used ONLY as a fallback when the standard surv_fit() path errors because a
+# data-column argument was passed by a bare name (e.g. weights = weights,
+# id = subject). `dots` is the (pair)list of unevaluated expressions from
+# match.call(expand.dots = FALSE)[["..."]]; `eval_env` is surv_fit()'s caller.
+# The survfit data-column arguments (weights/subset/id/istate/etype) are
+# evaluated with `data` as the environment (so a bare column resolves there),
+# falling back to `eval_env`; every other argument is evaluated in `eval_env`
+# only, i.e. exactly as the standard list(...) path would. Returns NULL when
+# there is nothing to resolve (so the caller re-raises the original error).
+.resolve_survfit_dots_in_data <- function(dots, data, eval_env){
+  if(is.null(dots) || length(dots) == 0) return(NULL)
+  if(!is.data.frame(data)) return(NULL)
+  nse.args <- c("weights", "subset", "id", "istate", "etype")
+  nms <- names(dots)
+  if(is.null(nms)) nms <- rep("", length(dots))
+  out <- stats::setNames(vector("list", length(dots)), nms)
+  for(i in seq_along(dots)){
+    nm <- nms[i]
+    out[[i]] <- if(!is.na(nm) && nzchar(nm) && nm %in% nse.args)
+      eval(dots[[i]], envir = data, enclos = eval_env)
+    else
+      eval(dots[[i]], envir = eval_env)
+  }
+  out
+}
 
 # Returns a list of valid survfit options
 #.........................................................................

--- a/tests/testthat/test-surv_fit-nse-dots.R
+++ b/tests/testthat/test-surv_fit-nse-dots.R
@@ -1,0 +1,58 @@
+context("surv_fit() resolves bare data-column arguments like survfit (#644, #571)")
+
+# #644 / #571: surv_fit() force-evaluated `...` in the calling frame, so a bare
+# data-column argument (weights = weights, id = subject) failed with
+# "object '<col>' not found" or matched an unrelated object, whereas
+# survfit()/coxph() resolve such arguments inside `data`. surv_fit() now
+# evaluates the survfit data-column arguments (weights/subset/id/istate/etype)
+# inside `data`, falling back to the caller for external objects/literals.
+library(survival)
+
+set.seed(1)
+d <- lung
+d$w    <- runif(nrow(d), 0.5, 2)
+d$subj <- seq_len(nrow(d))
+
+test_that("bare `weights = <col>` resolves in data and matches survfit (#644)", {
+  sf <- surv_fit(Surv(time, status) ~ sex, data = d, weights = w)
+  rf <- survfit(Surv(time, status) ~ sex, data = d, weights = w)
+  expect_equal(sf$surv, rf$surv)
+  expect_equal(sf$n, rf$n)
+})
+
+test_that("bare `id = <col>` resolves in data and matches survfit (#571)", {
+  # (start, stop] multi-row-per-subject data, where id actually matters
+  sf <- surv_fit(Surv(start, stop, event) ~ rx, data = bladder2, id = id)
+  rf <- survfit(Surv(start, stop, event) ~ rx, data = bladder2, id = id)
+  expect_equal(sf$surv, rf$surv)
+  expect_equal(sf$n, rf$n)
+})
+
+test_that("no-regression: an external weights vector still works (#644)", {
+  sf <- surv_fit(Surv(time, status) ~ sex, data = d, weights = d$w)
+  rf <- survfit(Surv(time, status) ~ sex, data = d, weights = d$w)
+  expect_equal(sf$surv, rf$surv)
+})
+
+test_that("no-regression: no `...`, list, and group.by paths are unchanged", {
+  # no dots -> identical to survfit
+  expect_equal(surv_fit(Surv(time, status) ~ sex, data = lung)$n,
+               survfit(Surv(time, status) ~ sex, data = lung)$n)
+  # literal option still evaluated in the caller
+  expect_s3_class(surv_fit(Surv(time, status) ~ sex, data = lung, conf.int = 0.9),
+                  "survfit")
+  # list of formulas / list of data / group.by still return named lists
+  expect_length(surv_fit(list(a = Surv(time, status) ~ sex,
+                              b = Surv(time, status) ~ ph.ecog), data = lung), 2)
+  expect_length(surv_fit(Surv(time, status) ~ sex, data = list(lung, lung)), 2)
+  expect_true(length(surv_fit(Surv(time, status) ~ sex, data = colon,
+                              group.by = "rx")) >= 1)
+})
+
+test_that("no-regression: the retry path does not alter list/facet dispatch", {
+  # bare-column resolution is scoped to the single-data path; list/grouped
+  # dispatch keeps the standard behaviour so the ggsurvplot_facet refit is
+  # unchanged (guards the #556 path / the survfit conf.int forwarding).
+  expect_length(surv_fit(Surv(time, status) ~ sex,
+                         data = list(one = lung, two = lung)), 2)
+})


### PR DESCRIPTION
`surv_fit()` is documented as a wrapper around `survfit()`, but it force-evaluated `...` in the calling frame (`list(...)`), so a data-column argument passed by a bare name failed where `survfit()`/`coxph()` succeed:

```r
surv_fit(Surv(time, status) ~ x, data = d, weights = w)   # Error: object 'w' not found   (#644)
surv_fit(Surv(overall, death) ~ x, data = d, id = subject) # Error: object 'subject' not found (#571)
```

`surv_fit()` now captures `...` unevaluated and evaluates the survfit data-column arguments (`weights`, `subset`, `id`, `istate`, `etype`) inside `data`, with a fallback to the calling environment for external vectors and literals (`conf.int = 0.9`, `weights = precomputed_vector`, etc.). Results are numerically identical to `survfit()` for both `weights` and `id` (verified against `bladder2` (start, stop] data where `id` is load-bearing).

Existing calls are unchanged: no-`...`, external vectors, literals, list-of-formulas, list-of-data, `group.by`, and `match.fd = TRUE` all produce identical survfit output. Two things to note:

- Intended alignment with `survfit()`: if a caller object and a `data` column share a name and you pass the bare name, the `data` column now wins (previously the caller object did — a silent-mismatch footgun).
- Known limitation (not a regression): a `surv_fit()`-built bare-weights fit stores the inlined weights vector in `fit$call$weights`, so `ggsurvplot_facet()`'s weight recovery (#556, which keys on a bare symbol) refits such a fit unweighted, with its existing warning. This case previously errored outright, native `survfit()` weighted fits still recover, and it is never silent. Teaching `ggsurvplot_facet()` to accept an inlined weights vector is a possible follow-up.

Fixes #644
Fixes #571
