### PR TITLE
Make step-legend-key recipe portable to R < 4.4 (#537)

### DIFF
--- a/vignettes/Customization_recipes.Rmd
+++ b/vignettes/Customization_recipes.Rmd
@@ -117,6 +117,7 @@ library(grid)
 # Draw the legend key of a ggsurvplot's curves as a small step (stair) that
 # echoes the Kaplan-Meier shape, instead of the default straight line.
 step_legend_key <- function(p) {
+  `%||%` <- function(x, y) if (is.null(x)) y else x   # base R has this since 4.4
   draw_key_step <- function(data, params, size) {
     grid::linesGrob(
       x = c(0, 0.45, 0.45, 1), y = c(0.25, 0.25, 0.7, 0.7),


### PR DESCRIPTION
Small robustness follow-up to #804. The `step_legend_key()` recipe used `%||%`, which is only a base-R operator since R 4.4.0; survminer supports older R, so a user copy-pasting the helper on R < 4.4 (without rlang/ggplot2 providing `%||%`) would hit "could not find function `%||%`". Defines `%||%` locally inside the helper so the recipe is self-contained on any supported R version. Docs-only; vignette rebuilt and verified. Flagged by a pre-close reviewer on #537.