### PR TITLE
Allow break.time.by to be a vector of custom breaks (#695, #435)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 ## Minor changes
 
+- `break.time.by` (and its alias `break.x.by`) now accepts a numeric vector of custom break positions, e.g. `break.time.by = c(0, 100, 300, 600, 1000)`, in addition to a single step. Passing a vector previously errored (`'by' must be of length 1`). The same breaks drive the survival curve and the number-at-risk/censor tables, so they stay aligned. A single value is unchanged. Requested in #435 and by @AjayKumar-O (#695).
+
 - `ggforest()` gains a `ggtheme` argument to customize the plot's theme (e.g. `ggtheme = theme(text = element_text(size = 14))`). Because `ggforest()` returns a rasterised gtable, a theme added to the returned object was silently ignored; passing it via `ggtheme` applies it to the plot before rasterisation. Default `NULL` is unchanged. Reported by @manuSrep (#530).
 
 - `ggforest()` gains a `var.labels` argument to relabel the variable names shown in the plot, e.g. `var.labels = c(age = "Age (years)", sex = "Sex")`. Only names matching a model term are relabelled; unmatched terms keep their original name. Default `NULL` is unchanged. Requested by @PeterStrom (#405).

--- a/R/ggsurvplot.R
+++ b/R/ggsurvplot.R
@@ -79,10 +79,12 @@ NULL
 #'
 #'@section Axis limits, breaks and scales:
 #'\itemize{
-#' \item \strong{break.time.by}: numeric value controlling time axis breaks. Default value
-#'  is NULL.
-#'  \item \strong{break.x.by}: alias of break.time.by. Numeric value controlling x axis
-#'  breaks. Default value is NULL.
+#' \item \strong{break.time.by}: numeric value controlling time axis breaks. A
+#'  single value gives regularly spaced breaks; a numeric vector is used as the
+#'  exact break positions (e.g. \code{c(0, 100, 300, 600)}), keeping the curve
+#'  and the risk/censor tables aligned. Default value is NULL.
+#'  \item \strong{break.x.by}: alias of break.time.by. Numeric value (or vector)
+#'  controlling x axis breaks. Default value is NULL.
 #'  \item \strong{break.y.by}: same as break.x.by but for y axis.
 #'  \item \strong{surv.scale}: scale transformation of survival curves. Allowed values are
 #'  "default" or "percent".

--- a/R/ggsurvplot_df.R
+++ b/R/ggsurvplot_df.R
@@ -235,7 +235,7 @@ ggsurvplot_df <- function(fit, fun = NULL,
   times <- .get_default_breaks(df$time, .log = xlog)
 
   if(!is.null(break.time.by) & !xlog)
-    times <- seq(0, max(c(df$time, xlim)), by = break.time.by)
+    times <- .time_breaks(break.time.by, max(c(df$time, xlim)))
 
   xticklabels <- .format_xticklabels(labels = times, xscale = xscale)
 

--- a/R/ggsurvtable.R
+++ b/R/ggsurvtable.R
@@ -110,7 +110,7 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
   xmin <- ifelse(xlog, min(c(1, fit$time)), min(c(0, fit$time), na.rm = TRUE))
   if(is.null(xlim)) xlim <- c(xmin, max(fit$time))
   times <- .get_default_breaks(fit$time, .log = xlog)
-  if(!is.null(break.time.by) &!xlog) times <- seq(0, max(c(fit$time, xlim)), by = break.time.by)
+  if(!is.null(break.time.by) &!xlog) times <- .time_breaks(break.time.by, max(c(fit$time, xlim)))
 
 
 

--- a/R/ggurvplot_arguments.R
+++ b/R/ggurvplot_arguments.R
@@ -36,10 +36,13 @@
 #'@param linetype line types. Allowed values includes i) "strata" for changing
 #'  linetypes by strata (i.e. groups); ii) a numeric vector (e.g., c(1, 2)) or a
 #'  character vector c("solid", "dashed").
-#'@param break.time.by numeric value controlling time axis breaks. Default value
-#'  is NULL.
-#'@param break.x.by alias of break.time.by. Numeric value controlling x axis
-#'  breaks. Default value is NULL.
+#'@param break.time.by numeric value controlling time axis breaks. A single
+#'  value gives regularly spaced breaks (from 0 by that step); a numeric vector
+#'  is used as the exact break positions (e.g. \code{c(0, 100, 300, 600)}),
+#'  which also keeps the survival curve and the risk/censor tables aligned.
+#'  Default value is NULL.
+#'@param break.x.by alias of break.time.by. Numeric value (or vector) controlling
+#'  x axis breaks. Default value is NULL.
 #'@param break.y.by same as break.x.by but for y axis.
 #'@param conf.int logical value. If TRUE, plots confidence interval.
 #'@param conf.int.fill fill color to be used for confidence interval.

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -572,6 +572,17 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
 }
 
 
+# Time-axis breaks for the survival plot and the risk/censor tables (#695, #435)
+#.........................................................................
+# `break.time.by` may be a single numeric step (regular breaks from 0, the
+# historical behaviour) OR a numeric vector of explicit break positions, used
+# as-is. Using the same value for the curve and the tables keeps their x-axes
+# aligned. A length-1 value reproduces the old seq() output exactly.
+.time_breaks <- function(break.time.by, max.time){
+  if (length(break.time.by) > 1) sort(unique(break.time.by))
+  else seq(0, max.time, by = break.time.by)
+}
+
 # Y-axis breaks for the number-of-censoring panel (ncensor.plot) (#542)
 #.........................................................................
 # One break per distinct censoring count crowds the short panel: with many

--- a/man/ggsurvplot.Rd
+++ b/man/ggsurvplot.Rd
@@ -234,10 +234,12 @@ Customize survival plots and tables. See also \link{ggsurvplot_arguments}.
 \section{Axis limits, breaks and scales}{
 
 \itemize{
-\item \strong{break.time.by}: numeric value controlling time axis breaks. Default value
- is NULL.
- \item \strong{break.x.by}: alias of break.time.by. Numeric value controlling x axis
- breaks. Default value is NULL.
+\item \strong{break.time.by}: numeric value controlling time axis breaks. A
+ single value gives regularly spaced breaks; a numeric vector is used as the
+ exact break positions (e.g. \code{c(0, 100, 300, 600)}), keeping the curve
+ and the risk/censor tables aligned. Default value is NULL.
+ \item \strong{break.x.by}: alias of break.time.by. Numeric value (or vector)
+ controlling x axis breaks. Default value is NULL.
  \item \strong{break.y.by}: same as break.x.by but for y axis.
  \item \strong{surv.scale}: scale transformation of survival curves. Allowed values are
  "default" or "percent".

--- a/man/ggsurvplot_arguments.Rd
+++ b/man/ggsurvplot_arguments.Rd
@@ -48,11 +48,14 @@ function \link[grDevices]{palette}.}
 linetypes by strata (i.e. groups); ii) a numeric vector (e.g., c(1, 2)) or a
 character vector c("solid", "dashed").}
 
-\item{break.time.by}{numeric value controlling time axis breaks. Default value
+\item{break.time.by}{numeric value controlling time axis breaks. A single
+value gives regularly spaced breaks (from 0 by that step); a numeric vector
+is used as the exact break positions (e.g. \code{c(0, 100, 300, 600)}), which
+also keeps the survival curve and the risk/censor tables aligned. Default value
 is NULL.}
 
-\item{break.x.by}{alias of break.time.by. Numeric value controlling x axis
-breaks. Default value is NULL.}
+\item{break.x.by}{alias of break.time.by. Numeric value (or vector) controlling
+x axis breaks. Default value is NULL.}
 
 \item{break.y.by}{same as break.x.by but for y axis.}
 

--- a/tests/testthat/test-vector-break-time-by.R
+++ b/tests/testthat/test-vector-break-time-by.R
@@ -1,0 +1,41 @@
+context("break.time.by accepts a vector of custom breaks (#695, #435)")
+
+# #435 / #695: break.time.by only accepted a single step (seq(0, max, by=)),
+# so a vector of custom time points errored ("'by' must be of length 1"), and a
+# custom scale_x_continuous(breaks=) on $plot never reached the risk table
+# (misalignment). break.time.by now accepts a vector, used as-is for both the
+# curve and the tables. A single value is unchanged.
+library(survival)
+
+fit <- survfit(Surv(time, status) ~ sex, data = lung)
+
+built_x_breaks <- function(p) {
+  b <- ggplot2::ggplot_build(p)$layout$panel_params[[1]]$x$get_breaks()
+  sort(b[!is.na(b)])
+}
+
+test_that("a vector break.time.by sets the exact plot breaks (#435)", {
+  brks <- c(0, 100, 300, 600, 1000)
+  p <- ggsurvplot(fit, data = lung, break.time.by = brks)
+  expect_equal(built_x_breaks(p$plot), brks)
+})
+
+test_that("the risk table uses the same custom breaks -> aligned (#695)", {
+  brks <- c(0, 100, 300, 600, 1000)
+  p <- ggsurvplot(fit, data = lung, risk.table = TRUE, break.time.by = brks)
+  expect_equal(built_x_breaks(p$plot), built_x_breaks(p$table))
+  expect_error(ggplot2::ggplotGrob(p$table), NA)
+})
+
+test_that("break.x.by (alias) also accepts a vector (#695)", {
+  brks <- c(0, 250, 750)
+  p <- ggsurvplot(fit, data = lung, break.x.by = brks)
+  expect_equal(built_x_breaks(p$plot), brks)
+})
+
+test_that("no-regression: a single break.time.by is unchanged (#435)", {
+  # helper: length-1 reproduces seq(0, max, by=)
+  expect_equal(.time_breaks(250, 1000), seq(0, 1000, by = 250))
+  p <- ggsurvplot(fit, data = lung, break.time.by = 250)
+  expect_true(all(c(0, 250, 500, 750, 1000) %in% built_x_breaks(p$plot)))
+})


### PR DESCRIPTION
`break.time.by` only accepted a single step (used as `seq(0, max, by = break.time.by)`), so:
- a vector of custom time points errored with `'by' must be of length 1` (#435), and
- setting custom breaks another way (e.g. `scale_x_continuous(breaks=)` on `$plot`) never reached the risk table, so the curve and table x-axes misaligned (#695).

`break.time.by` (and its alias `break.x.by`) now accepts a numeric vector of exact break positions:

```r
ggsurvplot(fit, data = lung, risk.table = TRUE,
           break.time.by = c(0, 100, 300, 600, 1000))
```

A new helper `.time_breaks()` uses a length>1 value as the breaks for **both** the curve and the number-at-risk/censor tables, so they stay aligned. A single value reproduces the old `seq()` output (byte-identical, verified against master for the plot, default, and risk-table build data).

Fixes #435
Fixes #695
