### PR TITLE
Add "Customization recipes" vignette (first recipe: solid-to-dashed below X% at risk, #559)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@
 
 ## Major changes
 
+## Documentation
+
+- New "Customization recipes" vignette collecting reusable recipes that solve common requests by composing on the objects survminer already returns (`ggsurvplot()`'s compound object and the `surv_summary()` data frame). The first recipe draws curves that switch from solid to dashed once the number at risk drops below a fraction of the initial cohort, as some reporting guidelines require (#559).
+
 ## Minor changes
 
 - `ggcompetingrisks()` now fails with a clear, actionable message instead of the opaque `Names repair functions can't return 'NA' values` error when given predicted curves from a multistate Cox model evaluated at several covariate profiles -- `survfit(coxph_multistate, newdata = <2+ rows>)`, whose `pstate` is a 3-D array with one column per profile-by-state combination, more than the number of states. The message points to supplying a single profile, using `cmprsk::cuminc()` / `survfit(Surv(., type = "mstate") ~ ...)`, or base `plot()` for the per-profile curves. The 2-D competing-risks path and a single-profile prediction (which already rendered) are unchanged. Reported by @adamssv (#625).

--- a/vignettes/Customization_recipes.Rmd
+++ b/vignettes/Customization_recipes.Rmd
@@ -1,0 +1,103 @@
+---
+title: "Customization recipes"
+author: "survminer"
+output:
+  rmarkdown::html_vignette:
+    toc: true
+    toc_depth: 2
+vignette: >
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteIndexEntry{Customization recipes}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  comment = "#>",
+  collapse = TRUE,
+  message = FALSE,
+  warning = FALSE,
+  fig.width = 7,
+  fig.height = 5
+)
+```
+
+`ggsurvplot()` returns a compound object -- a list holding the survival
+curve (`$plot`), the risk table (`$table`), the data actually plotted
+(`$data.survplot`), and more -- and `surv_summary()` returns a plain data
+frame with one row per event/censoring time (`time`, `surv`, `n.risk`,
+`n.event`, `n.censor`, `strata`, ...). Because both are ordinary ggplot2 /
+data-frame objects, a lot of "can survminer do X?" questions are answered by
+*composing* on what these already give you rather than by a dedicated argument.
+
+This page collects such recipes. Each is self-contained and uses the `lung`
+data set from the survival package.
+
+```{r setup}
+library(survminer)
+library(survival)
+library(dplyr)
+library(ggplot2)
+```
+
+# Dashed curves once few patients remain at risk
+
+Some reporting guidelines ask that a survival curve be drawn with a **dashed
+line beyond the point where few patients remain at risk** -- for example the
+[guidelines for reporting mortality and morbidity after cardiac valve
+interventions](https://pubmed.ncbi.nlm.nih.gov/18355567/) recommend a dashed
+line once the number at risk falls below 10% of the initial cohort (survminer
+issue [#559](https://github.com/kassambara/survminer/issues/559)).
+
+`surv_summary()` carries `n.risk` per stratum, so you can find, for each curve,
+the first time it drops below the threshold, split the curve into a solid
+"dense" part and a dashed "sparse" tail, and draw the two with different
+`linetype`s. Repeating the boundary point in the solid part makes the two step
+segments meet with no gap.
+
+```{r dashed-helper}
+# KM curves that switch solid -> dashed once the number at risk drops below
+# `frac` of each group's initial cohort (default 10%).
+ggsurv_dashed_below <- function(fit, data, frac = 0.10, ...) {
+  ss <- surv_summary(fit, data = data) %>%
+    group_by(strata) %>%
+    mutate(onset = { s <- n.risk < frac * max(n.risk)
+                     if (any(s)) min(time[s]) else Inf },
+           phase = ifelse(time >= onset, "sparse", "dense")) %>%
+    ungroup()
+  # repeat the first sparse point in the solid phase so the two steps join
+  bridge <- ss %>% filter(phase == "sparse") %>%
+    group_by(strata) %>% slice_min(time, n = 1) %>% ungroup() %>%
+    mutate(phase = "dense")
+
+  ggplot(bind_rows(ss, bridge), aes(time, surv, colour = strata)) +
+    geom_step(aes(linetype = phase), linewidth = 0.9) +
+    geom_point(data = filter(ss, n.censor > 0), shape = 3, size = 2,
+               show.legend = FALSE) +
+    scale_linetype_manual(values = c(dense = "solid", sparse = "dashed"),
+                          breaks = "sparse",
+                          labels = sprintf("< %g%% at risk", 100 * frac),
+                          name = NULL) +
+    coord_cartesian(ylim = c(0, 1)) +
+    labs(x = "Time", y = "Survival probability", ...) +
+    theme_survminer()
+}
+```
+
+```{r dashed-plot}
+fit <- survfit(Surv(time, status) ~ sex, data = lung)
+ggsurv_dashed_below(fit, lung, frac = 0.10) +
+  scale_colour_discrete(name = "Sex", labels = c("Male", "Female"))
+```
+
+Each curve turns dashed at its own crossing point. A few adjustments:
+
+- The threshold is each group's own initial cohort (`max(n.risk)` per stratum).
+  To key it to the pooled study size instead, replace `max(n.risk)` with the
+  overall starting `n` and every curve dashes at the same count.
+- `frac` is an argument, so the same helper produces the guideline's 10% cutoff
+  or any other fraction.
+- This rebuilds the line layer to control `linetype`, so it does not go through
+  `ggsurvplot()` directly. If you also want the number-at-risk table underneath,
+  build it separately with `ggrisktable()` on the same fit and stack the two
+  (for example with `ggpubr::ggarrange(..., ncol = 1, heights = c(3, 1))`).


### PR DESCRIPTION
Refs #559 (keeps the issue open — see below).

Adds a "Customization recipes" vignette: a central, discoverable home for the recurring pattern where a request is solved by composing on what survminer already returns (`ggsurvplot()`'s compound object, the `surv_summary()` data frame) rather than by a new argument.

## First recipe: solid-to-dashed curves once few remain at risk

Some reporting guidelines (e.g. [cardiac valve interventions](https://pubmed.ncbi.nlm.nih.gov/18355567/)) ask for a dashed line once the number at risk falls below ~10% of the initial cohort (#559). The recipe uses `surv_summary()`'s per-stratum `n.risk` to find each curve's crossing time, splits the curve into a solid head and a dashed tail sharing the boundary point (so the steps join with no gap), and maps `linetype` to the two phases. `frac` is an argument, so it does the guideline's 10% or any cutoff.

## Scope / process

- Docs-only: one new `.Rmd`, no R code touched. Self-contained, uses `lung` and only declared dependencies (`dplyr`, `ggplot2`); renders cleanly under `knitr`.
- Uses `Refs` (not `Fixes`): #559 stays open, since a built-in `ggsurvplot()` argument for this remains a reasonable future feature — the vignette is the discoverable workaround in the meantime.

The vignette is intended to grow: further composition recipes (from issues that are answered by customizing the returned object) can be appended as sections.
