### PR TITLE
Add ref.group to pairwise_survdiff() for all-vs-one-control comparisons (#364)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 ## Minor changes
 
+- `pairwise_survdiff()` gains a `ref.group` argument to compare every group against a single control/reference group only, instead of all pairwise comparisons. The p-values are then adjusted over just those k-1 comparisons (a smaller multiple-testing correction), which suits a many-treatments-vs-one-control design. The default `NULL` keeps the full pairwise comparison table unchanged. Requested by @th3minstr3l (#364).
+
 - `ggsurvplot_facet()` gains a `p.adjust.label` argument to customise the prefix shown before an adjusted p-value (used with `p.adjust.method`). The default `"adj.p ="` is unchanged; set e.g. `p.adjust.label = "q ="` or `"p.adj ="` for publication styling (a trailing `"="` becomes `"<"` for very small p-values). Follow-up to #407.
 - `ggsurvplot_facet()` gains a `p.adjust.method` argument to adjust the per-panel log-rank p-values for multiple comparisons across panels (passed to `stats::p.adjust()`, e.g. `"BH"`, `"bonferroni"`, `"holm"`), mirroring `pairwise_survdiff()`. The default `"none"` shows the raw per-panel p-values (unchanged); when a method is set the displayed text is prefixed with `"adj.p ="`. Panels with an undefined p-value (e.g. a single group) are left out of the adjustment. Requested by @choc2000 (#407).
 

--- a/R/pairwise_survdiff.R
+++ b/R/pairwise_survdiff.R
@@ -23,6 +23,12 @@ NULL
 #'  \code{"n"}/Gehan-Breslow, \code{"sqrtN"}/Tarone-Ware, \code{"S1"}/Peto-Peto,
 #'  \code{"S2"}/modified Peto-Peto, or \code{"FH_p=1_q=1"}/Fleming-Harrington.
 #'  Weighted methods do not support \code{strata()} terms.
+#'@param ref.group optional character string naming a single grouping level to
+#'  use as the common reference/control. When supplied, every other group is
+#'  compared against this one group only (rather than all pairwise comparisons),
+#'  and the p-values are adjusted over just those comparisons -- useful for a
+#'  many-treatments-vs-one-control design, which needs a smaller multiple-testing
+#'  correction. The default \code{NULL} performs all pairwise comparisons.
 #'@seealso survival::survdiff
 #'@return Returns an object of class "pairwise.htest", which is a list
 #'  containing the p values.
@@ -49,7 +55,7 @@ NULL
 #'@rdname pairwise_survdiff
 #'@export
 pairwise_survdiff <- function(formula, data, p.adjust.method = "BH", na.action, rho = 0,
-                              method = "survdiff")
+                              method = "survdiff", ref.group = NULL)
 
 {
   if(missing(na.action)) na.action <- options()$na.action
@@ -132,7 +138,29 @@ pairwise_survdiff <- function(formula, data, p.adjust.method = "BH", na.action, 
     }
   }
 
-  PVAL <- stats::pairwise.table(compare.levels, levels(group), p.adjust.method)
+  if(is.null(ref.group)){
+    # All pairwise comparisons (default, unchanged).
+    PVAL <- stats::pairwise.table(compare.levels, levels(group), p.adjust.method)
+  }
+  else {
+    # Compare every other group against a single control/reference group only.
+    # Fewer comparisons -> a smaller multiple-testing correction. The p-values
+    # are adjusted over just these k-1 comparisons (#364).
+    ref.group <- as.character(ref.group)
+    if(length(ref.group) != 1)
+      stop("`ref.group` must be a single grouping level.", call. = FALSE)
+    if(!(ref.group %in% levels(group)))
+      stop("`ref.group` (\"", ref.group, "\") is not one of the grouping levels: ",
+           .collapse(levels(group), sep = ", "), ".", call. = FALSE)
+    others <- setdiff(levels(group), ref.group)
+    i <- match(ref.group, levels(group))
+    raw <- vapply(others, function(g) compare.levels(i, match(g, levels(group))),
+                  numeric(1))
+    adj <- stats::p.adjust(raw, method = p.adjust.method)
+    # One column (the reference), one row per other group -- same
+    # "pairwise.htest" matrix shape that print.pairwise.htest expects.
+    PVAL <- matrix(adj, ncol = 1L, dimnames = list(others, ref.group))
+  }
 
   res <- list(method = METHOD, data.name = DNAME, p.value = PVAL,
               p.adjust.method = p.adjust.method)

--- a/man/pairwise_survdiff.Rd
+++ b/man/pairwise_survdiff.Rd
@@ -10,7 +10,8 @@ pairwise_survdiff(
   p.adjust.method = "BH",
   na.action,
   rho = 0,
-  method = "survdiff"
+  method = "survdiff",
+  ref.group = NULL
 )
 }
 \arguments{
@@ -39,6 +40,13 @@ test can be requested by its weight code, full name or abbreviation:
 \code{"n"}/Gehan-Breslow, \code{"sqrtN"}/Tarone-Ware, \code{"S1"}/Peto-Peto,
 \code{"S2"}/modified Peto-Peto, or \code{"FH_p=1_q=1"}/Fleming-Harrington.
 Weighted methods do not support \code{strata()} terms.}
+
+\item{ref.group}{optional character string naming a single grouping level to
+use as the common reference/control. When supplied, every other group is
+compared against this one group only (rather than all pairwise comparisons),
+and the p-values are adjusted over just those comparisons -- useful for a
+many-treatments-vs-one-control design, which needs a smaller multiple-testing
+correction. The default \code{NULL} performs all pairwise comparisons.}
 }
 \value{
 Returns an object of class "pairwise.htest", which is a list

--- a/tests/testthat/test-pairwise_survdiff.R
+++ b/tests/testthat/test-pairwise_survdiff.R
@@ -148,3 +148,47 @@ test_that("rows with a missing value in ANY of several grouping vars are dropped
   expect_false(any(grepl("NA", rownames(res_na$p.value))))
   expect_false(any(grepl("NA", colnames(res_na$p.value))))
 })
+
+test_that("ref.group compares every group against one control only (#364)", {
+  data(myeloma)
+  lv <- levels(droplevels(as.factor(myeloma$molecular_group)))
+  ctrl <- lv[1]
+  res <- pairwise_survdiff(Surv(time, event) ~ molecular_group, data = myeloma,
+                           ref.group = ctrl)
+  # one column (the control), one row per other group
+  expect_equal(ncol(res$p.value), 1L)
+  expect_identical(colnames(res$p.value), ctrl)
+  expect_setequal(rownames(res$p.value), setdiff(lv, ctrl))
+  # p-values are adjusted over only these k-1 comparisons, matching an
+  # independent p.adjust of the raw control-vs-other tests
+  others <- setdiff(lv, ctrl)
+  raw <- vapply(others, function(o) {
+    sd <- survival::survdiff(
+      Surv(time, event) ~ molecular_group,
+      data = myeloma[myeloma$molecular_group %in% c(ctrl, o), ])
+    stats::pchisq(sd$chisq, length(sd$n) - 1, lower.tail = FALSE)
+  }, numeric(1))
+  expect_equal(as.numeric(res$p.value[others, 1]),
+               as.numeric(stats::p.adjust(raw, "BH")))
+})
+
+test_that("no-regression: ref.group = NULL is the full pairwise table (#364)", {
+  data(myeloma)
+  a <- pairwise_survdiff(Surv(time, event) ~ molecular_group, data = myeloma)
+  b <- pairwise_survdiff(Surv(time, event) ~ molecular_group, data = myeloma,
+                         ref.group = NULL)
+  expect_equal(a$p.value, b$p.value)
+})
+
+test_that("an invalid ref.group errors clearly (#364)", {
+  data(myeloma)
+  expect_error(
+    pairwise_survdiff(Surv(time, event) ~ molecular_group, data = myeloma,
+                      ref.group = "not-a-level"),
+    "not one of the grouping levels")
+  # more than one level is a clear error, not R's generic condition-length one
+  expect_error(
+    pairwise_survdiff(Surv(time, event) ~ molecular_group, data = myeloma,
+                      ref.group = c("MAF", "MMSET")),
+    "single grouping level")
+})


### PR DESCRIPTION
Fixes #364.

`pairwise_survdiff()` compares all group pairs. For a many-treatments-vs-one-control design you want each group compared against a single control only — which also means a smaller multiple-testing correction.

## Change

New `ref.group` argument. When set to one grouping level, every other group is compared against that control, and the p-values are adjusted over just those k−1 comparisons. The default `ref.group = NULL` keeps the full pairwise table unchanged.

```r
library(survminer); library(survival); data(myeloma)
pairwise_survdiff(Surv(time, event) ~ molecular_group, data = myeloma,
                  ref.group = "Cyclin D-1")
#>                  Cyclin D-1
#> Cyclin D-2       0.78
#> Hyperdiploid     0.90
#> ...
```

## Verification

- Default (`ref.group = NULL`) is byte-identical to master across single/multi-variable grouping, all `p.adjust.method`s, `rho = 1`, weighted methods, and `strata()` terms (full `pairwise.htest` object compared).
- The raw control-vs-other tests equal the corresponding cells of the full table; the adjusted values equal an independent `p.adjust()` over the k−1 comparisons; the correction uses k−1, not k(k−1)/2 (verified with bonferroni).
- Clear errors for a non-level or non-scalar `ref.group`. `print`/`symnum` render the one-column result correctly.
- New tests in `test-pairwise_survdiff.R` (pass on this branch, fail on master); full clean-session suite FAIL 0; `checkRd` clean.
- Two independent adversarial reviewers cleared the change.

Requested by @th3minstr3l.
