### PR TITLE
Add ggtheme argument to ggforest() (#530)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 ## Minor changes
 
+- `ggforest()` gains a `ggtheme` argument to customize the plot's theme (e.g. `ggtheme = theme(text = element_text(size = 14))`). Because `ggforest()` returns a rasterised gtable, a theme added to the returned object was silently ignored; passing it via `ggtheme` applies it to the plot before rasterisation. Default `NULL` is unchanged. Reported by @manuSrep (#530).
+
 - `ggforest()` gains a `var.labels` argument to relabel the variable names shown in the plot, e.g. `var.labels = c(age = "Age (years)", sex = "Sex")`. Only names matching a model term are relabelled; unmatched terms keep their original name. Default `NULL` is unchanged. Requested by @PeterStrom (#405).
 
 - `ggsurvplot()` gains a `pval.parse` argument. Set `pval.parse = TRUE` to render the p-value text as a plotmath expression, allowing italic/superscript formatting such as `pval = "italic(P)==1.4~x~10^-6"`. Default `FALSE` draws the text literally (unchanged). Requested by @KBalazs1987 (#605) and @arossevold (#679).

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -23,6 +23,14 @@
 #'   must match the model term names (as shown in the plot by default); only
 #'   matched terms are relabelled, unmatched terms keep their original name.
 #'   Default \code{NULL} uses the term names unchanged.
+#' @param ggtheme a ggplot2 theme (e.g. the result of \code{theme(...)} or a
+#'   complete theme) applied to the forest plot. Because \code{ggforest()}
+#'   returns a rasterised \code{gtable}, a theme added to the returned object
+#'   has no effect; pass it here instead, e.g.
+#'   \code{ggtheme = theme(text = element_text(size = 14))}. It is added after
+#'   the built-in theme: a partial \code{theme(...)} overrides only the matching
+#'   elements, whereas a complete theme (e.g. \code{theme_void()}) replaces the
+#'   built-in look entirely. Default \code{NULL} leaves the appearance unchanged.
 #'
 #' @return returns a ggplot2 object (invisibly)
 #'
@@ -55,7 +63,8 @@
 ggforest <- function(model, data = NULL,
   main = "Hazard ratio", cpositions=c(0.02, 0.22, 0.4),
   fontsize = 0.7, refLabel = "reference", noDigits=2,
-  global.stats = TRUE, ref.display = TRUE, var.labels = NULL) {
+  global.stats = TRUE, ref.display = TRUE, var.labels = NULL,
+  ggtheme = NULL) {
   conf.high <- conf.low <- estimate <- .row <- NULL
   stopifnot(inherits(model, "coxph"))
 
@@ -317,6 +326,12 @@ ggforest <- function(model, data = NULL,
     # unchanged.
     scale_x_continuous(expand = expansion(mult = c(0.05, 0.05), add = c(1, 0))) +
     theme(plot.margin = grid::unit(c(0.5, 0.5, 1, 0.5), "lines"))
+  # Apply a user-supplied theme to the internal plot before it is rasterised
+  # into a gtable. ggforest() returns ggpubr::as_ggplot(gtable), so a theme
+  # added to the returned object cannot reach the inner text; passing it here
+  # via `ggtheme` does (#530). Added last so it overrides the built-in theme.
+  # Default NULL leaves the appearance unchanged.
+  if (!is.null(ggtheme)) p <- p + ggtheme
   # switch off clipping for p-vals, bottom annotation:
   gt <- ggplot_gtable(ggplot_build(p))
   gt$layout$clip[gt$layout$name == "panel"] <- "off"

--- a/man/ggforest.Rd
+++ b/man/ggforest.Rd
@@ -14,7 +14,8 @@ ggforest(
   noDigits = 2,
   global.stats = TRUE,
   ref.display = TRUE,
-  var.labels = NULL
+  var.labels = NULL,
+  ggtheme = NULL
 )
 }
 \arguments{
@@ -49,6 +50,15 @@ variable names, e.g. \code{c(age = "Age (years)", sex = "Sex")}. The names
 must match the model term names (as shown in the plot by default); only
 matched terms are relabelled, unmatched terms keep their original name.
 Default \code{NULL} uses the term names unchanged.}
+
+\item{ggtheme}{a ggplot2 theme (e.g. the result of \code{theme(...)} or a
+complete theme) applied to the forest plot. Because \code{ggforest()} returns
+a rasterised \code{gtable}, a theme added to the returned object has no effect;
+pass it here instead, e.g. \code{ggtheme = theme(text = element_text(size =
+14))}. It is added after the built-in theme: a partial \code{theme(...)}
+overrides only the matching elements, whereas a complete theme (e.g.
+\code{theme_void()}) replaces the built-in look entirely. Default \code{NULL}
+leaves the appearance unchanged.}
 }
 \value{
 returns a ggplot2 object (invisibly)

--- a/tests/testthat/test-ggforest-ggtheme.R
+++ b/tests/testthat/test-ggforest-ggtheme.R
@@ -1,0 +1,42 @@
+context("ggforest ggtheme argument (#530)")
+
+# #530: ggforest() returns as_ggplot(gtable), so a theme added to the returned
+# object is silently ignored. The new `ggtheme` argument applies a theme to the
+# internal plot before it is rasterised. Default NULL is unchanged.
+library(survival)
+
+fit <- coxph(Surv(time, status) ~ age + sex + ph.ecog, data = lung)
+
+# largest text-grob fontsize anywhere in the drawn plot
+max_text_size <- function(g) {
+  gt <- ggplot2::ggplotGrob(g)
+  sizes <- numeric(0)
+  walk <- function(x) {
+    if (inherits(x, "text") && !is.null(x$gp) && !is.null(x$gp$fontsize))
+      sizes <<- c(sizes, x$gp$fontsize)
+    if (!is.null(x$children)) for (nm in names(x$children)) walk(x$children[[nm]])
+    if (!is.null(x$grobs))    for (k in seq_along(x$grobs)) walk(x$grobs[[k]])
+  }
+  walk(gt)
+  max(sizes, na.rm = TRUE)
+}
+
+test_that("no-regression: default (ggtheme = NULL) is byte-identical (#530)", {
+  expect_equal(ggplot2::ggplot_build(ggforest(fit, data = lung))$data,
+               ggplot2::ggplot_build(ggforest(fit, data = lung, ggtheme = NULL))$data)
+})
+
+test_that("ggtheme reaches the internal plot text (#530)", {
+  base   <- max_text_size(ggforest(fit, data = lung))
+  themed <- max_text_size(ggforest(fit, data = lung,
+                          ggtheme = ggplot2::theme(text = ggplot2::element_text(size = 40))))
+  expect_gt(themed, base)                 # the big text theme actually took effect
+})
+
+test_that("ggtheme builds without error and NULL default renders (#530)", {
+  expect_error(ggplot2::ggplotGrob(
+    ggforest(fit, data = lung,
+             ggtheme = ggplot2::theme(plot.background =
+               ggplot2::element_rect(fill = "lightyellow")))), NA)
+  expect_error(ggplot2::ggplotGrob(ggforest(fit, data = lung)), NA)
+})


### PR DESCRIPTION
`ggforest()` returns `ggpubr::as_ggplot(gtable)`, so a theme added to the returned object (`ggforest(fit) + theme(...)`) is silently ignored — the text lives in an already-rasterised gtable (#530).

New `ggtheme` argument applies a theme to the internal plot **before** it is rasterised:

```r
fit <- coxph(Surv(time, status) ~ age + sex + ph.ecog, data = lung)
ggforest(fit, data = lung, ggtheme = theme(text = element_text(size = 14)))
```

It is added after the built-in theme, so it overrides matching elements. Default `NULL` is byte-identical to before (verified). Single-file change in `R/ggforest.R`.

Fixes #530
