### PR TITLE
Support percentage in cumevents/cumcensor tables (#499)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 ## Minor changes
 
+- `cumevents` and `cumcensor` now accept a character value ("absolute", "percentage", "abs_pct"), like `risk.table`, to show the cumulative events/censoring table as a percentage of the stratum size (or "count (percent)"), not only the absolute count. `TRUE`/`FALSE` are unchanged (absolute). The default table title reflects the type. Requested by @anarpkpd (#499).
+
 - `break.time.by` (and its alias `break.x.by`) now accepts a numeric vector of custom break positions, e.g. `break.time.by = c(0, 100, 300, 600, 1000)`, in addition to a single step. Passing a vector previously errored (`'by' must be of length 1`). The same breaks drive the survival curve and the number-at-risk/censor tables, so they stay aligned. A single value is unchanged. Requested in #435 and by @AjayKumar-O (#695).
 
 - `ggforest()` gains a `ggtheme` argument to customize the plot's theme (e.g. `ggtheme = theme(text = element_text(size = 14))`). Because `ggforest()` returns a rasterised gtable, a theme added to the returned object was silently ignored; passing it via `ggtheme` applies it to the plot before rasterisation. Default `NULL` is unchanged. Reported by @manuSrep (#530).

--- a/R/ggsurvplot_core.R
+++ b/R/ggsurvplot_core.R
@@ -47,6 +47,17 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
   stopifnot(log.rank.weights %in% c("survdiff", "1", "n", "sqrtN", "S1", "S2","FH_p=1_q=1"))
   log.rank.weights <- match.arg(log.rank.weights)
 
+  # cumevents / cumcensor accept the same values as risk.table: TRUE/FALSE, or a
+  # character ("absolute", "percentage", "abs_pct") selecting how the cumulative
+  # count is displayed (#499). Parse to a logical display flag + a type; logical
+  # inputs keep type "absolute" (the raw count), so existing calls are unchanged.
+  cumev.parsed <- .parse_risk_table_arg(cumevents)
+  cumevents <- cumev.parsed$display
+  cumevents.type <- cumev.parsed$type
+  cumcens.parsed <- .parse_risk_table_arg(cumcensor)
+  cumcensor <- cumcens.parsed$display
+  cumcensor.type <- cumcens.parsed$type
+
   # Make sure that user can do either ncensor.plot or cumcensor
   # But not both
   if(ncensor.plot & cumcensor){
@@ -57,10 +68,18 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
   if(cumcensor) ncensor.plot.height <- cumcensor.height
   if(is.null(ncensor.plot.title))
     ncensor.plot.title <- "Number of censoring"
+  # Default table titles reflect the display type so a percentage table is not
+  # labelled "number of ..." (#499). A user-supplied title is kept as-is.
   if(is.null(cumcensor.title))
-    cumcensor.title <- "Cumulative number of censoring"
+    cumcensor.title <- switch(cumcensor.type,
+      percentage = "Cumulative censoring (%)",
+      abs_pct    = "Cumulative censoring: n (%)",
+      "Cumulative number of censoring")
   if(is.null(cumevents.title))
-    cumevents.title <- "Cumulative number of events"
+    cumevents.title <- switch(cumevents.type,
+      percentage = "Cumulative events (%)",
+      abs_pct    = "Cumulative events: n (%)",
+      "Cumulative number of events")
 
   # risk.table argument
   risk.table.pos <- match.arg(risk.table.pos)
@@ -200,6 +219,7 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
     if(cumevents.y.text.col) pms$y.text.col <- scurve_cols
     pms$fontsize <- fontsize
     pms$survtable <- "cumevents"
+    pms$risk.table.type <- cumevents.type   # absolute (default) / percentage / abs_pct (#499)
     pms$origin.align <- TRUE   # always laid out "out"; align t=0 to the origin
     res$cumevents <- do.call(ggsurvtable, pms)
   }
@@ -247,6 +267,7 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
     #pms$y.text.col <- cumcensor.y.text.col
     pms$fontsize <- fontsize
     pms$survtable <- "cumcensor"
+    pms$risk.table.type <- cumcensor.type   # absolute (default) / percentage / abs_pct (#499)
     pms$origin.align <- TRUE   # always laid out "out"; align t=0 to the origin
     ncensor_plot  <- do.call(ggsurvtable, pms)
   }

--- a/R/ggsurvtable.R
+++ b/R/ggsurvtable.R
@@ -257,17 +257,31 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
     # literally, so no escaping is needed (and would show "&gt;").
     yticklabs <- .escape_markdown(yticklabs)
 
-  time <- strata <- label <- n.event <- cum.n.event  <- cum.n.censor<- NULL
+  time <- strata <- label <- n.event <- cum.n.event  <- cum.n.censor<- .cumlabel <- NULL
+
+  # cumevents / cumcensor tables honour risk.table.type: "absolute" (default,
+  # the raw cumulative count, unchanged), "percentage" (count as a percent of
+  # the stratum size), or "abs_pct" ("count (pct)") (#499). The other risk-table
+  # types (nrisk_*) have no cumulative meaning and fall back to the count.
+  .cum_pct <- function(count) round(count / survsummary$strata_size * 100)
 
   # Ploting the cumulative number of events table
   #:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   if(survtable == "cumevents"){
+    survsummary$.cumlabel <- switch(risk.table.type,
+      percentage = .cum_pct(survsummary$cum.n.event),
+      abs_pct    = paste0(survsummary$cum.n.event, " (", .cum_pct(survsummary$cum.n.event), ")"),
+      survsummary$cum.n.event)
     mapping <- aes(x = time, y = rev(strata),
-                   label = cum.n.event, shape = rev(strata))
+                   label = .cumlabel, shape = rev(strata))
   }
   else if (survtable == "cumcensor"){
+    survsummary$.cumlabel <- switch(risk.table.type,
+      percentage = .cum_pct(survsummary$cum.n.censor),
+      abs_pct    = paste0(survsummary$cum.n.censor, " (", .cum_pct(survsummary$cum.n.censor), ")"),
+      survsummary$cum.n.censor)
     mapping <- aes(x = time, y = rev(strata),
-                   label = cum.n.censor, shape = rev(strata))
+                   label = .cumlabel, shape = rev(strata))
 
   }
   else if (survtable == "risk.table"){

--- a/R/ggurvplot_arguments.R
+++ b/R/ggurvplot_arguments.R
@@ -127,7 +127,9 @@
 #'@param ncensor.plot.height The height of the censor plot. Used when
 #'  \code{ncensor.plot = TRUE}.
 #'@param cumevents logical value specifying whether to show or not the table of
-#'  the cumulative number of events. Default is FALSE.
+#'  the cumulative number of events. Default is FALSE. Can also be a character
+#'  string ("absolute", "percentage" or "abs_pct"); "percentage" shows the count
+#'  as a percent of the stratum size.
 #'@param cumevents.title The title to be used for the cumulative events table.
 #'@param cumevents.col same as tables.col but for the cumulative events table
 #'  only.
@@ -138,7 +140,8 @@
 #'@param cumevents.height the height of the cumulative events table on the grid.
 #'  Default is 0.25. Ignored when cumevents = FALSE.
 #'@param cumcensor logical value specifying whether to show or not the table of
-#'  the cumulative number of censoring. Default is FALSE.
+#'  the cumulative number of censoring. Default is FALSE. Can also be a character
+#'  string ("absolute", "percentage" or "abs_pct").
 #'@param cumcensor.title The title to be used for the cumcensor table.
 #'@param cumcensor.col same as tables.col but for cumcensor table only.
 #'@param cumcensor.y.text logical. Default is TRUE. If FALSE, the y axis tick

--- a/man/ggsurvplot.Rd
+++ b/man/ggsurvplot.Rd
@@ -110,10 +110,10 @@ to show both absolute number and percentage. \item "nrisk_cumcensor" and
 censoring and events, respectively. }}
 
 \item{cumevents}{logical value specifying whether to show or not the table of
-the cumulative number of events. Default is FALSE.}
+the cumulative number of events. Default is FALSE. Can also be a character string ("absolute", "percentage" or "abs_pct"); "percentage" shows the count as a percent of the stratum size.}
 
 \item{cumcensor}{logical value specifying whether to show or not the table of
-the cumulative number of censoring. Default is FALSE.}
+the cumulative number of censoring. Default is FALSE. Can also be a character string ("absolute", "percentage" or "abs_pct").}
 
 \item{tables.height}{numeric value (in [0 - 1]) specifying the general height
 of all tables under the main survival plot.}

--- a/man/ggsurvplot_arguments.Rd
+++ b/man/ggsurvplot_arguments.Rd
@@ -178,7 +178,7 @@ time t is plotted. Default is FALSE. Ignored when cumcensor = TRUE.}
 \code{ncensor.plot = TRUE}.}
 
 \item{cumevents}{logical value specifying whether to show or not the table of
-the cumulative number of events. Default is FALSE.}
+the cumulative number of events. Default is FALSE. Can also be a character string ("absolute", "percentage" or "abs_pct"); "percentage" shows the count as a percent of the stratum size.}
 
 \item{cumevents.title}{The title to be used for the cumulative events table.}
 
@@ -195,7 +195,7 @@ tick labels of the cumulative events will be colored by strata.}
 Default is 0.25. Ignored when cumevents = FALSE.}
 
 \item{cumcensor}{logical value specifying whether to show or not the table of
-the cumulative number of censoring. Default is FALSE.}
+the cumulative number of censoring. Default is FALSE. Can also be a character string ("absolute", "percentage" or "abs_pct").}
 
 \item{cumcensor.title}{The title to be used for the cumcensor table.}
 

--- a/man/ggsurvplot_combine.Rd
+++ b/man/ggsurvplot_combine.Rd
@@ -39,10 +39,10 @@ Allowed options are one of c("out", "in") indicating 'outside' or 'inside'
 the main plot, respectively. Default value is "out".}
 
 \item{cumevents}{logical value specifying whether to show or not the table of
-the cumulative number of events. Default is FALSE.}
+the cumulative number of events. Default is FALSE. Can also be a character string ("absolute", "percentage" or "abs_pct"); "percentage" shows the count as a percent of the stratum size.}
 
 \item{cumcensor}{logical value specifying whether to show or not the table of
-the cumulative number of censoring. Default is FALSE.}
+the cumulative number of censoring. Default is FALSE. Can also be a character string ("absolute", "percentage" or "abs_pct").}
 
 \item{tables.col}{color to be used for all tables under the main plot. Default
 value is "black". If you want to color by strata (i.e. groups), use

--- a/tests/testthat/test-cumevents-percentage.R
+++ b/tests/testthat/test-cumevents-percentage.R
@@ -1,0 +1,42 @@
+context("cumevents / cumcensor tables as percentage (#499)")
+
+# #499: the cumulative events/censor tables only showed absolute counts. They
+# now accept the same character values as risk.table -- "absolute" (default,
+# unchanged), "percentage", "abs_pct" -- shown as a percent of the stratum size.
+library(survival)
+
+fit <- survfit(Surv(time, status) ~ sex, data = lung)
+
+lab_of <- function(p) {
+  d <- ggplot2::ggplot_build(p)$data
+  i <- which(vapply(d, function(x) "label" %in% names(x), logical(1)))[1]
+  d[[i]]$label
+}
+
+test_that("no-regression: cumevents = TRUE equals cumevents = 'absolute' (#499)", {
+  a <- lab_of(ggsurvplot(fit, data = lung, cumevents = TRUE, break.time.by = 250)$cumevents)
+  b <- lab_of(ggsurvplot(fit, data = lung, cumevents = "absolute", break.time.by = 250)$cumevents)
+  expect_equal(a, b)
+})
+
+test_that("cumevents = 'percentage' shows count / stratum size * 100 (#499)", {
+  p   <- ggsurvplot(fit, data = lung, cumevents = "percentage", break.time.by = 250)
+  ss  <- .get_timepoints_survsummary(fit, lung, c(0, 250, 500, 750, 1000))
+  exp <- round(ss$cum.n.event / ss$strata_size * 100)
+  expect_setequal(as.numeric(lab_of(p$cumevents)), exp)
+  expect_match(p$cumevents$labels$title, "%", fixed = TRUE)   # title reflects %
+})
+
+test_that("cumevents = 'abs_pct' shows 'count (pct)' (#499)", {
+  p <- ggsurvplot(fit, data = lung, cumevents = "abs_pct", break.time.by = 250)
+  expect_true(any(grepl("\\(.*\\)", lab_of(p$cumevents))))
+})
+
+test_that("cumcensor accepts percentage too and builds (#499)", {
+  p <- ggsurvplot(fit, data = lung, cumcensor = "percentage", break.time.by = 250)
+  expect_error(ggplot2::ggplotGrob(p$ncensor.plot), NA)   # cumcensor returns as $ncensor.plot
+})
+
+test_that("an invalid cumevents string errors clearly (#499)", {
+  expect_error(ggsurvplot(fit, data = lung, cumevents = "bogus"), "Allowed values")
+})


### PR DESCRIPTION
The cumulative events / censoring tables only showed absolute counts, with no percentage option (unlike `risk.table`) (#499).

`cumevents` and `cumcensor` now accept the same character values as `risk.table` — `"absolute"` (the count, same as `TRUE`), `"percentage"` (count as a percent of the stratum size), or `"abs_pct"` (`"count (percent)"`):

```r
ggsurvplot(fit, data = lung, cumevents = "percentage", break.time.by = 250)
```

Parsed via `.parse_risk_table_arg()` in `ggsurvplot_core()` (same mechanism as `risk.table`); the per-table type drives the label and the default title ("Cumulative events (%)"). `TRUE`/`FALSE` are unchanged (absolute count) — verified byte-identical.

Fixes #499
