### PR TITLE
Add competing-risks single-event + risk-table recipe to vignette (#223)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@
 
 ## Documentation
 
-- New "Customization recipes" vignette collecting reusable recipes that solve common requests by composing on the objects survminer already returns (`ggsurvplot()`'s compound object and the `surv_summary()` data frame). Recipes so far: solid-to-dashed curves once the number at risk drops below a fraction of the initial cohort (#559); step-shaped legend keys that echo the Kaplan-Meier curve (#537); marking the median survival and its confidence interval (#345); plot math (expressions) in the legend (#350); one shared legend across a grid of survival plots (#340); a per-group risk table under Cox-adjusted survival curves (#231); and a number-at-risk table under `ggadjustedcurves()` (#286).
+- New "Customization recipes" vignette collecting reusable recipes that solve common requests by composing on the objects survminer already returns (`ggsurvplot()`'s compound object and the `surv_summary()` data frame). Recipes so far: solid-to-dashed curves once the number at risk drops below a fraction of the initial cohort (#559); step-shaped legend keys that echo the Kaplan-Meier curve (#537); marking the median survival and its confidence interval (#345); plot math (expressions) in the legend (#350); one shared legend across a grid of survival plots (#340); a per-group risk table under Cox-adjusted survival curves (#231); a number-at-risk table under `ggadjustedcurves()` (#286); and, for a `cmprsk::cuminc()` competing-risks fit, plotting a single event of interest with a number-at-risk table (#223).
 
 ## Minor changes
 

--- a/vignettes/Customization_recipes.Rmd
+++ b/vignettes/Customization_recipes.Rmd
@@ -305,3 +305,58 @@ print(km.surv, risk.table.height = 0.26)
 The same honesty caveat applies: the table is the KM number at risk **for the
 grouping variable**, not for the adjusted curves, and is meaningful only when the
 adjustment variable is a real group.
+
+# Single event and a number-at-risk table for competing risks
+
+For a `cmprsk::cuminc()` competing-risks fit, two common requests are to plot only
+the **event of interest** (dropping the competing events) and to add a
+**number-at-risk table** underneath (survminer issue
+[#223](https://github.com/kassambara/survminer/issues/223)). Both compose from the
+`cuminc` object and a companion `survfit()`: the cumulative-incidence estimates
+(and their variance) for the event of interest come straight out of `cuminc`, and
+the number at risk -- subjects still event-free and under observation, the usual
+convention for a competing-risks figure -- is the `n.risk` of a `survfit()` that
+treats **any** event as the endpoint.
+
+```{r cuminc-risktable, fig.height = 6, eval = requireNamespace("cmprsk", quietly = TRUE)}
+library(cmprsk)
+
+# competing-risks data: event 1 = PCM (of interest), 2 = death (competing)
+mg <- transform(mgus2,
+                etime = ifelse(pstat == 1, ptime, futime),
+                event = ifelse(pstat == 1, 1, 2 * death))
+pal <- c("#E7302A", "#2E43F3"); xmax <- max(mg$etime); eoi <- "1"
+
+ci <- cuminc(mg$etime, mg$event, group = mg$sex)
+
+# cumulative incidence of the event of interest, per group, with 95% CI bands
+comps <- names(ci)[grepl(paste0(" ", eoi, "$"), names(ci))]
+cif <- do.call(rbind, lapply(comps, function(nm) {
+  d <- as.data.frame(ci[[nm]][c("time", "est", "var")])
+  d$group <- sub(paste0(" ", eoi, "$"), "", nm); d
+}))
+cif$lower <- pmax(0, cif$est - 1.96 * sqrt(cif$var))
+cif$upper <- pmin(1, cif$est + 1.96 * sqrt(cif$var))
+
+p_cif <- ggplot(cif, aes(time, est, colour = group, fill = group)) +
+  geom_ribbon(aes(ymin = lower, ymax = upper), alpha = 0.15, colour = NA) +
+  geom_step(linewidth = 0.9) +
+  scale_colour_manual(values = pal) + scale_fill_manual(values = pal) +
+  scale_x_continuous(breaks = seq(0, xmax, 60)) +
+  coord_cartesian(xlim = c(0, xmax), ylim = c(0, 1)) +
+  labs(x = "Time (months)", y = "Cumulative incidence of PCM") +
+  guides(colour = guide_legend("Sex"), fill = guide_legend("Sex")) +
+  theme_survminer()
+
+# number-at-risk table: survfit on "any event" gives the event-free at-risk count
+km.surv <- ggsurvplot(survfit(Surv(etime, event > 0) ~ sex, data = mg), data = mg,
+                      risk.table = TRUE, palette = pal, legend.labs = c("F", "M"),
+                      legend.title = "Sex", break.time.by = 60, xlim = c(0, xmax))
+km.surv$plot <- p_cif                       # keep the aligned number-at-risk table
+print(km.surv, risk.table.height = 0.26)
+```
+
+To pick a different event of interest, change `eoi` (the numeric `fstatus` code as
+a string). The confidence bands use `cuminc`'s `var`; note the at-risk counts are
+the standard event-free-under-observation convention, not a competing-risks
+weighted count.


### PR DESCRIPTION
Refs #223 (keeps the issue open — see below).

Adds a recipe to the "Customization recipes" vignette covering the two requests from this thread that the earlier `conf.int` work did not: plotting a **single event of interest** (@SophiaJia) and adding a **number-at-risk table** under a competing-risks plot (@for8ver3).

## Approach

Both compose from a `cmprsk::cuminc()` fit plus a companion `survfit()`:
- the cumulative-incidence estimates and their variance for the event of interest come straight from the `cuminc` object (subset its components by the `fstatus` code);
- the number at risk — subjects still event-free and under observation, the usual convention for a competing-risks figure — is the `n.risk` of a `survfit()` that treats **any** event as the endpoint.

Build the CIF ggplot (with 95% CI bands from `cuminc`'s `var`), then swap it into a KM `ggsurvplot()`'s `$plot` to reuse its aligned number-at-risk table (the same swap trick as the #231/#286 recipes). The `cmprsk` chunk is guarded with `eval = requireNamespace("cmprsk")` so the vignette builds even without it.

Reproduces the structure of the figure @for8ver3 posted (single-event CIF by group + at-risk table).

## Scope

Docs-only, no package code. Uses `Refs` (not `Fixes`): #223 stays open to track a built-in `risk.table` for `ggcompetingrisks()` (a design call — @lgondara noted the competing-risks at-risk definition is nuanced). The `conf.int` part of the thread already shipped.
