### PR TITLE
Extend the plotmath legend recipe to the risk table (#350)

### DIFF
--- a/vignettes/Customization_recipes.Rmd
+++ b/vignettes/Customization_recipes.Rmd
@@ -205,6 +205,23 @@ p
 replacing survminer's default colour scale with one that carries the math
 labels.)
 
+With a risk table (`risk.table = TRUE`), the table's strata labels are a
+separate discrete y-axis, so they keep the raw `sex=1` / `sex=2` names unless you
+relabel them too. Carry the same expressions to `$table` with
+`scale_y_discrete()`. The table lists the strata top-to-bottom but the discrete
+y-axis orders its breaks bottom-to-top, so pass the labels reversed to keep each
+label on its own row:
+
+```{r plotmath-legend-risktable}
+math.labs <- c(expression(x^2 ~ y^2), expression(alpha[i] >= beta))
+p <- ggsurvplot(fit3, data = lung, palette = pal, risk.table = TRUE,
+                legend.title = "Group")
+p$plot  <- p$plot  +
+  scale_colour_manual(values = pal, labels = math.labs, name = "Group")
+p$table <- p$table + scale_y_discrete(labels = rev(math.labs))
+p
+```
+
 # One shared legend across a grid of plots
 
 Several separate survival analyses that use the same grouping are often shown in


### PR DESCRIPTION
Follow-up to the "Plot math (expressions) in the legend" recipe (#350). That recipe relabels only the curve's colour scale, so with `risk.table = TRUE` the table's strata rows kept the raw `sex=1` / `sex=2` names — a math legend over a plain-text table.

This adds a step that carries the same `expression()` labels to the risk table's discrete y-axis with `scale_y_discrete()`, so the legend and the table match. The labels are passed reversed because the table lists strata top-to-bottom while the discrete y-axis orders its breaks bottom-to-top.

Docs-only (one recipe extended in `vignettes/Customization_recipes.Rmd`); the full vignette renders. Verified the rendered output shows genuine plotmath in both the legend and the risk-table strata rows, correctly aligned and coloured by strata.

#350 stays open to track possible native `expression`/`legend.labs` support (two reviewers judged a native change disproportionate to the regression surface — `legend.labs` is used as a character key for strata matching, colour names, and table labels across ~10 files — so the recipe is the answer for now).

Refs #350
