### PR TITLE
Actionable message for an unrecoverable survfit formula symbol (#533)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,8 @@
 
 ## Bug fixes
 
+- `ggsurvplot()` now gives an actionable message instead of the cryptic "object of type 'symbol' is not subsettable" when a `survfit` was built from a formula stored in a variable in a non-global scope (e.g. `survfit(form, data)` inside a function, `lapply()`/`nest_by()`, or a `{targets}` pipeline), whose formula object is out of scope at plot time. The message points to `surv_fit()`, which retains the formula and data. Fits whose formula is recoverable are unchanged. Reported by @skent259 (#533).
+
 - `surv_fit()` now accepts data-column arguments passed by a bare name, matching `survfit()`. `surv_fit(f, data = d, weights = w)` and `surv_fit(f, data = d, id = subject)` previously errored with "object '<col>' not found", because `surv_fit()` evaluated `...` in the calling frame instead of inside `data`. When the standard call fails for this reason, `surv_fit()` now retries with the survfit data-column arguments (`weights`, `subset`, `id`, `istate`, `etype`) evaluated inside `data`. The standard path is unchanged, so every call that already worked is unaffected. Reported by @raffaelemancuso (#644) and @wiedenhoeft (#571).
 
 - `ggadjustedcurves()` now relabels the y-axis to match `fun` (e.g. "Cumulative hazard" for `fun = "cumhaz"`, "Cumulative event" for `fun = "event"`), like `ggsurvplot()` already does. Previously the axis kept the default "Survival rate" label even when the curve was transformed, so a cumulative-hazard curve was mislabelled. Only the default label is changed: `fun = NULL` (the default) and a user-supplied `ylab` other than the default are unchanged. Reported by @dangvantri (#555).

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -508,9 +508,30 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
   # formula stored in a variable (e.g. survfit(frm, data)); as.formula() then
   # fails with "object of type 'symbol' is not subsettable". stats::formula()
   # resolves it via survival's method; fall back to the old path if unavailable.
+  # If BOTH fail -- the formula variable was in a non-global scope (a function,
+  # lapply()/nest_by(), a {targets} pipeline) that is gone by plot time, and a
+  # survfit stores no reference to its creation environment -- raise an
+  # actionable message pointing to surv_fit() instead of the cryptic error
+  # (#533; symbol-formula cluster #324/#436).
   tryCatch(
     stats::formula(fit),
-    error = function(e) stats::as.formula(fit$call$formula)
+    error = function(e1) tryCatch(
+      stats::as.formula(fit$call$formula),
+      # e1 (from stats::formula) names the missing formula object, e.g.
+      # "object 'form' not found" -- more informative than e2's generic
+      # "object of type 'symbol' is not subsettable", so surface e1 as context.
+      error = function(e2) stop(
+        "The model formula could not be extracted from the survfit object. ",
+        "This happens when the model was fitted from a formula stored in a ",
+        "variable in a non-global environment (e.g. `survfit(form, data)` inside ",
+        "a function, `lapply()`/`nest_by()`, or a {targets} pipeline), whose ",
+        "formula object is out of scope at plot time. Build the fit with ",
+        "survminer's `surv_fit()` instead of `survival::survfit()` -- it retains ",
+        "the formula and data -- e.g. `surv_fit(form, data = data)`.\n",
+        "Original error: ", conditionMessage(e1),
+        call. = FALSE
+      )
+    )
   )
 }
 
@@ -627,10 +648,7 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
   if(inherits(fit, c("survfit.cox", "survfitcox")))
     return(list())
 
-  .formula <- tryCatch(
-    stats::formula(fit),
-    error = function(e) stats::as.formula(fit$call$formula)
-  )
+  .formula <- .get_fit_formula(fit)
   surv.obj <- deparse(.formula[[2]])
   surv.vars <- attr(stats::terms(.formula), "term.labels")
   data.all <- data <- .get_data(fit, data = data, complain = FALSE)

--- a/tests/testthat/test-fit-formula-symbol-message.R
+++ b/tests/testthat/test-fit-formula-symbol-message.R
@@ -1,0 +1,36 @@
+context("actionable message when a survfit formula can't be recovered (#533)")
+
+# #533: building survfit(form, data) with `form` a variable in a non-global
+# scope (function / lapply / nest_by / {targets}) leaves fit$call$formula as a
+# symbol that is out of scope at plot time. Extraction previously failed with
+# the cryptic "object of type 'symbol' is not subsettable". .get_fit_formula()
+# now raises an actionable message pointing to surv_fit(). Fits whose formula is
+# recoverable (inline formula, or built with surv_fit()) are unchanged.
+library(survival)
+
+test_that("gone-scope symbol formula gives an actionable message, not cryptic (#533)", {
+  mk  <- function() { f <- Surv(time, status) ~ sex; survfit(f, data = lung) }
+  fit <- mk()   # `f` is gone
+  expect_error(ggsurvplot(fit, data = lung),
+               "could not be extracted")
+  expect_error(ggsurvplot(fit, data = lung),
+               "surv_fit")
+  # the actionable guidance is what matters; the appended "Original error:"
+  # text is survival-version/locale dependent, so it is not asserted on.
+})
+
+test_that("no-regression: inline-formula fits recover the formula unchanged (#533)", {
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  f <- .get_fit_formula(fit)
+  expect_s3_class(f, "formula")
+  expect_identical(attr(stats::terms(f), "term.labels"), "sex")
+  # renders fine
+  expect_error(ggplot2::ggplot_build(ggsurvplot(fit, data = lung)$plot), NA)
+})
+
+test_that("no-regression: surv_fit() many-models pattern works (#533)", {
+  f  <- Surv(time, status) ~ sex
+  sf <- surv_fit(f, data = lung)                 # surv_fit retains the formula
+  expect_error(ggplot2::ggplot_build(ggsurvplot(sf, data = lung)$plot), NA)
+  expect_s3_class(.get_fit_formula(sf), "formula")
+})


### PR DESCRIPTION
Building `survfit(form, data)` with `form` a variable in a non-global scope (inside a function, `lapply()`/`nest_by()`, a `{targets}` pipeline) leaves `fit$call$formula` as an unevaluated symbol that is out of scope by plot time — and a `survfit` records no reference to its creation environment. Neither `stats::formula(fit)` nor `as.formula(fit$call$formula)` can then recover the formula, so `ggsurvplot()` failed with the cryptic `object of type 'symbol' is not subsettable` (#533).

`.get_fit_formula()` now raises an actionable message in that case, pointing to survminer's own `surv_fit()` (which retains the formula and data). `.extract.survfit()` reuses the same helper instead of its duplicated `tryCatch`.

```r
mk  <- function() { f <- Surv(time, status) ~ sex; survfit(f, data = lung) }
fit <- mk()
ggsurvplot(fit, data = lung)
#> Error: The model formula could not be extracted from the survfit object.
#> This happens when the model was fitted from a formula stored in a variable
#> in a non-global environment ... Build the fit with survminer's `surv_fit()`
#> instead of `survival::survfit()` ... Original error: object of type 'symbol' is not subsettable
```

The remedy works: using `surv_fit(f, data = lung)` in the same pattern renders. Fits whose formula is recoverable (inline formula, or built with `surv_fit()`) are byte-identical to before — the new message fires only on the path that already errored.

Refs #533
