### PR TITLE
Fix ggforest() dropping interaction terms (#536)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,8 @@
 
 ## Bug fixes
 
+- Fix `ggforest()` silently dropping interaction terms. Only main-effect variables were iterated (`attr(model$terms, "dataClasses")`), so a model with an interaction (e.g. `Surv(time, status) ~ sex * ph.ecog`) omitted the interaction coefficients (`sexfemale:ph.ecog1`, ...) from both the plot and the table. Each interaction coefficient is now drawn as its own row, mapped to the fitted coefficients via `model$assign`. Models without interactions are unchanged. Reported by @Generalized (#536).
+
 - `ggsurvplot()` now gives an actionable message instead of the cryptic "object of type 'symbol' is not subsettable" when a `survfit` was built from a formula stored in a variable in a non-global scope (e.g. `survfit(form, data)` inside a function, `lapply()`/`nest_by()`, or a `{targets}` pipeline), whose formula object is out of scope at plot time. The message points to `surv_fit()`, which retains the formula and data. Fits whose formula is recoverable are unchanged. Reported by @skent259 (#533).
 
 - `surv_fit()` now accepts data-column arguments passed by a bare name, matching `survfit()`. `surv_fit(f, data = d, weights = w)` and `surv_fit(f, data = d, id = subject)` previously errored with "object '<col>' not found", because `surv_fit()` evaluated `...` in the calling frame instead of inside `data`. When the standard call fails for this reason, `surv_fit()` now retries with the survfit data-column arguments (`weights`, `subset`, `id`, `istate`, `etype`) evaluated inside `data`. The standard path is unchanged, so every call that already worked is unaffected. Reported by @raffaelemancuso (#644) and @wiedenhoeft (#571).

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -123,6 +123,21 @@ ggforest <- function(model, data = NULL,
                  pos = seq_along(vars))
     }
   })
+  # attr(model$terms, "dataClasses") lists only main-effect variables, so
+  # interaction terms (e.g. sex:ph.ecog) were never visited by the loop above
+  # and their coefficients were silently dropped from the plot and table (#536).
+  # Add each interaction coefficient as its own row, mapped to the fitted
+  # coefficients via model$assign (the same reliable mechanism used for
+  # multi-coefficient terms above). Models with no interaction terms are
+  # unaffected: .inter.terms is empty, so allTerms is unchanged.
+  .inter.terms <- grep(":", names(model$assign), value = TRUE, fixed = TRUE)
+  if (length(.inter.terms) > 0) {
+    allTerms <- c(allTerms, lapply(.inter.terms, function(term){
+      idx <- model$assign[[term]]
+      vars <- coef$term[idx]
+      data.frame(var = vars, Var1 = "", Freq = nrow(data), pos = seq_along(vars))
+    }))
+  }
   allTermsDF <- do.call(rbind, allTerms)
   colnames(allTermsDF) <- c("var", "level", "N", "pos")
   inds <- apply(allTermsDF[,1:2], 1, paste0, collapse="")

--- a/tests/testthat/test-ggforest-interactions.R
+++ b/tests/testthat/test-ggforest-interactions.R
@@ -1,0 +1,52 @@
+context("ggforest draws interaction-term rows (#536)")
+
+# #536: ggforest() iterated only over main-effect variables
+# (attr(model$terms, "dataClasses")), so interaction terms (sex:ph.ecog) were
+# silently dropped -- their coefficients never appeared in the plot or table.
+# Interaction coefficients are now added as rows, mapped via model$assign.
+# Models without interactions are unchanged.
+library(survival)
+library(broom)
+
+d <- lung
+d$sex <- factor(d$sex, labels = c("male", "female"))
+d <- subset(d, !is.na(ph.ecog) & ph.ecog != 3)
+d$ph.ecog <- factor(d$ph.ecog)
+
+grob_labels <- function(g) {
+  gt <- ggplot2::ggplotGrob(g)
+  out <- character(0)
+  walk <- function(x) {
+    if (!is.null(x$label)) out[[length(out) + 1L]] <<- paste(x$label, collapse = "|")
+    if (!is.null(x$children)) for (nm in names(x$children)) walk(x$children[[nm]])
+    if (!is.null(x$grobs))    for (k in seq_along(x$grobs)) walk(x$grobs[[k]])
+  }
+  walk(gt)
+  paste(out, collapse = " || ")
+}
+
+test_that("factor:factor interaction coefficients are drawn (#536)", {
+  fit  <- coxph(Surv(time, status) ~ sex * ph.ecog, data = d)
+  labs <- grob_labels(ggforest(fit, data = d))
+  expect_true(grepl("sexfemale:ph.ecog1", labs, fixed = TRUE))
+  expect_true(grepl("sexfemale:ph.ecog2", labs, fixed = TRUE))
+})
+
+test_that("numeric:factor and 3-way interactions render (#536)", {
+  expect_true(grepl("age:sexfemale",
+              grob_labels(ggforest(coxph(Surv(time, status) ~ age * sex, data = d), data = d)),
+              fixed = TRUE))
+  d3 <- d; d3$adh <- factor(ifelse(seq_len(nrow(d3)) %% 2 == 0, "y", "n"))
+  expect_error(ggplot2::ggplotGrob(
+    ggforest(coxph(Surv(time, status) ~ sex * ph.ecog * adh, data = d3), data = d3)), NA)
+})
+
+test_that("no-regression: a model without interactions is unchanged (#536)", {
+  fit_main <- coxph(Surv(time, status) ~ age + sex + ph.ecog, data = d)
+  labs <- grob_labels(ggforest(fit_main, data = d))
+  # no interaction-coefficient rows (an interaction label is alnum:alnum, which
+  # the caption's "test): 3.4e-05" / "Index: 0.64" colons never match)
+  expect_false(grepl("[[:alnum:]]:[[:alnum:]]", labs))
+  expect_true(grepl("ph.ecog", labs, fixed = TRUE))
+  expect_error(ggplot2::ggplotGrob(ggforest(fit_main, data = d)), NA)
+})


### PR DESCRIPTION
`ggforest()` iterated only over main-effect variables (`attr(model$terms, "dataClasses")`), so a model with an interaction silently dropped the interaction coefficients from both the plot and the table:

```r
fit <- coxph(Surv(time, status) ~ sex * ph.ecog, data = d)   # 5 coefficients
ggforest(fit, data = d)   # before: only sex + ph.ecog main effects drawn
```

Each interaction coefficient is now added as its own row, mapped to the fitted coefficients via `model$assign` (the same reliable mechanism the existing multi-coefficient path uses). Verified for factor:factor, numeric:factor, and 3-way interactions; interaction rows show their HR/CI/p.

Non-regression: for a model with no interaction terms, `grep(":", names(model$assign))` is empty, so the added block is a no-op — output is byte-identical (confirmed against master via `ggplot_build` for main-effect models).

This changes the drawn output for interaction models (previously incomplete) — a correctness fix, done with maintainer sign-off.

Fixes #536
