### PR TITLE
Fix per-subgroup p-value for grouped ggsurvplot (group.by) (#799)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 ## Minor changes
 
+- `ggsurvplot()` on a grouped fit from `surv_fit(..., group.by=)` now shows the correct per-subgroup log-rank p-value on each panel with `pval = TRUE`. Previously every panel displayed the same pooled p-value, because `ggsurvplot_list()` recomputed the test on the pooled `data=` instead of each subgroup. `surv_fit()` now carries the per-group data subsets, which `ggsurvplot_list()` uses; the curves/tables and same-data multi-fit lists are unchanged (#799).
+
 - `ggsurvplot_combine()` now accepts `surv_summary()` data frames as list elements, not only survfit objects -- the data-frame analogue of `ggsurvplot_df()`. A data-frame element is drawn directly (and `data` is optional in that case). Survfit elements are unchanged. The number-at-risk/cumulative tables and median lines require a survfit and are refused with a clear message for a summary data frame. Requested by @HeidiSeibold (#323).
 
 - `pairwise_survdiff()` gains a `ref.group` argument to compare every group against a single control/reference group only, instead of all pairwise comparisons. The p-values are then adjusted over just those k-1 comparisons (a smaller multiple-testing correction), which suits a many-treatments-vs-one-control design. The default `NULL` keeps the full pairwise comparison table unchanged. Requested by @th3minstr3l (#364).

--- a/R/ggsurvplot_list.R
+++ b/R/ggsurvplot_list.R
@@ -47,6 +47,17 @@ ggsurvplot_list <- function(fit, data, title = NULL, legend.labs = NULL,
   if(.is_list(fit) & is.null(title))
     title <- names(fit)
 
+  # A grouped fit (from surv_fit(..., group.by=) or a grouped data set) is a list
+  # of survfit objects each fitted on its own subset, carried in the
+  # "surv_fit_group_data" attribute. Use those subsets as the per-fit data so each
+  # panel is drawn -- and its p-value computed -- on its own subgroup, instead of
+  # forcing the pooled `data` (which gave the same overall p-value on every panel)
+  # (#799). Only applies when the caller passed a single (pooled) data frame; an
+  # explicit list of data is left as given.
+  .group.data <- attr(fit, "surv_fit_group_data")
+  if(!is.null(.group.data) & !.is_list(data))
+    data <- .group.data
+
   if(.is_list (fit) & .is_list (data)){
     if(length(fit) != length(data))
       stop("fit and data are lists with different length. ",

--- a/R/surv_fit.R
+++ b/R/surv_fit.R
@@ -156,6 +156,11 @@ surv_fit <- function(formula, data, group.by = NULL, match.fd = FALSE, ...){
 
   # Grouped data sets by one or two grouping variables
   #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+  # Remember whether this is a grouped call: the result is then a list of
+  # survfit objects each fitted on its OWN subset. Downstream (ggsurvplot_list)
+  # needs to know that, so the per-panel p-value is computed on each subset
+  # rather than on the pooled data passed as `data=` (#799).
+  .grouped.call <- .is_grouped_data(data) || !is.null(group.by)
   if(.is_grouped_data(data) )
     data <- input_data <- data$data
   else if(!is.null(group.by))
@@ -260,6 +265,13 @@ surv_fit <- function(formula, data, group.by = NULL, match.fd = FALSE, ...){
 
   if(.is_list(data) | .is_list(formula))
     names(res) <- .collapse(DNAME, FNAME, sep = "::")
+
+  # For a grouped call, attach the per-group data subsets so that plotting the
+  # resulting list (ggsurvplot_list) can use each subset for its panel -- in
+  # particular for a correct per-subgroup p-value instead of the pooled one
+  # (#799). Only added for grouped calls; other list results are unchanged.
+  if(.grouped.call && .is_list(res))
+    attr(res, "surv_fit_group_data") <- data
 
   res
 }

--- a/tests/testthat/test-ggsurvplot-groupby-pval.R
+++ b/tests/testthat/test-ggsurvplot-groupby-pval.R
@@ -1,0 +1,60 @@
+context("per-subgroup p-value for grouped ggsurvplot (#799)")
+
+# Regression test for #799: plotting a grouped fit from surv_fit(..., group.by=)
+# with ggsurvplot(..., pval = TRUE) printed the SAME pooled log-rank p-value on
+# every panel, because ggsurvplot_list() forced the pooled `data =` into each
+# panel's surv_pvalue(). surv_fit() now tags the grouped result with the per-group
+# data subsets ("surv_fit_group_data"), and ggsurvplot_list() uses them so each
+# panel's p-value is computed on its own subgroup. Genuine same-data multi-fit
+# lists are unchanged.
+library(survival)
+
+panel_pvals <- function(sp) {
+  vapply(sp, function(p) {
+    b <- suppressWarnings(ggplot2::ggplot_build(p$plot))
+    idx <- which(vapply(p$plot$layers, function(l) inherits(l$geom, "GeomText"),
+                        logical(1)))
+    txt <- unlist(lapply(idx, function(i) b$data[[i]]$label))
+    txt[grepl("^p [=<]", txt)][1]
+  }, character(1))
+}
+
+test_that("surv_fit(group.by=) tags the result with per-group data (#799)", {
+  d <- lung; d$sex <- factor(d$sex)
+  fits <- surv_fit(Surv(time, status) ~ sex, data = d, group.by = "ph.ecog")
+  expect_false(is.null(attr(fits, "surv_fit_group_data")))
+  # a plain (non-grouped) list of fits is NOT tagged
+  li <- list(a = survfit(Surv(time, status) ~ sex, data = d))
+  expect_null(attr(li, "surv_fit_group_data"))
+})
+
+test_that("grouped ggsurvplot shows a per-subgroup p-value on each panel (#799)", {
+  d <- lung; d$sex <- factor(d$sex, labels = c("Male", "Female"))
+  d <- d[d$ph.ecog %in% c(0, 1, 2), ]
+  fits <- surv_fit(Surv(time, status) ~ sex, data = d, group.by = "ph.ecog")
+  sp <- suppressWarnings(ggsurvplot(fits, data = d, pval = TRUE))
+  shown <- panel_pvals(sp)
+  # independent per-subgroup truth
+  truth <- vapply(c(0, 1, 2), function(e) {
+    s <- d[d$ph.ecog == e, ]
+    sd <- survdiff(Surv(time, status) ~ sex, data = s)
+    signif(pchisq(sd$chisq, length(sd$n) - 1, lower.tail = FALSE), 2)
+  }, numeric(1))
+  shown_num <- as.numeric(sub("p = ", "", shown))
+  expect_equal(sort(shown_num), sort(truth))
+  # they are NOT all the pooled value (the bug) -> more than one distinct p
+  expect_gt(length(unique(shown_num)), 1L)
+})
+
+test_that("no-regression: same-data multi-fit list keeps its per-fit p-values (#799)", {
+  d <- lung; d$sex <- factor(d$sex)
+  f1 <- survfit(Surv(time, status) ~ sex, data = d)
+  f2 <- survfit(Surv(time, status) ~ ph.ecog, data = d)
+  sp <- suppressWarnings(ggsurvplot(list(bySex = f1, byEcog = f2), data = d,
+                                    pval = TRUE))
+  shown <- unname(panel_pvals(sp))
+  # each panel shows its own fit's p-value text (computed on the shared data,
+  # exactly as before this change), including the "p < 0.0001" formatting
+  truth <- c(surv_pvalue(f1, d)$pval.txt, surv_pvalue(f2, d)$pval.txt)
+  expect_equal(shown, truth)
+})


### PR DESCRIPTION
Fixes #799.

Plotting a grouped fit from `surv_fit(..., group.by=)` with `ggsurvplot(pval = TRUE)` printed the **same pooled log-rank p-value on every panel** — `ggsurvplot_list()` recomputed the test on the pooled `data=` rather than on each subgroup. (`ggsurvplot_group_by()` was already correct.)

## Change

`surv_fit()` tags a grouped result with its per-group data subsets (attr `surv_fit_group_data`); `ggsurvplot_list()` uses them as the per-fit data when the caller passed a single pooled data frame, so each panel's p-value is computed on its own subgroup.

```r
library(survminer); library(survival)
d <- lung; d$sex <- factor(d$sex, labels = c("Male", "Female"))
d <- d[d$ph.ecog %in% c(0, 1, 2), ]
fits <- surv_fit(Surv(time, status) ~ sex, data = d, group.by = "ph.ecog")
ggsurvplot(fits, data = d, pval = TRUE)   # now p = 0.11 / 0.0068 / 0.25 (was 0.0018 on all)
```

## Verification

- Correct per-subgroup p-values for `group.by` of length 1 and 2 (matched to independent `survdiff`).
- Grouped curves/tables byte-identical to master — only the p-value text changes.
- Non-grouped `surv_fit()` (single fit, list-of-formulas, list-of-data, list×list) byte-identical; the attribute is added only for grouped calls.
- `surv_pvalue()`/`surv_median()` on grouped fits, genuine same-data multi-fit lists, and `ggsurvplot_group_by()` all unchanged (reroute guarded by `!is.list(data)`).
- New regression test passes on this branch, fails on master; full clean-session suite FAIL 0.
- Two independent adversarial reviewers cleared the change.
