### PR TITLE
Accept surv_summary() data frames in ggsurvplot_combine() (#323)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 ## Minor changes
 
+- `ggsurvplot_combine()` now accepts `surv_summary()` data frames as list elements, not only survfit objects -- the data-frame analogue of `ggsurvplot_df()`. A data-frame element is drawn directly (and `data` is optional in that case). Survfit elements are unchanged. The number-at-risk/cumulative tables and median lines require a survfit and are refused with a clear message for a summary data frame. Requested by @HeidiSeibold (#323).
+
 - `pairwise_survdiff()` gains a `ref.group` argument to compare every group against a single control/reference group only, instead of all pairwise comparisons. The p-values are then adjusted over just those k-1 comparisons (a smaller multiple-testing correction), which suits a many-treatments-vs-one-control design. The default `NULL` keeps the full pairwise comparison table unchanged. Requested by @th3minstr3l (#364).
 
 - `ggsurvplot_facet()` gains a `p.adjust.label` argument to customise the prefix shown before an adjusted p-value (used with `p.adjust.method`). The default `"adj.p ="` is unchanged; set e.g. `p.adjust.label = "q ="` or `"p.adj ="` for publication styling (a trailing `"="` becomes `"<"` for very small p-values). Follow-up to #407.

--- a/R/ggsurvplot_combine.R
+++ b/R/ggsurvplot_combine.R
@@ -9,8 +9,13 @@ NULL
 #'   \code{\link{ggsurvplot}()} function for doing that.
 #'
 #' @inheritParams ggsurvplot_arguments
-#' @param fit a named list of survfit objects.
-#' @param data the data frame used to compute survival curves.
+#' @param fit a named list whose elements are either survfit objects or
+#'   \code{\link{surv_summary}()} data frames (the latter are drawn directly, as
+#'   in \code{\link{ggsurvplot_df}()}). Note that the number-at-risk /
+#'   cumulative tables and median lines are only available for survfit elements
+#'   (they cannot be recomputed from a summary data frame).
+#' @param data the data frame used to compute survival curves. Optional; not
+#'   needed when \code{fit} contains only \code{surv_summary()} data frames.
 #' @param keep.data logical value specifying whether the plot data frame should be kept in the result.
 #' Setting these to FALSE (default) can give much smaller results and hence even save memory allocation time.
 #' @param ... other arguments to pass to the \code{\link{ggsurvplot}()} function.
@@ -48,7 +53,7 @@ NULL
 #' ggsurvplot_combine(fit, demo.data)
 #'
 #'@export
-ggsurvplot_combine <- function(fit, data,
+ggsurvplot_combine <- function(fit, data = NULL,
                                risk.table = FALSE, risk.table.pos = c("out", "in"),
                                cumevents = FALSE, cumcensor = FALSE,
                                tables.col = "black", tables.y.text = TRUE, tables.y.text.col = TRUE,
@@ -79,6 +84,24 @@ ggsurvplot_combine <- function(fit, data,
   }
   names(fit) <- fitnames
 
+  # A list element may be a survfit object (the usual input) OR a surv_summary()
+  # data frame, which is used directly for the curves -- the data-frame analogue
+  # of ggsurvplot_df() (#323). The number-at-risk / cumulative tables and the
+  # median lines need the survfit object (they are recomputed at the plot's time
+  # breaks), so they are not available from a summary data frame; error clearly
+  # rather than failing cryptically downstream.
+  has_df_fit <- any(vapply(fit, is.data.frame, logical(1)))
+  if(has_df_fit){
+    wants.tables <- !isFALSE(risk.table) || !isFALSE(cumevents) || !isFALSE(cumcensor)
+    smline <- .dots$surv.median.line
+    wants.median <- !is.null(smline) && !identical(smline, "none")
+    if(wants.tables || wants.median)
+      stop("When `fit` contains a surv_summary() data frame, risk.table, ",
+           "cumevents, cumcensor and surv.median.line are not available (they ",
+           "require the survfit object). Pass survfit objects for those, or turn ",
+           "these options off.", call. = FALSE)
+  }
+
     # Create a list-column data containing the list of fits
     #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
     grouped.d <- tibble::tibble(name = names(fit)) %>%
@@ -92,7 +115,22 @@ ggsurvplot_combine <- function(fit, data,
     # Helper function
     .surv_summary <- function(fit, fitname, ...){
       time <- n.censor <- surv <- upper <- lower <- strata <- NULL
-      survsummary <- surv_summary(fit, ...)
+      # A surv_summary() data frame is used as-is; a survfit is summarised (#323).
+      # Coerce to a plain data.frame first: a tibble's `df[, col]` returns a
+      # one-column tibble that breaks downstream factor()/select() ("cannot xtfrm
+      # data frame"), the pitfall documented for surv_group_by/ggadjustedcurves
+      # (#501/#548). Also require the surv_summary() columns so a wrong data frame
+      # gives a clear error instead of silently producing an empty plot.
+      if(is.data.frame(fit)){
+        survsummary <- as.data.frame(fit)
+        .needed <- c("time", "surv", "upper", "lower", "n.censor")
+        .missing <- setdiff(.needed, colnames(survsummary))
+        if(length(.missing) > 0)
+          stop("A data-frame element of `fit` is missing the surv_summary() ",
+               "column(s): ", .collapse(.missing, sep = ", "),
+               ". Pass a surv_summary() output (see ?surv_summary).", call. = FALSE)
+      }
+      else survsummary <- surv_summary(fit, ...)
       # Bind fit name to the srata levels in survsummary
       if(is.null(survsummary$strata)) survsummary$strata <- as.factor(rep("All", nrow(survsummary)))
       strata.levels <- paste(fitname, "::", .levels(survsummary$strata), sep = "")
@@ -190,41 +228,48 @@ ggsurvplot_combine <- function(fit, data,
                                        "cum.n.censor", "strata_size")))
     }
 
-    grouped.d <- grouped.d %>%
-      mutate(survtable = purrr::map2(grouped.d$fit, grouped.d$name,
-                                     .surv_table, data = data, times = time.breaks))
+    # The number-at-risk / cumulative tables are recomputed from each survfit at
+    # the plot's time breaks, so they are only available for survfit inputs. For
+    # a surv_summary() data-frame input the table options are already refused
+    # above, so this whole block is skipped and the survfit path is unchanged.
+    all.survtable <- NULL
+    if(!has_df_fit){
+      grouped.d <- grouped.d %>%
+        mutate(survtable = purrr::map2(grouped.d$fit, grouped.d$name,
+                                       .surv_table, data = data, times = time.breaks))
 
-    # Row bind all survival table
-    #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-    all.levels <- NULL
-    for(ss in grouped.d$survtable )
-      all.levels <- c(all.levels, .levels(ss$strata))
-    # convert strata into character before binding
-    # avoid this warning: Unequal factor levels: coercing to character
-    grouped.d$survtable <- map(grouped.d$survtable,
-                               function(x){
-                                 x$strata <- as.character(x$strata)
-                                 x
-                               })
-    all.survtable <- dplyr::bind_rows(grouped.d$survtable)
-    all.survtable$strata <- factor(all.survtable$strata, levels = all.levels)
+      # Row bind all survival table
+      #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      all.levels <- NULL
+      for(ss in grouped.d$survtable )
+        all.levels <- c(all.levels, .levels(ss$strata))
+      # convert strata into character before binding
+      # avoid this warning: Unequal factor levels: coercing to character
+      grouped.d$survtable <- map(grouped.d$survtable,
+                                 function(x){
+                                   x$strata <- as.character(x$strata)
+                                   x
+                                 })
+      all.survtable <- dplyr::bind_rows(grouped.d$survtable)
+      all.survtable$strata <- factor(all.survtable$strata, levels = all.levels)
 
-     # Risk table
-    #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-    pms$fit <- list(table = all.survtable, time = all.survsummary$time)
-    tables <- do.call(ggsurvtable, pms)
+       # Risk table
+      #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      pms$fit <- list(table = all.survtable, time = all.survsummary$time)
+      tables <- do.call(ggsurvtable, pms)
 
-    if(risk.table)
-      res$table <- tables$risk.table
-    if(cumevents)
-      res$cumevents <- tables$cumevents
-    if(cumcensor)
-      res$ncensor.plot <- tables$cumcensor
+      if(risk.table)
+        res$table <- tables$risk.table
+      if(cumevents)
+        res$cumevents <- tables$cumevents
+      if(cumcensor)
+        res$ncensor.plot <- tables$cumcensor
+    }
     #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
     if(keep.data){
     res$data.survplot <- tibble::as_tibble(all.survsummary)
-    res$data.survtable <- tibble::as_tibble(all.survtable)
+    if(!is.null(all.survtable)) res$data.survtable <- tibble::as_tibble(all.survtable)
     }
 
 

--- a/man/ggsurvplot_combine.Rd
+++ b/man/ggsurvplot_combine.Rd
@@ -6,7 +6,7 @@
 \usage{
 ggsurvplot_combine(
   fit,
-  data,
+  data = NULL,
   risk.table = FALSE,
   risk.table.pos = c("out", "in"),
   cumevents = FALSE,
@@ -22,9 +22,14 @@ ggsurvplot_combine(
 )
 }
 \arguments{
-\item{fit}{a named list of survfit objects.}
+\item{fit}{a named list whose elements are either survfit objects or
+\code{\link{surv_summary}()} data frames (the latter are drawn directly, as
+in \code{\link{ggsurvplot_df}()}). Note that the number-at-risk /
+cumulative tables and median lines are only available for survfit elements
+(they cannot be recomputed from a summary data frame).}
 
-\item{data}{the data frame used to compute survival curves.}
+\item{data}{the data frame used to compute survival curves. Optional; not
+needed when \code{fit} contains only \code{surv_summary()} data frames.}
 
 \item{risk.table}{Allowed values include: \itemize{ \item TRUE or FALSE
 specifying whether to show or not the risk table. Default is FALSE. \item

--- a/tests/testthat/test-ggsurvplot-combine-df.R
+++ b/tests/testthat/test-ggsurvplot-combine-df.R
@@ -1,0 +1,74 @@
+context("ggsurvplot_combine accepts surv_summary data frames (#323)")
+
+# Regression test for #323: ggsurvplot_combine() only accepted a list of survfit
+# objects; passing a surv_summary() data frame (as ggsurvplot_df() accepts)
+# errored in surv_summary() -> summary(x)$table ("$ operator is invalid for
+# atomic vectors"). A data-frame element is now drawn directly. The survfit path
+# is unchanged; the number-at-risk/cumulative tables and median lines are not
+# available for a summary data frame and are refused with a clear message.
+library(survival)
+
+draw_ok <- function(p) {
+  tmp <- tempfile(fileext = ".pdf"); grDevices::pdf(tmp)
+  on.exit({ grDevices::dev.off(); unlink(tmp) }, add = TRUE)
+  print(p); invisible(TRUE)
+}
+
+pfs <- survfit(Surv(time, status) ~ 1, data = colon)
+os  <- survfit(Surv(time, status) ~ rx, data = colon)
+dpfs <- surv_summary(pfs, colon)
+dos  <- surv_summary(os, colon)
+
+test_that("a surv_summary data frame can be combined (with or without data) (#323)", {
+  p1 <- suppressWarnings(ggsurvplot_combine(list(a = dpfs)))          # no data
+  expect_s3_class(p1, "ggsurvplot")
+  expect_error(suppressWarnings(draw_ok(p1)), NA)
+  p2 <- suppressWarnings(ggsurvplot_combine(list(a = dpfs), data = colon))
+  expect_error(suppressWarnings(draw_ok(p2)), NA)
+})
+
+test_that("several data frames combine with name::strata labels (#323)", {
+  p <- suppressWarnings(ggsurvplot_combine(list(PFS = dpfs, OS = dos)))
+  b <- suppressWarnings(ggplot2::ggplot_build(p$plot))
+  strata <- levels(p$data.survplot$strata %||% factor(character()))
+  # one PFS curve + three OS curves
+  lv <- levels(droplevels(as.factor(b$data[[1]]$group)))
+  expect_gte(length(lv), 4L)
+  expect_error(suppressWarnings(draw_ok(p)), NA)
+})
+
+test_that("a data frame and a survfit can be mixed (#323)", {
+  p <- suppressWarnings(ggsurvplot_combine(list(PFS = dpfs, OS = os), data = colon))
+  expect_error(suppressWarnings(draw_ok(p)), NA)
+})
+
+test_that("tables/median lines are refused for a summary data frame (#323)", {
+  expect_error(suppressWarnings(ggsurvplot_combine(list(a = dpfs), risk.table = TRUE)),
+               "require the survfit")
+  expect_error(suppressWarnings(ggsurvplot_combine(list(a = dpfs), cumevents = TRUE)),
+               "require the survfit")
+  expect_error(suppressWarnings(ggsurvplot_combine(list(a = dpfs), surv.median.line = "hv")),
+               "require the survfit")
+})
+
+test_that("a tibble surv_summary element is handled (coerced, not xtfrm error) (#323)", {
+  skip_if_not_installed("tibble")
+  tb <- tibble::as_tibble(dpfs)
+  p <- suppressWarnings(ggsurvplot_combine(list(a = tb)))
+  expect_error(suppressWarnings(draw_ok(p)), NA)
+})
+
+test_that("a data frame lacking surv_summary columns errors clearly (#323)", {
+  bad <- data.frame(x = 1:5, y = 6:10)
+  expect_error(suppressWarnings(ggsurvplot_combine(list(a = bad))),
+               "missing the surv_summary")
+})
+
+test_that("no-regression: a survfit list still combines (with tables) (#323)", {
+  p <- suppressWarnings(ggsurvplot_combine(list(PFS = pfs, OS = os), data = colon))
+  expect_s3_class(p, "ggsurvplot")
+  expect_error(suppressWarnings(draw_ok(p)), NA)
+  pr <- suppressWarnings(ggsurvplot_combine(list(PFS = pfs, OS = os), data = colon,
+                                            risk.table = TRUE))
+  expect_false(is.null(pr$table))
+})


### PR DESCRIPTION
Fixes #323.

`ggsurvplot_combine()` only accepted a list of survfit objects; passing a `surv_summary()` data frame (the way `ggsurvplot_df()` accepts one) errored inside `surv_summary()` → `summary(x)$table` ("$ operator is invalid for atomic vectors").

## Change

A list element may now be a `surv_summary()` data frame, drawn directly — the data-frame analogue of `ggsurvplot_df()`. The element is coerced with `as.data.frame()` (so a tibble doesn't hit the one-column `xtfrm` pitfall) and its `surv_summary()` columns are validated with a clear error. `data` is now optional (not needed for data-frame input).

```r
library(survminer); library(survival)
pfs <- survfit(Surv(time, status) ~ 1,  data = colon)
os  <- survfit(Surv(time, status) ~ rx, data = colon)
ggsurvplot_combine(list(PFS = surv_summary(pfs, colon),
                        OS  = surv_summary(os,  colon)))
```

## Verification

- The survfit-list path is byte-identical to master across plain / `risk.table` / `cumevents` / `cumcensor` / `keep.data` / `surv.median.line` / `risk.table.pos` (full object compared) — the table block is skipped only when a data-frame element is present.
- Data-frame input renders with the correct `name::strata` legend; tibble input works; a data frame missing `surv_summary()` columns gives a clear error instead of a silent broken plot.
- The number-at-risk/cumulative tables and median lines require a survfit and are refused for a summary data frame with a clear message.
- New tests (`test-ggsurvplot-combine-df.R`) pass on this branch, fail on master; full clean-session suite FAIL 0; `checkRd` clean.
- Two independent adversarial reviewers cleared the change, plus a focused re-review of the tibble/validation hardening.

Requested by @HeidiSeibold.
