### PR TITLE
Add p.adjust.label to customise the adjusted p-value prefix in ggsurvplot_facet()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 
 ## Minor changes
 
+- `ggsurvplot_facet()` gains a `p.adjust.label` argument to customise the prefix shown before an adjusted p-value (used with `p.adjust.method`). The default `"adj.p ="` is unchanged; set e.g. `p.adjust.label = "q ="` or `"p.adj ="` for publication styling (a trailing `"="` becomes `"<"` for very small p-values). Follow-up to #407.
 - `ggsurvplot_facet()` gains a `p.adjust.method` argument to adjust the per-panel log-rank p-values for multiple comparisons across panels (passed to `stats::p.adjust()`, e.g. `"BH"`, `"bonferroni"`, `"holm"`), mirroring `pairwise_survdiff()`. The default `"none"` shows the raw per-panel p-values (unchanged); when a method is set the displayed text is prefixed with `"adj.p ="`. Panels with an undefined p-value (e.g. a single group) are left out of the adjustment. Requested by @choc2000 (#407).
 
 - `ggsurvplot_facet()` now fails with a clear, actionable message instead of a cryptic `grDevices::col2rgb()` / "Unknown colour name" error at draw time when the fit's grouping term is not a plain data column -- e.g. a fit built from `Surv(...) ~ I(sex)`, `~ strata(sex)`, `~ cut(age, 3)`, or a formula assembled with `eval(as.name(...))` inside a loop. Such a term is not a column and cannot be used to colour the panels; the message points to using a plain variable / `reformulate()`. Fits whose grouping variable is a real column are unchanged. Reported by @Yatros (#380).

--- a/R/ggsurvplot_facet.R
+++ b/R/ggsurvplot_facet.R
@@ -13,7 +13,12 @@ NULL
 #'  comparisons across panels, passed to \code{\link[stats]{p.adjust}()} (e.g.
 #'  \code{"BH"}, \code{"bonferroni"}, \code{"holm"}). The default \code{"none"}
 #'  shows the raw per-panel p-values. When an adjustment method is used the
-#'  displayed text is prefixed with \code{"adj.p ="}.
+#'  displayed text is prefixed with \code{p.adjust.label}.
+#'@param p.adjust.label the label placed before the adjusted p-value when
+#'  \code{p.adjust.method} is not \code{"none"}. The default is \code{"adj.p ="}
+#'  (e.g. \code{"adj.p = 0.03"}); set it to customise the wording, e.g.
+#'  \code{"p.adj ="} or \code{"q ="}. For a very small p-value the label's
+#'  trailing \code{"="} is replaced by \code{"<"} (\code{"adj.p < 0.0001"}).
 #'@param facet.by character vector, of length 1 or 2, specifying grouping
 #'  variables for faceting the plot. Should be in the data.
 #'@param nrow,ncol Number of rows and columns in the pannel. Used only when the
@@ -73,7 +78,7 @@ ggsurvplot_facet <- function(fit, data, facet.by,
                              legend.labs = NULL,
                              pval = FALSE, pval.method = FALSE, pval.size = 5,
                              pval.coord = NULL, pval.method.coord = NULL,
-                             p.adjust.method = "none",
+                             p.adjust.method = "none", p.adjust.label = "adj.p =",
                              nrow = NULL, ncol = NULL,
                              scales = "fixed",
                              short.panel.labs = FALSE, panel.labs = NULL,
@@ -326,10 +331,16 @@ ggsurvplot_facet <- function(fit, data, facet.by,
       pval.digits <- if("pval.digits" %in% names(list(...))) list(...)$pval.digits else 2
       adj <- stats::p.adjust(pvalue$pval, method = p.adjust.method)
       pvalue$pval <- adj
+      # `p.adjust.label` is the full displayed prefix (default "adj.p ="); for the
+      # very-small-p case its trailing "=" is dropped and a "<" is used instead,
+      # so it reads "adj.p < 0.0001". This also adds the "<" for a label given
+      # without a trailing "=" (e.g. "q" -> "q < 0.0001"), rather than dropping
+      # the operator.
+      lt.label <- paste(sub("\\s*=\\s*$", "", p.adjust.label), "<")
       pvalue$pval.txt <- ifelse(
         is.na(adj), pvalue$pval.txt,
-        ifelse(adj < 1e-04, "adj.p < 0.0001",
-               paste("adj.p =", signif(adj, pval.digits)))
+        ifelse(adj < 1e-04, paste(lt.label, "0.0001"),
+               paste(p.adjust.label, signif(adj, pval.digits)))
       )
     }
     # Select the grouping variable columns and cbind the corresponding pvalue

--- a/man/ggsurvplot_facet.Rd
+++ b/man/ggsurvplot_facet.Rd
@@ -17,6 +17,7 @@ ggsurvplot_facet(
   pval.coord = NULL,
   pval.method.coord = NULL,
   p.adjust.method = "none",
+  p.adjust.label = "adj.p =",
   nrow = NULL,
   ncol = NULL,
   scales = "fixed",
@@ -82,7 +83,13 @@ coordinates of the p-value. Default values are NULL.}
 comparisons across panels, passed to \code{\link[stats]{p.adjust}()} (e.g.
 \code{"BH"}, \code{"bonferroni"}, \code{"holm"}). The default \code{"none"}
 shows the raw per-panel p-values. When an adjustment method is used the
-displayed text is prefixed with \code{"adj.p ="}.}
+displayed text is prefixed with \code{p.adjust.label}.}
+
+\item{p.adjust.label}{the label placed before the adjusted p-value when
+\code{p.adjust.method} is not \code{"none"}. The default is \code{"adj.p ="}
+(e.g. \code{"adj.p = 0.03"}); set it to customise the wording, e.g.
+\code{"p.adj ="} or \code{"q ="}. For a very small p-value the label's
+trailing \code{"="} is replaced by \code{"<"} (\code{"adj.p < 0.0001"}).}
 
 \item{nrow, ncol}{Number of rows and columns in the pannel. Used only when the
 data is faceted by one grouping variable.}

--- a/tests/testthat/test-ggsurvplot-facet-padjust.R
+++ b/tests/testthat/test-ggsurvplot-facet-padjust.R
@@ -46,6 +46,35 @@ test_that("an invalid p.adjust.method errors clearly (#407)", {
                                       pval = TRUE, p.adjust.method = "nope")))
 })
 
+test_that("p.adjust.label customises the adjusted-p-value prefix (#407)", {
+  d <- subset(colon, etype == 2); d$sex <- factor(d$sex, labels = c("F", "M"))
+  fit <- survfit(Surv(time, status) ~ rx, data = d)
+  # default prefix
+  def <- panel_pvals(suppressWarnings(
+    ggsurvplot_facet(fit, data = d, facet.by = "sex", pval = TRUE,
+                     p.adjust.method = "BH")))
+  expect_true(all(grepl("^adj\\.p =", def)))
+  # custom prefix
+  q <- panel_pvals(suppressWarnings(
+    ggsurvplot_facet(fit, data = d, facet.by = "sex", pval = TRUE,
+                     p.adjust.method = "BH", p.adjust.label = "q =")))
+  expect_true(all(grepl("^q =", q)))
+  expect_false(any(grepl("adj\\.p", q)))
+  # the adjusted numeric value is the same regardless of the label
+  expect_equal(sort(as.numeric(sub("adj\\.p = ", "", def))),
+               sort(as.numeric(sub("q = ", "", q))))
+})
+
+test_that("p.adjust.label is ignored when p.adjust.method = 'none' (#407)", {
+  d <- subset(colon, etype == 2); d$sex <- factor(d$sex, labels = c("F", "M"))
+  fit <- survfit(Surv(time, status) ~ rx, data = d)
+  txt <- panel_pvals(suppressWarnings(
+    ggsurvplot_facet(fit, data = d, facet.by = "sex", pval = TRUE,
+                     p.adjust.label = "q =")))   # method defaults to "none"
+  expect_true(all(grepl("^p =", txt)))          # raw, label not applied
+  expect_false(any(grepl("q =", txt)))
+})
+
 test_that("panels with an undefined p-value are excluded from the adjustment (#407)", {
   # lung ph.ecog == 3 has a single observation -> undefined per-panel p (NA),
   # which must stay blank and not count toward the multiple-comparison n.


### PR DESCRIPTION
Follow-up to #407.

The adjusted per-panel p-value text added in #407 was hard-coded to `adj.p =`. This adds a `p.adjust.label` argument so the prefix is user-settable for publication styling.

## Change

`ggsurvplot_facet(..., p.adjust.method = <method>, p.adjust.label = "adj.p =")`. The default `"adj.p ="` reproduces the #407 output exactly. Set e.g. `p.adjust.label = "q ="` or `"p.adj ="`. For a very small p-value the label's trailing `=` is replaced by `<` (`"adj.p < 0.0001"`), and the `<` is added even for a bare-word label (`"q"` → `"q < 0.0001"`).

```r
library(survminer); library(survival)
d <- subset(colon, etype == 2); d$sex <- factor(d$sex, labels = c("F", "M"))
fit <- survfit(Surv(time, status) ~ rx, data = d)
ggsurvplot_facet(fit, data = d, facet.by = "sex", pval = TRUE,
                 p.adjust.method = "BH", p.adjust.label = "q =")
```

## Verification

- Default output is byte-identical to master (`ggplot_build` labels) for `p.adjust.method` in {`none`, `BH`}, the very-small-p branch (`"adj.p < 0.0001"`), and NA panels.
- Custom labels render `"<label> <value>"` with the same adjusted numeric; the very-small-p case shows exactly one `<` for every label form (never `"q = < 0.0001"` or `"q 0.0001"`).
- Only the `p.adjust.method != "none"` path is touched; interactions (`pval.method`, `pval.coord`, `pval.size`, NA panels, `pval.digits`) unchanged.
- New tests in `test-ggsurvplot-facet-padjust.R`; full clean-session suite FAIL 0; `checkRd` clean.
- Three independent adversarial reviews cleared the change.
