### PR TITLE
Add Cox-adjusted-curves risk-table recipe to vignette (#231)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@
 
 ## Documentation
 
-- New "Customization recipes" vignette collecting reusable recipes that solve common requests by composing on the objects survminer already returns (`ggsurvplot()`'s compound object and the `surv_summary()` data frame). Recipes so far: solid-to-dashed curves once the number at risk drops below a fraction of the initial cohort (#559); step-shaped legend keys that echo the Kaplan-Meier curve (#537); marking the median survival and its confidence interval (#345); plot math (expressions) in the legend (#350); and one shared legend across a grid of survival plots (#340).
+- New "Customization recipes" vignette collecting reusable recipes that solve common requests by composing on the objects survminer already returns (`ggsurvplot()`'s compound object and the `surv_summary()` data frame). Recipes so far: solid-to-dashed curves once the number at risk drops below a fraction of the initial cohort (#559); step-shaped legend keys that echo the Kaplan-Meier curve (#537); marking the median survival and its confidence interval (#345); plot math (expressions) in the legend (#350); one shared legend across a grid of survival plots (#340); and a per-group risk table under Cox-adjusted survival curves (#231).
 
 ## Minor changes
 

--- a/vignettes/Customization_recipes.Rmd
+++ b/vignettes/Customization_recipes.Rmd
@@ -229,3 +229,40 @@ plots <- lapply(names(subsets), function(nm) {
 ggpubr::ggarrange(plotlist = plots, ncol = 2, nrow = 2,
                   common.legend = TRUE, legend = "bottom")
 ```
+
+# Risk table under Cox-adjusted survival curves
+
+Cox-model *adjusted* curves are drawn with `survfit(coxph_fit, newdata = ...)`,
+one curve per covariate profile. Asking for `risk.table = TRUE` there gives a
+single pooled row, because those predicted curves have no per-group number at
+risk -- the profiles are hypothetical covariate combinations, not subject groups
+(survminer issue [#231](https://github.com/kassambara/survminer/issues/231)).
+
+When the profiles correspond to a **real grouping variable** (here `sex`), the
+meaningful at-risk counts are the Kaplan-Meier ones for that variable. Build them
+with `ggrisktable()` from a KM fit and drop them into the compound object's
+`$table` slot, matching `legend.labs` and sharing an `xlim` so the two panels
+line up:
+
+```{r cox-risktable, fig.height = 6}
+km.fit  <- survfit(Surv(time, status) ~ sex, data = lung)
+res.cox <- coxph(Surv(time, status) ~ age + sex + ph.ecog, data = lung)
+sex_df  <- with(lung, data.frame(sex = c(1, 2),
+                                 age = mean(age, na.rm = TRUE), ph.ecog = c(1, 1)))
+fit <- survfit(res.cox, newdata = sex_df)
+
+# note: a survfit() from a coxph fit carries no data, so pass `data =` explicitly
+cox.surv <- ggsurvplot(fit, data = sex_df, conf.int = TRUE,
+                       legend.labs = c("sex=1", "sex=2"))
+cox.surv$table <- ggrisktable(km.fit, data = lung, color = "strata",
+                              legend.labs = c("sex=1", "sex=2"),
+                              xlim = c(0, max(fit$time)))
+print(cox.surv, risk.table.height = 0.28)
+```
+
+Be careful with the meaning: the table is the **Kaplan-Meier number at risk for
+the grouping variable**, not an at-risk count for the model-based adjusted curves
+(adjusted curves are expectations for hypothetical profiles and have no literal
+number at risk). It is honest only when each `newdata` row is a real subgroup of
+the data (e.g. `sex = 1` / `sex = 2`); for arbitrary covariate combinations there
+is no per-profile risk table and this overlay would mislead.


### PR DESCRIPTION
Refs #231 (keeps the issue open — see below).

Adds a recipe to the "Customization recipes" vignette for a per-group risk table under Cox-adjusted survival curves.

## Why a recipe, not a code change

`ggsurvplot(survfit(coxph, newdata = profiles), risk.table = TRUE)` shows a single pooled row. Verified against current dev: the root cause is that `.get_timepoints_survsummary()` (`R/utilities.R:252`) branches only on `is.null(fit$strata)`, unlike `surv_summary()` which splits the cox-`newdata` matrix — but even after splitting, `summary(fit, times=)` only returns the **pooled** cohort n.risk. The predicted per-profile curves genuinely have no per-group at-risk set, so a code fix to the risk-table builder can't produce the counts the reporter wants (sex=1: 138…, sex=2: 90…). Those come only from a KM fit by the grouping variable.

## Recipe

Build the KM risk table with `ggrisktable()` and assign it to the compound object's `$table`, matching `legend.labs` and sharing `xlim`:

```r
cox.surv <- ggsurvplot(fit, data = sex_df, conf.int = TRUE,
                       legend.labs = c("sex=1", "sex=2"))
cox.surv$table <- ggrisktable(km.fit, data = lung, color = "strata",
                              legend.labs = c("sex=1", "sex=2"),
                              xlim = c(0, max(fit$time)))
print(cox.surv, risk.table.height = 0.28)
```

This reproduces the maintainer's own "hack result" from the thread (adjusted curves + 2-row KM risk table). The recipe states the honesty caveat: the table is the KM at-risk count *by the grouping variable*, valid only when each `newdata` row is a real subgroup — not an at-risk count for the model-based adjusted curves.

## Scope

Docs-only, no package code. Uses `Refs` (not `Fixes`): #231 stays open to track a possible built-in option. Also confirmed while verifying: the old `legend.labs` length-2 crash is already fixed (now a guarded warning), and the `pval=TRUE` "null model" warning is expected for a cox-`newdata` fit (no groups to compare).
