### PR TITLE
ggflexsurvplot(): honor summary.flexsurv and fun for single-stratum fits (#400)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,8 @@
 
 ## Bug fixes
 
+- `ggflexsurvplot()` now honors a user-supplied `summary.flexsurv` and the `fun` argument for a single-stratum fit. The single-stratum branch of the internal summary helper recomputed `summary(fit)` with the default time grid and type, so a `summary.flexsurv` meant to extend the fitted curve to a wider `xlim` was ignored (the curve stopped at the last observed time), and `fun = "cumhaz"` fell back to the survival curve. It now uses the already-selected summary. Multi-stratum fits and the default single-stratum survival curve are unchanged (#400).
+
 - `ggsurvplot()` now accepts a per-strata `linetype` vector that contains a hex dash pattern, e.g. `linetype = c("solid", "F1")`. Only all-base-name or all-numeric vectors were mapped to a manual per-strata scale; a vector with a hex pattern fell through and crashed with "the condition has length > 1". Any length-1 value (including a single hex pattern or `"strata"`) is unchanged (#344).
 
 - `ggforest()` no longer draws spurious "reference" rows for an interaction-only model. With a term such as `Surv(time, status) ~ sex:ph.ecog` (an interaction without the corresponding `sex`/`ph.ecog` main effects), the main-effect factor levels were still listed as reference rows, implying main effects that were never fit. A variable that appears only inside an interaction (absent from `names(model$assign)`) is now skipped; its coefficients are still drawn as interaction rows. Models with genuine main effects (including splines/transformations) are unchanged. Reported by @anaveda (#594).

--- a/R/ggflexsurvplot.R
+++ b/R/ggflexsurvplot.R
@@ -117,7 +117,12 @@ ggflexsurvplot <- function(fit, data = NULL,
     summ <- summary(fit, type = type)
 
   if(length(summ) == 1){
-    summ <- summary(fit)[[1]] %>%
+    # Use the summary already selected above (the user-supplied summary.flexsurv,
+    # or summary(fit, type = type)); previously this branch recomputed
+    # summary(fit)[[1]] with the DEFAULT t and type, discarding a user summary
+    # meant to extend the curve (e.g. to a wider xlim) and ignoring `fun`/type
+    # for single-stratum fits (#400).
+    summ <- summ[[1]] %>%
       dplyr::mutate(strata = "All")
   }
 

--- a/tests/testthat/test-ggflexsurvplot-single-stratum.R
+++ b/tests/testthat/test-ggflexsurvplot-single-stratum.R
@@ -1,0 +1,44 @@
+context("ggflexsurvplot() single-stratum summary.flexsurv / fun (#400)")
+
+# #400: for a single-stratum flexsurvreg fit, .summary_flexsurv() discarded the
+# selected summary and recomputed summary(fit)[[1]] with the DEFAULT t and type.
+# So a user-supplied summary.flexsurv meant to extend the curve (wider xlim) was
+# ignored, and fun = "cumhaz" fell back to the survival curve. It now uses the
+# already-selected summary (summary.flexsurv, or summary(fit, type = fun)).
+skip_if_not_installed("flexsurv")
+library(survival)
+
+fit1 <- flexsurv::flexsurvreg(Surv(futime, fustat) ~ 1, data = ovarian, dist = "weibull")
+
+test_that("a user summary.flexsurv with extended t reaches the curve (#400)", {
+  us <- summary(fit1, t = seq(0, 3000, by = 50))
+  s  <- .summary_flexsurv(fit1, type = "survival", summary.flexsurv = us)
+  expect_equal(max(s$time), 3000)                 # extends to the user grid
+  # default (no summary.flexsurv) still stops at observed follow-up (unchanged)
+  s0 <- .summary_flexsurv(fit1, type = "survival")
+  expect_equal(max(s0$time), max(ovarian$futime))
+})
+
+test_that("fun/type is honored for a single-stratum fit (#400)", {
+  s_ch <- .summary_flexsurv(fit1, type = "cumhaz")
+  ref  <- summary(fit1, type = "cumhaz")[[1]]
+  expect_equal(s_ch$est, ref$est)                 # cumulative hazard, not survival
+  # and it differs from the survival curve
+  s_su <- .summary_flexsurv(fit1, type = "survival")
+  expect_false(isTRUE(all.equal(s_ch$est, s_su$est)))
+})
+
+test_that("no-regression: multi-stratum summary is unchanged (#400)", {
+  d <- ovarian; d$rx <- factor(d$rx)
+  fit2 <- flexsurv::flexsurvreg(Surv(futime, fustat) ~ rx, data = d, dist = "weibull")
+  s <- .summary_flexsurv(fit2, type = "survival")
+  expect_setequal(as.character(unique(s$strata)), c("rx=1", "rx=2"))
+})
+
+test_that("ggflexsurvplot() renders for a single-stratum fit (#400)", {
+  # suppressWarnings: the ggflexsurvplot render path emits an unrelated,
+  # pre-existing ggplot2/ggpubr "use linewidth instead of size" deprecation.
+  expect_error(
+    suppressWarnings(ggplot2::ggplotGrob(ggflexsurvplot(fit1, data = ovarian)$plot)),
+    NA)
+})


### PR DESCRIPTION
Reported in #400: for a single-stratum `flexsurvreg` fit, `ggflexsurvplot()` did not extend the fitted curve to a wider `xlim` even when a `summary.flexsurv` with an extended time grid was supplied — the parametric curve stopped at the last observed time.

Root cause: `.summary_flexsurv()`'s single-stratum branch recomputed `summary(fit)[[1]]` with the DEFAULT time grid and type, discarding the summary selected just above (the user's `summary.flexsurv`, or `summary(fit, type = fun)`). This also made `fun = "cumhaz"` fall back to the survival curve for single-stratum fits.

Fix: use the already-selected `summ[[1]]`.

No-regression (verified old-vs-new via worktree):
- Default single-stratum survival curve: `time`/`est` byte-identical (the CI band uses flexsurv's simulation-based CI, which already varied run-to-run; the fix actually calls `summary()` once instead of twice).
- Multi-stratum path is untouched (byte-identical).
- Fix confirmed: a `summary.flexsurv` with `t = seq(0, 3000, 50)` now reaches 3000 (was clipped to ~1227); `fun = "cumhaz"` now uses the cumulative hazard.

Regression tests added (flexsurv-guarded; fail on master, pass here). Two adversarial reviewers cleared the diff.

Refs #400
