### PR TITLE
Harden median-CI recipe: drop internal helper, handle unreached medians (#345)

### DIFF
--- a/vignettes/Customization_recipes.Rmd
+++ b/vignettes/Customization_recipes.Rmd
@@ -153,18 +153,15 @@ To also show the *confidence interval* of the median (survminer issue
 a horizontal band at survival = 0.5.
 
 ```{r median-ci}
-# Match each group's curve colour, falling back to a palette.
-.pull_strata_colours <- function(p, strata) {
-  cols <- tryCatch(survminer:::.extract_ggplot_colors(p$plot, grp.levels = strata),
-                   error = function(e) NULL)
-  if (is.null(cols) || length(cols) != length(strata))
-    cols <- scales::hue_pal()(length(strata))
-  unname(cols)
-}
-
 add_median_ci <- function(p, fit, y = 0.5) {
   med  <- surv_median(fit)
-  cols <- .pull_strata_colours(p, med$strata)
+  # one colour per group, read from the drawn curve layer (no internal helpers)
+  b     <- ggplot2::ggplot_build(p$plot)$data[[1]]
+  cols  <- b$colour[match(sort(unique(b$group)), b$group)]
+  # drop groups whose median is not reached (surv_median() returns NA there)
+  keep  <- !is.na(med$median)
+  med   <- med[keep, ]
+  cols  <- cols[keep]
   p$plot +
     geom_segment(data = med, aes(x = lower, xend = upper, y = y, yend = y),
                  colour = cols, linewidth = 0.9, inherit.aes = FALSE) +
@@ -183,7 +180,9 @@ p
 ```
 
 The horizontal bar spans the 95% CI of the median survival time
-(`surv_median()`'s `lower`/`upper`); the point marks the median itself.
+(`surv_median()`'s `lower`/`upper`); the point marks the median itself. A group
+whose survival never drops to 0.5 has no median (`surv_median()` returns `NA`),
+so it is simply left without a bar.
 
 # Plot math (expressions) in the legend
 


### PR DESCRIPTION
Small robustness follow-up to #806, from the pre-close review of #345. The median-CI recipe now reads group colours from the drawn curve layer via public `ggplot_build()` instead of the internal `survminer:::.extract_ggplot_colors`, and drops groups whose median is never reached (`surv_median()` returns `NA`) with a note. Docs-only; vignette rebuilt and verified (normal case unchanged; NA-median case renders without error).