### PR TITLE
Add var.labels to ggforest() for custom variable names (#405)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 ## Minor changes
 
+- `ggforest()` gains a `var.labels` argument to relabel the variable names shown in the plot, e.g. `var.labels = c(age = "Age (years)", sex = "Sex")`. Only names matching a model term are relabelled; unmatched terms keep their original name. Default `NULL` is unchanged. Requested by @PeterStrom (#405).
+
 - `ggsurvplot()` gains a `pval.parse` argument. Set `pval.parse = TRUE` to render the p-value text as a plotmath expression, allowing italic/superscript formatting such as `pval = "italic(P)==1.4~x~10^-6"`. Default `FALSE` draws the text literally (unchanged). Requested by @KBalazs1987 (#605) and @arossevold (#679).
 
 - `ggcoxzph()` now accepts a `coxph` model directly (running `survival::cox.zph()` on it automatically), instead of only a pre-computed `cox.zph` object — `ggcoxzph(coxph_fit)` previously errored with "Can't handle an object of class coxph". Passing a `cox.zph` object is unchanged. Contributed by @DanChaltiel (#410).

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -18,6 +18,11 @@
 #'   \code{strata()} terms, i.e. the rows labelled \code{refLabel} ("reference")
 #'   -- are omitted from both the plot and the table, keeping only the estimated
 #'   levels. Default TRUE shows every row (unchanged).
+#' @param var.labels a named character vector giving display labels for the
+#'   variable names, e.g. \code{c(age = "Age (years)", sex = "Sex")}. The names
+#'   must match the model term names (as shown in the plot by default); only
+#'   matched terms are relabelled, unmatched terms keep their original name.
+#'   Default \code{NULL} uses the term names unchanged.
 #'
 #' @return returns a ggplot2 object (invisibly)
 #'
@@ -50,7 +55,7 @@
 ggforest <- function(model, data = NULL,
   main = "Hazard ratio", cpositions=c(0.02, 0.22, 0.4),
   fontsize = 0.7, refLabel = "reference", noDigits=2,
-  global.stats = TRUE, ref.display = TRUE) {
+  global.stats = TRUE, ref.display = TRUE, var.labels = NULL) {
   conf.high <- conf.low <- estimate <- .row <- NULL
   stopifnot(inherits(model, "coxph"))
 
@@ -161,6 +166,24 @@ ggforest <- function(model, data = NULL,
     .undrawable(toShowExpClean$conf.low) | .undrawable(toShowExpClean$conf.high)
   nonfinite_terms <- unique(as.character(toShowExpClean$var)[toShowExpClean$.nonfinite])
   toShowExpClean$var = as.character(toShowExpClean$var)
+  # Optional user-supplied display labels for the variable names (#405). A named
+  # character vector mapping model term name -> label (e.g.
+  # c(age = "Age (years)", sex = "Sex")). Only names that match a term are
+  # remapped; unmatched terms keep their original name, so the default
+  # (var.labels = NULL) is unchanged.
+  if (!is.null(var.labels)) {
+    if (is.null(names(var.labels)))
+      stop("`var.labels` must be a named character vector, e.g. ",
+           "c(age = \"Age (years)\").", call. = FALSE)
+    # Coerce to a plain named character vector (a named factor would otherwise
+    # inject its integer codes; note `x[] <- as.character(x)` keeps a factor a
+    # factor, so rebuild explicitly); ignore NA labels so a variable name is
+    # never silently dropped.
+    var.labels <- stats::setNames(as.character(var.labels), names(var.labels))
+    .map <- var.labels[!is.na(var.labels)]
+    .hit <- toShowExpClean$var %in% names(.map)
+    toShowExpClean$var[.hit] <- .map[toShowExpClean$var[.hit]]
+  }
   toShowExpClean$var[duplicated(toShowExpClean$var)] = ""
   # make label strings:
   toShowExpClean$N <- paste0("(N=",toShowExpClean$N,")")

--- a/man/ggforest.Rd
+++ b/man/ggforest.Rd
@@ -13,7 +13,8 @@ ggforest(
   refLabel = "reference",
   noDigits = 2,
   global.stats = TRUE,
-  ref.display = TRUE
+  ref.display = TRUE,
+  var.labels = NULL
 )
 }
 \arguments{
@@ -42,6 +43,12 @@ no hazard ratio -- factor baselines, and any non-estimable / aliased or
 \code{strata()} terms, i.e. the rows labelled \code{refLabel} ("reference") --
 are omitted from both the plot and the table, keeping only the estimated levels.
 Default TRUE shows every row (unchanged).}
+
+\item{var.labels}{a named character vector giving display labels for the
+variable names, e.g. \code{c(age = "Age (years)", sex = "Sex")}. The names
+must match the model term names (as shown in the plot by default); only
+matched terms are relabelled, unmatched terms keep their original name.
+Default \code{NULL} uses the term names unchanged.}
 }
 \value{
 returns a ggplot2 object (invisibly)

--- a/tests/testthat/test-ggforest-var-labels.R
+++ b/tests/testthat/test-ggforest-var-labels.R
@@ -1,0 +1,70 @@
+context("ggforest var.labels custom variable names (#405)")
+
+# #405: ggforest() drew the raw model term names as the variable labels with no
+# way to rename them. A named `var.labels` vector now remaps them; NULL (default)
+# is unchanged, unmatched terms keep their original name.
+# ggforest() returns as_ggplot(gtable), so labels are baked into text grobs;
+# collect them by walking the grob tree.
+library(survival)
+
+fit <- coxph(Surv(time, status) ~ age + sex + ph.ecog, data = lung)
+
+grob_labels <- function(g) {
+  gt <- ggplot2::ggplotGrob(g)
+  out <- character(0)
+  walk <- function(x) {
+    if (!is.null(x$label)) out[[length(out) + 1L]] <<- paste(x$label, collapse = "|")
+    if (!is.null(x$children)) for (nm in names(x$children)) walk(x$children[[nm]])
+    if (!is.null(x$grobs))    for (k in seq_along(x$grobs)) walk(x$grobs[[k]])
+  }
+  walk(gt)
+  paste(out, collapse = " || ")
+}
+
+test_that("no-regression: default (var.labels = NULL) is byte-identical (#405)", {
+  expect_equal(ggplot2::ggplot_build(ggforest(fit, data = lung))$data,
+               ggplot2::ggplot_build(ggforest(fit, data = lung, var.labels = NULL))$data)
+})
+
+test_that("var.labels remaps the drawn variable names (#405)", {
+  g <- ggforest(fit, data = lung,
+                var.labels = c(age = "Age (years)", sex = "Sex", ph.ecog = "ECOG PS"))
+  labs <- grob_labels(g)
+  expect_true(grepl("Age (years)", labs, fixed = TRUE))
+  expect_true(grepl("ECOG PS", labs, fixed = TRUE))
+  # raw names no longer drawn as standalone variable labels
+  expect_false(grepl("(^|\\|)age(\\||$)", labs))
+  expect_false(grepl("(^|\\|)ph.ecog(\\||$)", labs))
+  expect_error(ggplot2::ggplotGrob(g), NA)
+})
+
+test_that("unmatched terms keep their original name; partial map works (#405)", {
+  g <- ggforest(fit, data = lung, var.labels = c(age = "Age (yrs)"))
+  labs <- grob_labels(g)
+  expect_true(grepl("Age (yrs)", labs, fixed = TRUE))   # remapped
+  expect_true(grepl("sex", labs))                        # untouched
+  expect_true(grepl("ph.ecog", labs, fixed = TRUE))      # untouched
+})
+
+test_that("var.labels must be a named vector (#405)", {
+  expect_error(ggforest(fit, data = lung, var.labels = c("Age", "Sex")),
+               "named")
+})
+
+test_that("a named factor var.labels is coerced to its labels, not codes (#405)", {
+  vl <- factor(c("Age (yrs)", "Sex"))          # named factor -> would inject 1/2
+  names(vl) <- c("age", "sex")
+  g <- ggforest(fit, data = lung, var.labels = vl)
+  labs <- grob_labels(g)
+  # labels present (not the integer codes 1/2 a raw factor->character coercion
+  # would have injected in their place)
+  expect_true(grepl("Age (yrs)", labs, fixed = TRUE))
+  expect_true(grepl("Sex", labs, fixed = TRUE))
+})
+
+test_that("an NA label leaves that variable name unchanged, not dropped (#405)", {
+  g <- ggforest(fit, data = lung, var.labels = c(age = NA, sex = "Sex"))
+  labs <- grob_labels(g)
+  expect_true(grepl("age", labs))     # age kept (NA label ignored)
+  expect_true(grepl("Sex", labs, fixed = TRUE))
+})


### PR DESCRIPTION
`ggforest()` drew the raw model term names as the variable labels, with no way to rename them (#405, requested by several users).

New `var.labels` argument — a named character vector mapping term name to display label:

```r
fit <- coxph(Surv(time, status) ~ age + sex + ph.ecog, data = lung)
ggforest(fit, data = lung,
         var.labels = c(age = "Age (years)", sex = "Sex", ph.ecog = "ECOG PS"))
```

Only names matching a model term are relabelled; unmatched terms keep their original name. Default `NULL` is byte-identical to before (verified). Single-file change in `R/ggforest.R` (remap applied to `toShowExpClean$var` before the duplicate-blanking that groups rows per variable).

Fixes #405
