### PR TITLE
Build risk table from a surv_summary data frame in ggsurvplot() (#409)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 ## Minor changes
 
+- `ggsurvplot()` on a `surv_summary()` data frame now supports `risk.table`, `cumevents` and `cumcensor`, building the number-at-risk / cumulative tables from the data frame (it already carries `n.risk`/`n.event`/`n.censor`) -- previously these were ignored and only the curve was drawn. The displayed tables match those from the corresponding survfit (for a weighted or left-truncated fit the internal `strata_size` may differ, but the shown numbers do not). A data-frame call without a table request still returns a bare ggplot (unchanged), and the survfit path is untouched. Requested by @wnilesanderson (#409).
+
 - `ggsurvplot()` on a grouped fit from `surv_fit(..., group.by=)` now shows the correct per-subgroup log-rank p-value on each panel with `pval = TRUE`. Previously every panel displayed the same pooled p-value, because `ggsurvplot_list()` recomputed the test on the pooled `data=` instead of each subgroup. `surv_fit()` now carries the per-group data subsets, which `ggsurvplot_list()` uses; the curves/tables and same-data multi-fit lists are unchanged (#799).
 
 - `ggsurvplot_combine()` now accepts `surv_summary()` data frames as list elements, not only survfit objects -- the data-frame analogue of `ggsurvplot_df()`. A data-frame element is drawn directly (and `data` is optional in that case). Survfit elements are unchanged. The number-at-risk/cumulative tables and median lines require a survfit and are refused with a clear message for a summary data frame. Requested by @HeidiSeibold (#323).

--- a/R/ggsurvplot.R
+++ b/R/ggsurvplot.R
@@ -383,7 +383,14 @@ ggsurvplot <- function(fit, data = NULL, fun = NULL,
   }
 
   else if(is.data.frame(fit))
-    ggsurv <- do.call(ggsurvplot_df, opts_df)
+    # Data-frame (surv_summary) input. Route through a wrapper that also builds
+    # the number-at-risk / cumulative tables from the data frame when requested
+    # (#409); with no table requested it returns the bare ggplot exactly as
+    # ggsurvplot_df() did.
+    ggsurv <- do.call(.ggsurvplot_df_tables,
+                      c(opts_df, list(risk.table = risk.table, cumevents = cumevents,
+                                      cumcensor = cumcensor, tables.height = tables.height,
+                                      tables.theme = tables.theme)))
 
   else if(.is_survfit(fit)){
 

--- a/R/ggsurvplot_df.R
+++ b/R/ggsurvplot_df.R
@@ -314,6 +314,140 @@ ggsurvplot_df <- function(fit, fun = NULL,
 # Helper functions
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+# Data-frame input path WITH number-at-risk / cumulative tables (#409).
+# ggsurvplot_df() itself only draws the curves (it is also the shared plot
+# builder for the survfit paths, so it must keep returning a bare ggplot). When
+# the user passes a surv_summary() data frame to ggsurvplot() and requests
+# risk.table / cumevents / cumcensor, this builds the curve plot with
+# ggsurvplot_df() and the tables from the data frame (which carries n.risk /
+# n.event / n.censor), assembling the same compound "ggsurvplot" object the
+# survfit path returns. Modeled on ggsurvplot_combine(); the tables are computed
+# by .get_timepoints_from_df(), which matches the survfit risk table exactly.
+.ggsurvplot_df_tables <- function(fit, risk.table = FALSE, cumevents = FALSE,
+                                  cumcensor = FALSE, risk.table.pos = c("out", "in"),
+                                  axes.offset = TRUE,
+                                  fontsize = 4.5,
+                                  tables.height = 0.25, tables.col = "black",
+                                  tables.y.text = TRUE, tables.y.text.col = TRUE,
+                                  risk.table.title = NULL, risk.table.col = tables.col,
+                                  risk.table.fontsize = fontsize,
+                                  risk.table.y.text = tables.y.text,
+                                  risk.table.y.text.col = tables.y.text.col,
+                                  risk.table.height = tables.height,
+                                  surv.plot.height = 0.75,
+                                  ncensor.plot.height = tables.height,
+                                  cumevents.height = tables.height,
+                                  cumcensor.height = tables.height,
+                                  cumevents.col = tables.col, cumevents.title = NULL,
+                                  cumevents.y.text = tables.y.text,
+                                  cumevents.y.text.col = tables.y.text.col,
+                                  cumcensor.col = tables.col, cumcensor.title = NULL,
+                                  cumcensor.y.text = tables.y.text,
+                                  cumcensor.y.text.col = tables.y.text.col,
+                                  ggtheme = theme_survminer(), tables.theme = ggtheme, ...)
+{
+  risk.table.pos <- match.arg(risk.table.pos)
+  risktable  <- .parse_risk_table_arg(risk.table);  risk.table <- risktable$display
+  cumev      <- .parse_risk_table_arg(cumevents);   cumevents  <- cumev$display
+  cumcens    <- .parse_risk_table_arg(cumcensor);   cumcensor  <- cumcens$display
+
+  # Curve plot (bare ggplot). axes.offset is forwarded (as the old direct
+  # ggsurvplot_df() call did via ...) so it is not silently dropped.
+  p <- ggsurvplot_df(fit, ggtheme = ggtheme, axes.offset = axes.offset, ...)
+
+  # No table requested -> behave exactly like ggsurvplot_df() (byte-identical).
+  if(!(risk.table | cumevents | cumcensor))
+    return(p)
+
+  # A risk table can only be built from a surv_summary()-style data frame.
+  fit <- as.data.frame(fit)
+  needed <- c("time", "n.risk", "n.event", "n.censor")
+  miss <- setdiff(needed, colnames(fit))
+  if(length(miss) > 0)
+    stop("Can't build a risk/events/censor table from this data frame: missing ",
+         "the column(s) ", .collapse(miss, sep = ", "),
+         ". Pass a surv_summary() data frame (or a survfit object).", call. = FALSE)
+
+  res <- list(plot = p)
+  scurve_cols <- .extract_ggplot_colors(p, grp.levels = attr(p, "parameters")$legend.labs)
+
+  # Shared table params, taken from the plot then extended (mirrors ggsurvplot_core).
+  pms <- attr(p, "parameters")
+  surv.color <- pms$color   # the plot's colour aesthetic (usually "strata")
+  pms$ggtheme <- ggtheme
+  pms$tables.theme <- tables.theme
+  pms$ylab <- pms$legend.title
+  pms$axes.offset <- axes.offset
+  # Time-point table from the data frame, wrapped in the (table, time) shape
+  # ggsurvtable() accepts; matches the survfit path exactly.
+  survtable <- .get_timepoints_from_df(fit, times = pms$time.breaks)
+  pms$fit <- list(table = survtable, time = fit$time)
+
+  # Each table is built with its OWN display type / colour / y-text, exactly as
+  # ggsurvplot_core does (a single shared call would apply one type to all).
+  if(risk.table){
+    pms$survtable <- "risk.table"
+    pms$risk.table.type <- risktable$type
+    pms$title <- risk.table.title
+    pms$fontsize <- risk.table.fontsize
+    pms$y.text <- risk.table.y.text
+    # In-plot table: colour the numbers by strata (the curve colours), as the
+    # survfit path does -- surv.color is the plot's colour aesthetic ("strata").
+    pms$color <- if(risk.table.pos == "in") surv.color else risk.table.col
+    if(risk.table.y.text.col) pms$y.text.col <- scurve_cols
+    pms$origin.align <- (risk.table.pos != "in")
+    res$table <- do.call(ggsurvtable, pms)
+  }
+  if(cumevents){
+    pms$survtable <- "cumevents"
+    pms$risk.table.type <- cumev$type
+    pms$title <- cumevents.title
+    pms$fontsize <- fontsize
+    pms$color <- cumevents.col
+    pms$y.text <- cumevents.y.text
+    if(cumevents.y.text.col) pms$y.text.col <- scurve_cols
+    pms$origin.align <- TRUE
+    res$cumevents <- do.call(ggsurvtable, pms)
+  }
+  if(cumcensor){
+    pms$survtable <- "cumcensor"
+    pms$risk.table.type <- cumcens$type
+    pms$title <- cumcensor.title
+    pms$fontsize <- fontsize
+    pms$color <- cumcensor.col
+    pms$y.text <- cumcensor.y.text
+    if(cumcensor.y.text.col) pms$y.text.col <- scurve_cols
+    pms$origin.align <- TRUE
+    res$ncensor.plot <- do.call(ggsurvtable, pms)
+  }
+
+  # Component heights / y-text attributes (per table, as ggsurvplot_core).
+  heights <- list(
+    plot         = surv.plot.height,
+    table        = ifelse(risk.table, risk.table.height, 0),
+    ncensor.plot = ifelse(cumcensor, cumcensor.height, 0),
+    cumevents    = ifelse(cumevents, cumevents.height, 0)
+  )
+  y.text     <- list(table = risk.table.y.text, cumevents = cumevents.y.text,
+                     cumcensor = cumcensor.y.text)
+  y.text.col <- list(table = risk.table.y.text.col, cumevents = cumevents.y.text.col,
+                     cumcensor = cumcensor.y.text.col)
+
+  res$data.survplot  <- fit
+  res$data.survtable <- survtable
+
+  class(res) <- c("ggsurvplot", "ggsurv", "list")
+  attr(res, "heights") <- heights
+  attr(res, "y.text") <- y.text
+  attr(res, "y.text.col") <- y.text.col
+  attr(res, "legend.position") <- pms$legend
+  attr(res, "legend.labs") <- pms$legend.labs
+  attr(res, "cumcensor") <- cumcensor
+  attr(res, "risk.table.pos") <- risk.table.pos
+  attr(res, "axes.offset") <- axes.offset
+  res
+}
+
 # Adapt ylab according to the value of the argument fun
 #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 .check_ylab <- function(ylab, fun){

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -189,6 +189,54 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
 #   - n.event: the cumulative number of events that have occurred since the last time listed until time t+0
 #   - n.censor: number of censored subjects
 #   - strata_size: number of subject in the strata
+# Build the number-at-risk / cumulative time-point table directly from a
+# surv_summary() DATA FRAME (no survfit available), for the data-frame input path
+# of ggsurvplot() (#409). Mirrors the columns produced by
+# .get_timepoints_survsummary(): at each requested time, n.risk is the number
+# still at risk (the value at the first summary row with time >= t; 0 past the
+# last), and cum.n.event / cum.n.censor are the running totals up to t, per
+# stratum. strata_size is the number at risk at the origin. Verified to match
+# .get_timepoints_survsummary() exactly for a df produced by surv_summary(fit).
+.get_timepoints_from_df <- function(df, times, decimal.place = 0){
+  df <- as.data.frame(df)
+  if(is.null(df$strata)) df$strata <- factor(rep("All", nrow(df)))
+  df$strata <- factor(df$strata)
+  parts <- lapply(levels(df$strata), function(s){
+    o <- df[df$strata == s, , drop = FALSE]
+    o <- o[order(o$time), , drop = FALSE]
+    ssize  <- max(o$n.risk)
+    n.risk <- vapply(times, function(tt){
+      idx <- which(o$time >= tt); if(length(idx)) o$n.risk[idx[1]] else 0
+    }, numeric(1))
+    cum.ev  <- vapply(times, function(tt) sum(o$n.event[o$time  <= tt]),  numeric(1))
+    cum.cen <- vapply(times, function(tt) sum(o$n.censor[o$time <= tt]), numeric(1))
+    n.ev    <- c(cum.ev[1],  diff(cum.ev))
+    n.cen   <- c(cum.cen[1], diff(cum.cen))
+    data.frame(strata = s, time = times,
+               n.risk = round(n.risk, decimal.place),
+               pct.risk = round(n.risk * 100 / ssize),
+               n.event = round(n.ev, decimal.place),
+               cum.n.event = round(cum.ev, decimal.place),
+               n.censor = round(n.cen, decimal.place),
+               cum.n.censor = round(cum.cen, decimal.place),
+               strata_size = ssize, stringsAsFactors = FALSE)
+  })
+  res <- do.call(rbind, parts)
+  res$strata <- factor(res$strata, levels = levels(df$strata))
+  # Carry any strata-variable columns (e.g. "sex"), constant within a stratum,
+  # so the table matches .get_timepoints_survsummary() and can be faceted.
+  standard <- c("time","n.risk","n.event","n.censor","surv","std.err",
+                "upper","lower","strata")
+  extra <- setdiff(colnames(df), standard)
+  for(v in extra){
+    # Index the original column by the first row of each stratum, preserving the
+    # column's class (e.g. a factor stays a factor, matching the survfit path).
+    res[[v]] <- df[[v]][match(as.character(res$strata), as.character(df$strata))]
+  }
+  rownames(res) <- seq_len(nrow(res))
+  res
+}
+
 .get_timepoints_survsummary <- function(fit, data, times, decimal.place = 0)
 {
   survsummary <- summary(fit, times = times, extend = TRUE)

--- a/tests/testthat/test-ggsurvplot-df-risktable.R
+++ b/tests/testthat/test-ggsurvplot-df-risktable.R
@@ -1,0 +1,88 @@
+context("risk table from a surv_summary data frame (#409)")
+
+# Regression test for #409: ggsurvplot(surv_summary(fit), risk.table = TRUE)
+# produced only the curve, no risk table -- the data-frame input path ignored
+# risk.table/cumevents/cumcensor. It now builds those tables from the data frame
+# (which carries n.risk / n.event / n.censor) and returns the same compound
+# "ggsurvplot" object as the survfit path. ggsurvplot_df() itself is unchanged
+# (still returns a bare ggplot), so the survfit and combine paths are untouched.
+library(survival)
+
+draw_ok <- function(p) {
+  tmp <- tempfile(fileext = ".pdf"); grDevices::pdf(tmp)
+  on.exit({ grDevices::dev.off(); unlink(tmp) }, add = TRUE)
+  print(p); invisible(TRUE)
+}
+
+fit <- survfit(Surv(time, status) ~ sex, data = lung)
+ss  <- surv_summary(fit, lung)
+
+test_that(".get_timepoints_from_df matches the survfit time-point table (#409)", {
+  cols <- c("strata", "time", "n.risk", "pct.risk", "n.event",
+            "cum.n.event", "n.censor", "cum.n.censor", "strata_size")
+  times <- c(0, 200, 400, 600, 800, 1000)
+  tgt <- survminer:::.get_timepoints_survsummary(fit, lung, times)[, cols]
+  got <- survminer:::.get_timepoints_from_df(ss, times)[, cols]
+  tgt$strata <- as.character(tgt$strata); got$strata <- as.character(got$strata)
+  expect_equal(got, tgt, check.attributes = FALSE)
+})
+
+test_that("ggsurvplot(surv_summary(fit), risk.table=TRUE) builds a risk table (#409)", {
+  p <- suppressWarnings(ggsurvplot(ss, risk.table = TRUE))
+  expect_s3_class(p, "ggsurvplot")
+  expect_false(is.null(p$table))
+  expect_error(suppressWarnings(draw_ok(p)), NA)
+  # the risk-table layer is identical to the survfit path's
+  tbl_df  <- suppressWarnings(ggplot2::ggplot_build(p$table)$data)
+  tbl_fit <- suppressWarnings(ggplot2::ggplot_build(
+    ggsurvplot(fit, data = lung, risk.table = TRUE)$table)$data)
+  expect_equal(tbl_df, tbl_fit)
+})
+
+test_that("cumevents and cumcensor also build from a data frame (#409)", {
+  p <- suppressWarnings(ggsurvplot(ss, cumevents = TRUE, cumcensor = TRUE))
+  expect_false(is.null(p$cumevents))
+  expect_false(is.null(p$ncensor.plot))
+  expect_error(suppressWarnings(draw_ok(p)), NA)
+})
+
+test_that("single-stratum data frame gets a risk table (#409)", {
+  fit1 <- survfit(Surv(time, status) ~ 1, data = lung)
+  p <- suppressWarnings(ggsurvplot(surv_summary(fit1, lung), risk.table = TRUE))
+  expect_false(is.null(p$table))
+  expect_error(suppressWarnings(draw_ok(p)), NA)
+})
+
+test_that("no-regression: a data frame without a table request is a bare ggplot (#409)", {
+  p <- suppressWarnings(ggsurvplot(ss))
+  expect_s3_class(p, "ggplot")
+  expect_false(inherits(p, "ggsurvplot"))
+})
+
+test_that("axes.offset is honored on the data-frame path (#409)", {
+  xr <- function(p){ pl <- if(inherits(p,"ggsurvplot")) p$plot else p
+    suppressWarnings(ggplot2::ggplot_build(pl))$layout$panel_params[[1]]$x.range }
+  # axes.offset = FALSE removes the x expansion (range starts at 0), like the
+  # survfit path; with a table too.
+  expect_equal(xr(suppressWarnings(ggsurvplot(ss, axes.offset = FALSE)))[1], 0)
+  expect_equal(xr(suppressWarnings(ggsurvplot(ss, axes.offset = FALSE, risk.table = TRUE)))[1], 0)
+})
+
+test_that("cumevents/cumcensor display type is applied per table (#409)", {
+  lbl <- function(tb) suppressWarnings(ggplot2::ggplot_build(tb)$data[[1]]$label)
+  # cumevents = "percentage" shows percentages, matching the survfit path
+  ce_df  <- suppressWarnings(ggsurvplot(ss, cumevents = "percentage"))$cumevents
+  ce_fit <- suppressWarnings(ggsurvplot(fit, data = lung, cumevents = "percentage"))$cumevents
+  expect_equal(lbl(ce_df), lbl(ce_fit))
+})
+
+test_that("risk.table.height is honored on the data-frame path (#409)", {
+  h <- attr(suppressWarnings(ggsurvplot(ss, risk.table = TRUE, risk.table.height = 0.4)),
+            "heights")$table
+  expect_equal(h, 0.4)
+})
+
+test_that("a data frame lacking n.risk gives a clear error with risk.table (#409)", {
+  bad <- data.frame(time = 1:5, surv = seq(1, 0.5, length.out = 5))
+  expect_error(suppressWarnings(ggsurvplot(bad, risk.table = TRUE)), "Can't build")
+})


### PR DESCRIPTION
Fixes #409.

`ggsurvplot(surv_summary(fit), risk.table = TRUE)` previously drew only the curve — the data-frame input path ignored `risk.table` / `cumevents` / `cumcensor`, even though `surv_summary()` output carries `n.risk` / `n.event` / `n.censor`.

## Change

The data-frame path now builds those tables from the data frame and returns the same compound `ggsurvplot` object as the survfit path.

```r
library(survminer); library(survival)
fit <- survfit(Surv(time, status) ~ sex, data = lung)
ggsurvplot(surv_summary(fit, lung), risk.table = TRUE)
```

- New `.get_timepoints_from_df()` computes the number-at-risk / cumulative time-point table from the data frame; verified to match `.get_timepoints_survsummary()` (survfit) exactly on all columns.
- New `.ggsurvplot_df_tables()` assembles the compound object (per-table display types, per-table heights, colours, in-plot strata colouring, `data.survplot`/`data.survtable`), mirroring `ggsurvplot_core()`.
- `ggsurvplot_df()` is unchanged, so the survfit and `ggsurvplot_combine` paths stay byte-identical.

## Verification

- The displayed df tables (`ggplot_build` of `$table`/`$cumevents`/`$ncensor.plot`) are **identical** to the survfit path for `~sex`, `~1`, `~rx`, non-round `break.time.by`, and `percentage`/`abs_pct`/`nrisk_cumcensor` types; `risk.table.pos="in"` renders pixel-identical.
- Byte-identical no-regression: df default (no table, incl. `axes.offset=FALSE`/`fun=`/`conf.int`/`palette`/`xlim`), the full survfit path, and `ggsurvplot_combine` — all unchanged vs master.
- A data frame lacking `n.risk` gives a clear error instead of a cryptic crash. (For weighted/left-truncated fits the internal `strata_size` may differ from `fit$n`, but the shown numbers match.)
- New regression test (`test-ggsurvplot-df-risktable.R`) passes on this branch, fails on master; full clean-session suite FAIL 0.
- Three independent adversarial reviews cleared the change.

Requested by @wnilesanderson.
