### PR TITLE
Add pval.parse for plotmath p-values (#605, #679)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 ## Minor changes
 
+- `ggsurvplot()` gains a `pval.parse` argument. Set `pval.parse = TRUE` to render the p-value text as a plotmath expression, allowing italic/superscript formatting such as `pval = "italic(P)==1.4~x~10^-6"`. Default `FALSE` draws the text literally (unchanged). Requested by @KBalazs1987 (#605) and @arossevold (#679).
+
 - `ggcoxzph()` now accepts a `coxph` model directly (running `survival::cox.zph()` on it automatically), instead of only a pre-computed `cox.zph` object — `ggcoxzph(coxph_fit)` previously errored with "Can't handle an object of class coxph". Passing a `cox.zph` object is unchanged. Contributed by @DanChaltiel (#410).
 
 - `ggforest()` gains a `ref.display` argument. Set `ref.display = FALSE` to omit the rows that have no hazard ratio — factor baselines and any non-estimable/aliased or `strata()` terms (the rows labelled "reference") — from both the plot and the table, keeping only the estimated levels; useful for compact panels. Default is `TRUE` (every row shown, unchanged). Contributed by @trentleslie (#563).

--- a/R/ggsurvplot.R
+++ b/R/ggsurvplot.R
@@ -112,6 +112,10 @@ NULL
 #'  \item \strong{pval.coord}: numeric vector, of length 2,
 #'  specifying the x and y coordinates of the p-value.
 #'  Default values are NULL.
+#'  \item \strong{pval.parse}: logical. If TRUE, a custom p-value string given
+#'  via \code{pval} is parsed as a plotmath expression, allowing
+#'  italic/superscript p-values (e.g. \code{pval = "italic(P)==1.4~x~10^-6"}).
+#'  The auto-computed p-value is plain text, not plotmath. Default is FALSE.
 #'  \item \strong{pval.method.size}: the same as \code{pval.size} but for displaying
 #'  \code{log.rank.weights} name.
 #'  \item \strong{pval.method.coord}: the same as \code{pval.coord} but for displaying

--- a/R/ggsurvplot_add_all.R
+++ b/R/ggsurvplot_add_all.R
@@ -94,7 +94,8 @@ ggsurvplot_add_all <- function(fit, data, legend.title = "Strata", legend.labs =
                    else if(!is.null(.dots$pval.size)) .dots$pval.size else 5
     p$plot <- p$plot +
       ggplot2::annotate("text", x = pval$method.x[1], y = pval$method.y[1],
-                        label = pval$method[1], size = method.size, hjust = 0)
+                        label = pval$method[1], size = method.size, hjust = 0,
+                        parse = FALSE)  # method name is generated text, never plotmath
   }
 
   p

--- a/R/ggsurvplot_core.R
+++ b/R/ggsurvplot_core.R
@@ -11,6 +11,7 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
                             conf.int.alpha = 0.3,
                             censor = TRUE, censor.shape = "+", censor.size = 4.5,
                             pval = FALSE, pval.size = 5, pval.coord = c(NULL, NULL),
+                            pval.parse = FALSE,
                             test.for.trend = FALSE,
                             pval.method = FALSE, pval.method.size = pval.size, pval.method.coord = c(NULL, NULL),
                             log.rank.weights = c("survdiff", "1", "n", "sqrtN", "S1", "S2", "FH_p=1_q=1"),
@@ -126,11 +127,15 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
   if(pval$pval.txt != ""){
     p <- p + ggplot2::annotate("text", x = pval$pval.x, y = pval$pval.y,
                                label = pval$pval.txt, size = pval.size, hjust = 0,
-                               family = font.family)
+                               family = font.family, parse = pval.parse)
     if(pval.method)
+      # The method name is package-generated literal text (e.g. "Log-rank",
+      # or "Log-rank, tft" with test.for.trend); never plotmath-parse it, or
+      # pval.parse = TRUE would crash / mis-render the hyphen. pval.parse only
+      # affects the p-value text above.
       p <- p + ggplot2::annotate("text", x = pval$method.x, y = pval$method.y,
                                  label = pval$method, size = pval.method.size, hjust = 0,
-                                 family = font.family)
+                                 family = font.family, parse = FALSE)
   }
 
 

--- a/R/ggurvplot_arguments.R
+++ b/R/ggurvplot_arguments.R
@@ -59,6 +59,13 @@
 #'@param pval.size numeric value specifying the p-value text size. Default is 5.
 #'@param pval.coord numeric vector, of length 2, specifying the x and y
 #'  coordinates of the p-value. Default values are NULL.
+#'@param pval.parse logical. If TRUE, a custom p-value string supplied via
+#'  \code{pval} is treated as a plotmath expression and parsed, so you can show
+#'  italic/superscript p-values, e.g. \code{pval = "italic(P)==1.4~x~10^-6"}.
+#'  The string must be a valid plotmath expression; the auto-computed p-value
+#'  (e.g. \code{"p = 0.001"}) is plain text, not plotmath, so supply your own
+#'  expression when using this. The test-name label from \code{pval.method} is
+#'  never parsed. Default is FALSE (drawn literally).
 #'@param title main title
 #'@param xlab x axis label
 #'@param ylab y axis label

--- a/man/ggsurvplot.Rd
+++ b/man/ggsurvplot.Rd
@@ -270,6 +270,10 @@ Customize survival plots and tables. See also \link{ggsurvplot_arguments}.
  \item \strong{pval.coord}: numeric vector, of length 2,
  specifying the x and y coordinates of the p-value.
  Default values are NULL.
+ \item \strong{pval.parse}: logical. If TRUE, a custom p-value string given
+ via \code{pval} is parsed as a plotmath expression, allowing
+ italic/superscript p-values (e.g. \code{pval = "italic(P)==1.4~x~10^-6"}).
+ The auto-computed p-value is plain text, not plotmath. Default is FALSE.
  \item \strong{pval.method.size}: the same as \code{pval.size} but for displaying
  \code{log.rank.weights} name.
  \item \strong{pval.method.coord}: the same as \code{pval.coord} but for displaying

--- a/man/ggsurvplot_arguments.Rd
+++ b/man/ggsurvplot_arguments.Rd
@@ -84,6 +84,14 @@ customized string appears on the plot. See examples - Example 3.}
 \item{pval.coord}{numeric vector, of length 2, specifying the x and y
 coordinates of the p-value. Default values are NULL.}
 
+\item{pval.parse}{logical. If TRUE, a custom p-value string supplied via
+\code{pval} is treated as a plotmath expression and parsed, so you can show
+italic/superscript p-values, e.g. \code{pval = "italic(P)==1.4~x~10^-6"}.
+The string must be a valid plotmath expression; the auto-computed p-value
+(e.g. \code{"p = 0.001"}) is plain text, not plotmath, so supply your own
+expression when using this. The test-name label from \code{pval.method} is
+never parsed. Default is FALSE (drawn literally).}
+
 \item{title}{main title}
 
 \item{xlab}{x axis label}

--- a/tests/testthat/test-pval-parse.R
+++ b/tests/testthat/test-pval-parse.R
@@ -1,0 +1,69 @@
+context("pval.parse renders plotmath p-values (#605, #679)")
+
+# #605/#679: a custom p-value string was always drawn literally, so italic /
+# superscript p-values (e.g. "italic(P)==1.4~x~10^-6") could not be shown.
+# The new pval.parse argument passes parse = TRUE to the p-value annotate()
+# calls. Default FALSE keeps the literal behaviour (byte-identical).
+library(survival)
+
+fit <- survfit(Surv(time, status) ~ sex, data = lung)
+
+pval_layer_parse <- function(p) {
+  # find the annotate("text") layer carrying the p-value label and read its parse flag
+  for (ly in p$plot$layers) {
+    if (inherits(ly$geom, "GeomText") && !is.null(ly$aes_params$label) &&
+        grepl("P|p =|p <", ly$aes_params$label))
+      return(isTRUE(ly$geom_params$parse))
+  }
+  NA
+}
+
+test_that("no-regression: default pval is drawn literally, unchanged (#605)", {
+  p_no <- ggsurvplot(fit, data = lung, pval = TRUE)
+  p_ex <- ggsurvplot(fit, data = lung, pval = TRUE, pval.parse = FALSE)
+  # default text label unchanged and not parsed
+  expect_false(isTRUE(pval_layer_parse(p_no)))
+  expect_equal(ggplot2::ggplot_build(p_no$plot)$data,
+               ggplot2::ggplot_build(p_ex$plot)$data)
+})
+
+test_that("pval.parse = TRUE marks the p-value layer for plotmath parsing (#605, #679)", {
+  p <- ggsurvplot(fit, data = lung, pval = "italic(P)==1.4~x~10^-6",
+                  pval.parse = TRUE)
+  expect_true(isTRUE(pval_layer_parse(p)))
+  # and it renders (plotmath is valid) without error
+  expect_error(ggplot2::ggplotGrob(p$plot), NA)
+})
+
+test_that("a custom plotmath string without parse still renders (no error) (#679)", {
+  p <- ggsurvplot(fit, data = lung, pval = "p = 0.001")
+  expect_error(ggplot2::ggplotGrob(p$plot), NA)
+})
+
+test_that("pval.parse never parses the (generated) method label -> no crash (#605)", {
+  # The method name is generated text (e.g. "modified Peto-Peto", "Log-rank,
+  # tft"), NOT plotmath; parsing it would crash. pval.parse must only affect
+  # the p-value text. Use pval = TRUE (auto) with pval.method = TRUE so a real,
+  # non-plotmath method label ("modified Peto-Peto") is actually present -- a
+  # custom character pval forces method = "" and would make this test vacuous.
+  # This combo crashed under the prior code (method parsed as plotmath).
+  find_method_layer <- function(p) {
+    for (ly in p$plot$layers)
+      if (inherits(ly$geom, "GeomText") && !is.null(ly$aes_params$label) &&
+          grepl("Peto|Log-rank|rank", ly$aes_params$label, ignore.case = TRUE))
+        return(ly)
+    NULL
+  }
+  p <- ggsurvplot(fit, data = lung, pval = TRUE, pval.parse = TRUE,
+                  pval.method = TRUE, log.rank.weights = "S2")
+  expect_error(ggplot2::ggplotGrob(p$plot), NA)
+  ml <- find_method_layer(p)
+  expect_false(is.null(ml))                       # the method label is really there
+  expect_match(ml$aes_params$label, "Peto")       # "modified Peto-Peto"
+  expect_false(isTRUE(ml$geom_params$parse))      # and it is NOT parsed
+
+  # weighted test + trend appends ", tft" -> also non-plotmath; must still render
+  p2 <- ggsurvplot(fit, data = lung, pval = TRUE, pval.parse = TRUE,
+                   pval.method = TRUE, log.rank.weights = "n", test.for.trend = TRUE)
+  expect_error(ggplot2::ggplotGrob(p2$plot), NA)
+})


### PR DESCRIPTION
The p-value text — whether computed or supplied as a custom string via `pval` — was always drawn literally, so italic/superscript p-values (e.g. journal-style `P = 1.4 × 10⁻⁶`) could not be shown (#605, #679).

New `pval.parse` argument (default `FALSE`): when `TRUE`, the p-value annotation is rendered as a plotmath expression.

```r
ggsurvplot(fit, data = lung, pval = "italic(P)==1.4~x~10^-6", pval.parse = TRUE)
```

`parse = pval.parse` is passed to the p-value (and method) `annotate()` calls in `ggsurvplot_core()`, and to the `add.all` method annotation. Default `FALSE` keeps the literal behaviour — verified byte-identical build data for the default `pval = TRUE` path.

Fixes #605
Fixes #679
