### PR TITLE
Add method= (weighted log-rank tests) to pairwise_survdiff() (#433)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 ## Minor changes
 
+- `pairwise_survdiff()` gains a `method` argument matching `surv_pvalue()`, so pairwise comparisons can use a weighted log-rank test (`"n"`/Gehan-Breslow, `"sqrtN"`/Tarone-Ware, `"S1"`/Peto-Peto, `"S2"`/modified Peto-Peto, `"FH_p=1_q=1"`/Fleming-Harrington), not only `survival::survdiff()` + `rho`. The method name/alias resolution is now shared between the two functions. Default `method = "survdiff"` reproduces the previous result exactly (`rho` still applies). Weighted methods do not support `strata()` terms and error clearly if combined. Addresses the inconsistency reported in #433.
+
 - `cumevents` and `cumcensor` now accept a character value ("absolute", "percentage", "abs_pct"), like `risk.table`, to show the cumulative events/censoring table as a percentage of the stratum size (or "count (percent)"), not only the absolute count. `TRUE`/`FALSE` are unchanged (absolute). The default table title reflects the type. Requested by @anarpkpd (#499).
 
 - `break.time.by` (and its alias `break.x.by`) now accepts a numeric vector of custom break positions, e.g. `break.time.by = c(0, 100, 300, 600, 1000)`, in addition to a single step. Passing a vector previously errored (`'by' must be of length 1`). The same breaks drive the survival curve and the number-at-risk/censor tables, so they stay aligned. A single value is unchanged. Requested in #435 and by @AjayKumar-O (#695).

--- a/R/pairwise_survdiff.R
+++ b/R/pairwise_survdiff.R
@@ -13,8 +13,16 @@ NULL
 #'  adjust the p value (not recommended), use p.adjust.method = "none".
 #'@param na.action a missing-data filter function. Default is
 #'  options()$na.action.
-#'@param rho a scalar parameter that controls the type of test. Allowed values
-#'  include 0 (for Log-Rank test) and 1 (for peto & peto test).
+#'@param rho a scalar parameter that controls the type of test (used when
+#'  \code{method = "survdiff"}). Allowed values include 0 (for Log-Rank test) and
+#'  1 (for peto & peto test).
+#'@param method the log-rank test to use, matching the \code{method} argument of
+#'  \code{\link{surv_pvalue}}. Default \code{"survdiff"} uses
+#'  \code{survival::survdiff()} (controlled by \code{rho}). A weighted log-rank
+#'  test can be requested by its weight code, full name or abbreviation:
+#'  \code{"n"}/Gehan-Breslow, \code{"sqrtN"}/Tarone-Ware, \code{"S1"}/Peto-Peto,
+#'  \code{"S2"}/modified Peto-Peto, or \code{"FH_p=1_q=1"}/Fleming-Harrington.
+#'  Weighted methods do not support \code{strata()} terms.
 #'@seealso survival::survdiff
 #'@return Returns an object of class "pairwise.htest", which is a list
 #'  containing the p values.
@@ -40,10 +48,17 @@ NULL
 #'
 #'@rdname pairwise_survdiff
 #'@export
-pairwise_survdiff <- function(formula, data, p.adjust.method = "BH", na.action, rho = 0)
+pairwise_survdiff <- function(formula, data, p.adjust.method = "BH", na.action, rho = 0,
+                              method = "survdiff")
 
 {
   if(missing(na.action)) na.action <- options()$na.action
+  # Resolve the log-rank method/alias (shared with surv_pvalue()). "survdiff"
+  # (default) keeps the exact survival::survdiff() + rho path; a weighted-test
+  # name ("n"/Gehan-Breslow, "sqrtN"/Tarone-Ware, "S1"/Peto-Peto,
+  # "S2"/modified Peto-Peto, "FH_p=1_q=1"/Fleming-Harrington) uses the internal
+  # weighted log-rank test, matching surv_pvalue()'s method argument (#433).
+  method <- .resolve_logrank_method(method)
   all_terms <- attr(stats::terms(formula), "term.labels")
   # Separate strata() terms (an adjustment, not a grouping variable): they are
   # not data columns, so using them to subset/group crashed with "undefined
@@ -63,8 +78,21 @@ pairwise_survdiff <- function(formula, data, p.adjust.method = "BH", na.action, 
 
   DNAME <- paste(deparse(substitute(data)), "and", .collapse(group_var, sep = " + " ))
   METHOD <- "Log-Rank"
-  METHOD <- if (rho == 0) "Log-Rank test"
-  else if(rho==1) "Peto & Peto test"
+  if (method == "survdiff") {
+    METHOD <- if (rho == 0) "Log-Rank test"
+    else if(rho==1) "Peto & Peto test"
+  } else {
+    METHOD <- switch(method,
+                     n = "Gehan-Breslow test", sqrtN = "Tarone-Ware test",
+                     S1 = "Peto-Peto test", S2 = "modified Peto-Peto test",
+                     `FH_p=1_q=1` = "Fleming-Harrington (p=1, q=1) test")
+  }
+  # Weighted log-rank tests operate on the two-group subset directly and do not
+  # support a stratified comparison; keep those to the survdiff path.
+  if (method != "survdiff" && length(strata_terms) > 0)
+    stop("Weighted log-rank methods (method = \"", method, "\") do not support ",
+         "strata() terms; use method = \"survdiff\" for a stratified test.",
+         call. = FALSE)
 
 
   # Removing missing value
@@ -94,9 +122,14 @@ pairwise_survdiff <- function(formula, data, p.adjust.method = "BH", na.action, 
 
   compare.levels <- function(i, j) {
     .subset = group %in% (levels(group))[c(i,j)]
-    sdif <- survival::survdiff(formula, data = data[.subset, , drop = FALSE],
-                               rho = rho, na.action = na.action)
-    stats::pchisq(sdif$chisq, length(sdif$n) - 1, lower.tail = FALSE)
+    sub_data <- data[.subset, , drop = FALSE]
+    if (method == "survdiff") {
+      sdif <- survival::survdiff(formula, data = sub_data,
+                                 rho = rho, na.action = na.action)
+      stats::pchisq(sdif$chisq, length(sdif$n) - 1, lower.tail = FALSE)
+    } else {
+      .weighted_logrank_test(formula, data = sub_data, method = method)$pvalue
+    }
   }
 
   PVAL <- stats::pairwise.table(compare.levels, levels(group), p.adjust.method)

--- a/R/surv_pvalue.R
+++ b/R/surv_pvalue.R
@@ -173,21 +173,9 @@ surv_pvalue <- function(fit, data = NULL, method = "survdiff", test.for.trend = 
 
   . <- NULL
 
-  allowed.methods <- c("survdiff", "log-rank", "LR", "1",
-                       "n", "Gehan-Breslow", "GB",
-                       "sqrtN", "Tarone-Ware", "TW",
-                       "S1", "Peto-Peto", "PP",
-                       "S2", "modified Peto-Peto", "mPP",
-                       "FH_p=1_q=1", "Fleming-Harrington(p=1, q=1)", "FH")
-
-  method.names <- c(rep("survdiff", 4),
-                    rep(c("n", "sqrtN", "S1", "S2", "FH_p=1_q=1"), each = 3))
-  # don't use grep which will detect many positions for "n" or "FH
-  choosed.method  <- which(tolower(allowed.methods) %in% tolower(method))
-  if(.is_empty(choosed.method))
-    stop("Don't support the choosed method: ", choosed.method, ". ",
-         "Allowed methods include: ", .collapse(allowed.methods, sep = ", "))
-  else method <- method.names[choosed.method] %>% .[1]
+  # Resolve the method name/alias to its canonical form (shared with
+  # pairwise_survdiff() via .resolve_logrank_method()).
+  method <- .resolve_logrank_method(method)
 
   if(test.for.trend & method == "survdiff")
     method <- "1" # use survMisc

--- a/R/weighted_logrank.R
+++ b/R/weighted_logrank.R
@@ -21,7 +21,11 @@
   status <- surv_obj[, "status"]
   # Ensure status is 0/1
   if (max(status) == 2) status <- status - 1
-  group <- as.factor(mf[[2]])
+  # drop unused factor levels so a two-group subset (e.g. from pairwise
+  # comparisons) is treated as 2 groups, not the parent's full level set --
+  # otherwise empty groups make the covariance matrix singular. For a full-data
+  # fit there are no empty levels, so this is a no-op.
+  group <- droplevels(as.factor(mf[[2]]))
   groups <- levels(group)
   ngroups <- length(groups)
 
@@ -166,4 +170,30 @@
   }
 
   list(pvalue = pvalue, method_name = test_name)
+}
+
+
+# Resolve a user-supplied log-rank method name/alias to its canonical form.
+# Returns "survdiff" (ordinary log-rank via survival::survdiff) or one of the
+# weighted-test names accepted by .weighted_logrank_test() ("n", "sqrtN", "S1",
+# "S2", "FH_p=1_q=1"). Case-insensitive; accepts the weight code, the full test
+# name, or the abbreviation. Shared by surv_pvalue() and pairwise_survdiff() so
+# the accepted names stay in sync.
+.resolve_logrank_method <- function(method) {
+  if (is.null(method)) method <- "survdiff"
+  . <- NULL
+  allowed.methods <- c("survdiff", "log-rank", "LR", "1",
+                       "n", "Gehan-Breslow", "GB",
+                       "sqrtN", "Tarone-Ware", "TW",
+                       "S1", "Peto-Peto", "PP",
+                       "S2", "modified Peto-Peto", "mPP",
+                       "FH_p=1_q=1", "Fleming-Harrington(p=1, q=1)", "FH")
+  method.names <- c(rep("survdiff", 4),
+                    rep(c("n", "sqrtN", "S1", "S2", "FH_p=1_q=1"), each = 3))
+  # don't use grep which will detect many positions for "n" or "FH"
+  choosed.method <- which(tolower(allowed.methods) %in% tolower(method))
+  if (.is_empty(choosed.method))
+    stop("Don't support the choosed method: ", method, ". ",
+         "Allowed methods include: ", .collapse(allowed.methods, sep = ", "))
+  method.names[choosed.method] %>% .[1]
 }

--- a/man/pairwise_survdiff.Rd
+++ b/man/pairwise_survdiff.Rd
@@ -4,7 +4,14 @@
 \alias{pairwise_survdiff}
 \title{Multiple Comparisons of Survival Curves}
 \usage{
-pairwise_survdiff(formula, data, p.adjust.method = "BH", na.action, rho = 0)
+pairwise_survdiff(
+  formula,
+  data,
+  p.adjust.method = "BH",
+  na.action,
+  rho = 0,
+  method = "survdiff"
+)
 }
 \arguments{
 \item{formula}{a formula expression as for other survival models, of the form
@@ -21,8 +28,17 @@ adjust the p value (not recommended), use p.adjust.method = "none".}
 \item{na.action}{a missing-data filter function. Default is
 options()$na.action.}
 
-\item{rho}{a scalar parameter that controls the type of test. Allowed values
-include 0 (for Log-Rank test) and 1 (for peto & peto test).}
+\item{rho}{a scalar parameter that controls the type of test (used when
+\code{method = "survdiff"}). Allowed values include 0 (for Log-Rank test) and
+1 (for peto & peto test).}
+
+\item{method}{the log-rank test to use, matching the \code{method} argument of
+\code{\link{surv_pvalue}}. Default \code{"survdiff"} uses
+\code{survival::survdiff()} (controlled by \code{rho}). A weighted log-rank
+test can be requested by its weight code, full name or abbreviation:
+\code{"n"}/Gehan-Breslow, \code{"sqrtN"}/Tarone-Ware, \code{"S1"}/Peto-Peto,
+\code{"S2"}/modified Peto-Peto, or \code{"FH_p=1_q=1"}/Fleming-Harrington.
+Weighted methods do not support \code{strata()} terms.}
 }
 \value{
 Returns an object of class "pairwise.htest", which is a list

--- a/tests/testthat/test-pairwise_survdiff.R
+++ b/tests/testthat/test-pairwise_survdiff.R
@@ -65,6 +65,56 @@ test_that("no-regression: a grouping variable is never misread as strata (#672)"
   expect_equal(rownames(res$p.value), c("Lev", "Lev+5FU"))
 })
 
+test_that("method= runs a weighted log-rank test, matching surv_pvalue (#433)", {
+  # #433: pairwise_survdiff() only exposed rho (survdiff); surv_pvalue() accepted
+  # weighted tests via method=. pairwise_survdiff() now takes the same method=,
+  # dispatching to the shared .weighted_logrank_test() for a pairwise comparison.
+  res <- pairwise_survdiff(Surv(time, status) ~ rx, data = colon,
+                           method = "sqrtN", p.adjust.method = "none")
+  expect_s3_class(res, "pairwise.htest")
+  # each cell equals the 2-group weighted test on that pair
+  sub <- droplevels(colon[colon$rx %in% c("Obs", "Lev+5FU"), ])
+  expect_equal(res$p.value["Lev+5FU", "Obs"],
+               .weighted_logrank_test(Surv(time, status) ~ rx, data = sub,
+                                      method = "sqrtN")$pvalue)
+})
+
+test_that("method aliases resolve like surv_pvalue (#433)", {
+  a <- pairwise_survdiff(Surv(time, status) ~ rx, data = colon,
+                         method = "Tarone-Ware", p.adjust.method = "none")$p.value
+  b <- pairwise_survdiff(Surv(time, status) ~ rx, data = colon,
+                         method = "TW", p.adjust.method = "none")$p.value
+  d <- pairwise_survdiff(Surv(time, status) ~ rx, data = colon,
+                         method = "sqrtN", p.adjust.method = "none")$p.value
+  expect_equal(a, d)
+  expect_equal(b, d)
+})
+
+test_that("no-regression: default method='survdiff' equals the rho path (#433)", {
+  a <- pairwise_survdiff(Surv(time, status) ~ rx, data = colon,
+                         p.adjust.method = "none")$p.value
+  b <- pairwise_survdiff(Surv(time, status) ~ rx, data = colon,
+                         method = "survdiff", p.adjust.method = "none")$p.value
+  expect_equal(a, b)
+  # rho still works under the default survdiff path
+  expect_error(pairwise_survdiff(Surv(time, status) ~ rx, data = colon, rho = 1), NA)
+})
+
+test_that("a weighted method with a strata() term errors clearly (#433)", {
+  expect_error(
+    pairwise_survdiff(Surv(time, status) ~ rx + strata(sex), data = colon,
+                      method = "sqrtN"),
+    "do not support"
+  )
+})
+
+test_that("an unknown method errors with the allowed list (#433)", {
+  expect_error(
+    pairwise_survdiff(Surv(time, status) ~ rx, data = colon, method = "bogus"),
+    "Allowed methods"
+  )
+})
+
 test_that("rows with a missing grouping value are dropped (#635)", {
   # pairwise_survdiff() removes rows with NA in any grouping column before the
   # pairwise tests. This locks that behavior after switching the row-wise check


### PR DESCRIPTION
Addresses #433: `surv_pvalue()` accepts weighted log-rank tests via `method=`, but `pairwise_survdiff()` only exposed `rho` (survdiff), so `pairwise_survdiff(..., method="sqrtN")` errored "unused argument". The two are now consistent.

`pairwise_survdiff()` gains a `method` argument matching `surv_pvalue()`:
- `method = "survdiff"` (default) — unchanged: `survival::survdiff()` controlled by `rho`.
- weighted tests — `"n"`/Gehan-Breslow, `"sqrtN"`/Tarone-Ware, `"S1"`/Peto-Peto, `"S2"`/modified Peto-Peto, `"FH_p=1_q=1"`/Fleming-Harrington — dispatched to the shared internal `.weighted_logrank_test()` for each pairwise comparison.

Details:
- The method name/alias resolution is factored into `.resolve_logrank_method()`, now used by both `surv_pvalue()` and `pairwise_survdiff()` (single source of truth for the accepted names).
- Weighted methods don't support `strata()` terms and error clearly if combined.
- `.weighted_logrank_test()` now drops unused factor levels, so a two-group pairwise subset of an N-level factor is treated as 2 groups rather than N (an empty group made the covariance matrix singular). No-op for full-data fits.

No-regression (verified old-vs-new via worktree):
- `surv_pvalue()` byte-identical across all 14 method spellings x test.for.trend x several fits.
- `pairwise_survdiff()` default (`method="survdiff"`) byte-identical for single/multi-var, rho 0/1, BH/none, `strata()` and `survival::strata()`.
- Each weighted pairwise cell equals `.weighted_logrank_test()` / `surv_pvalue()` on that 2-group subset.

Regression tests added; NEWS + man updated. Two adversarial reviewers cleared the diff.

Refs #433
