### PR TITLE
Fix risk-table strata_size/pct for id counting-process fits (#592)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,8 @@
 
 ## Bug fixes
 
+- Fix the risk table's `strata_size` and `pct.risk` for id-based counting-process fits (`survfit(Surv(start, stop, event) ~ g, id = subject)`, with time-varying covariates / multiple rows per subject). `fit$n` counts intervals (rows), not subjects, so the stratum size was overstated and the at-risk percentage did not start at 100%. `strata_size` now uses `fit$n.id` (the per-stratum unique-subject count) when the fit provides it; ordinary right-censored, weighted and plain left-truncated fits (which have no `fit$n.id`) are unchanged. The number-at-risk counts themselves are computed by `survival` and were already correct on current versions. Reported by @wiedenhoeft (#592).
+
 - Fix `ggforest()` silently dropping interaction terms. Only main-effect variables were iterated (`attr(model$terms, "dataClasses")`), so a model with an interaction (e.g. `Surv(time, status) ~ sex * ph.ecog`) omitted the interaction coefficients (`sexfemale:ph.ecog1`, ...) from both the plot and the table. Each interaction coefficient is now drawn as its own row, mapped to the fitted coefficients via `model$assign`. Models without interactions are unchanged. Reported by @Generalized (#536).
 
 - `ggsurvplot()` now gives an actionable message instead of the cryptic "object of type 'symbol' is not subsettable" when a `survfit` was built from a formula stored in a variable in a non-global scope (e.g. `survfit(form, data)` inside a function, `lapply()`/`nest_by()`, or a `{targets}` pipeline), whose formula object is out of scope at plot time. The message points to `surv_fit()`, which retains the formula and data. Fits whose formula is recoverable are unchanged. Reported by @skent259 (#533).

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -193,16 +193,24 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
 {
   survsummary <- summary(fit, times = times, extend = TRUE)
 
+  # For an id-based counting-process / multi-state fit, fit$n counts ROWS
+  # (intervals), not subjects, so strata_size (and pct.risk) would overcount and
+  # the percentage would not start at 100% (#592). fit$n.id is the per-stratum
+  # unique-subject count and is present ONLY for such fits (NULL for standard,
+  # single-group, weighted, and plain left-truncated fits), so this is
+  # byte-identical for every ordinary fit and needs no survival-version guard.
+  strata_totals <- if (!is.null(fit$n.id)) fit$n.id else fit$n
+
   if (is.null(fit$strata)) {
     .strata <- factor(rep("All", length(survsummary$time)))
     strata_names <- "All"
-    strata_size <- rep(fit$n, length(.strata))
+    strata_size <- rep(strata_totals, length(.strata))
   }
   else {
     .strata <- factor(survsummary$strata)
     strata_names <- names(fit$strata)
     nstrata <- length(strata_names)
-    strata_size <- rep(fit$n, each = length(.strata)/nstrata)
+    strata_size <- rep(strata_totals, each = length(.strata)/nstrata)
   }
 
   # Percentage at risk. The denominator is normally the (unweighted) stratum size

--- a/tests/testthat/test-counting-process-strata-size.R
+++ b/tests/testthat/test-counting-process-strata-size.R
@@ -1,0 +1,38 @@
+context("risk table strata_size / pct.risk for id-based counting-process fits (#592)")
+
+# #592: for an id-based counting-process fit (Surv(start, stop, event) ~ g,
+# id = subject; multi-row per subject), fit$n counts intervals (rows), not
+# subjects, so strata_size and pct.risk over-counted (pct did not start at 100%).
+# strata_size now uses fit$n.id (per-stratum unique-subject count) when present.
+# fit$n.id is NULL for ordinary fits, so they are unchanged.
+library(survival)
+
+test_that("id counting-process fit: strata_size = unique subjects, pct starts at 100 (#592)", {
+  fit <- survfit(Surv(start, stop, event) ~ rx, data = bladder2, id = id)
+  st  <- ggsurvplot(fit, data = bladder2, risk.table = TRUE, break.time.by = 10)$data.survtable
+  s0  <- st[st$time == 0, ]
+  expect_equal(as.numeric(s0$strata_size), as.numeric(fit$n.id))  # subjects, not fit$n rows
+  expect_true(all(as.numeric(fit$n.id) < fit$n))                  # intervals really exceed subjects
+  expect_equal(as.numeric(s0$pct.risk), rep(100, nrow(s0)))       # starts at 100%
+})
+
+test_that("single-group id fit uses subject count (#592)", {
+  f1 <- survfit(Surv(start, stop, event) ~ 1, data = bladder2, id = id)
+  st <- ggsurvplot(f1, data = bladder2, risk.table = TRUE)$data.survtable
+  expect_equal(unique(as.numeric(st$strata_size)), as.numeric(f1$n.id))
+})
+
+test_that("no-regression: ordinary fits keep strata_size = fit$n (#592)", {
+  # standard right-censored, single-group, and plain left-truncated (NO id) all
+  # have fit$n.id == NULL -> strata_size stays fit$n (byte-identical).
+  fs <- survfit(Surv(time, status) ~ sex, data = lung)
+  expect_null(fs$n.id)
+  st <- ggsurvplot(fs, data = lung, risk.table = TRUE)$data.survtable
+  expect_equal(sort(unique(as.numeric(st$strata_size))), sort(as.numeric(fs$n)))
+
+  # left-truncated without id must NOT be treated as an id fit
+  fl <- survfit(Surv(start, stop, event) ~ 1, data = heart)
+  expect_null(fl$n.id)
+  stl <- ggsurvplot(fl, data = heart, risk.table = TRUE)$data.survtable
+  expect_equal(unique(as.numeric(stl$strata_size)), as.numeric(fl$n))
+})


### PR DESCRIPTION
For an id-based counting-process fit — `survfit(Surv(start, stop, event) ~ g, id = subject)` with time-varying covariates / multiple rows per subject — the risk table's `strata_size` used `fit$n`, which counts **intervals (rows)**, not subjects. So the stratum size was overstated and `pct.risk` did not start at 100% (#592).

The number-at-risk counts themselves are computed by `survival` and are already correct on current versions (the reporter's original overcount was a survival 3.2-13 artifact, since fixed upstream). This PR fixes only the denominator.

`strata_size` now uses `fit$n.id` — the per-stratum unique-subject count — when the fit provides it. `fit$n.id` is present **only** for id-based fits, so ordinary right-censored, single-group, weighted, and plain **left-truncated (no id)** fits have `fit$n.id == NULL` and are byte-identical (verified against master for all of these, including the left-truncated `heart` case that a naive "3-column response" gate would have broken). No survival-version guard needed — old versions lacking `n.id` fall back to `fit$n`.

Approach and the `fit$n.id` discriminator were confirmed by two independent pre-fix reviews.

Fixes #592
