### PR TITLE
Fix surv_median() on a fit without / non-default confidence limits (#818)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
 
 ## Minor changes
 
+- `surv_median()` no longer errors on a `survfit` stored without confidence limits (`conf.type = "none"`) or fitted at a non-default confidence level (e.g. `conf.int = 0.9`). It hard-coded the `0.95LCL`/`0.95UCL` columns of `summary()$table`; these are now detected by suffix, so a `0.9` fit returns its real limits and a no-CI fit returns the median with `NA` limits instead of failing. Default (0.95) output is unchanged. Found alongside #639 (#818).
+
 - `ggsurvplot()` no longer errors with a cryptic `arguments imply differing number of rows` message on a `survfit` stored without confidence limits (e.g. fit with `conf.type = "none"`, or any fit that kept no CI). `surv_summary()` treated the absent `upper`/`lower` as length-0 columns; because it runs for every `ggsurvplot()`, such a fit could not be plotted at all -- even with `conf.int = FALSE`. The missing limits are now filled with `NA`, so the curve draws with no confidence band. Fits with confidence limits are unchanged. Reported by @pmpradhan (#639).
 
 - `ggadjustedcurves()` now emits an informative message when it is called with `risk.table = TRUE`, pointing to the "Risk table under `ggadjustedcurves()`" recipe, instead of silently ignoring the argument. `ggadjustedcurves()` returns a plain ggplot and the model-adjusted curves have no literal number at risk of their own, so a risk table has to be built from the Kaplan-Meier fit for the grouping variable (the recipe). Ordinary calls (no `risk.table`, or `risk.table = FALSE`) are unchanged. Reported by @BenCorden (#286).

--- a/R/surv_median.R
+++ b/R/surv_median.R
@@ -3,14 +3,18 @@ NULL
 #'Median of Survival Curves
 #'
 #'@description Returns the median survival with upper and lower confidence
-#'  limits for the median at 95\% confidence levels.
+#'  limits for the median. The confidence limits are taken at the confidence
+#'  level the survfit was built with (95\% by default); a fit stored without
+#'  confidence limits (e.g. \code{conf.type = "none"}) returns \code{NA} limits.
 #'@param fit A survfit object. Can be also a list of survfit objects.
 #'@param combine logical value. Used only when fit is a list of survfit objects.
 #'  If TRUE, combine the results for multiple fits.
 #'@return Returns for each fit, a data frame with the following column:
 #'  \itemize{ \item strata: strata/group names \item median: median survival of
-#'  each group \item lower: 95\% lower confidence limit \item upper: 95\% upper
-#'  confidence limit }Returns a list of data frames when the input is a
+#'  each group \item lower: lower confidence limit of the median \item upper:
+#'  upper confidence limit of the median }The confidence limits use the fit's own
+#'  confidence level (95\% by default), and are \code{NA} for a fit built without
+#'  confidence limits. Returns a list of data frames when the input is a
 #'  list of survfit objects. If combine = TRUE, results are combined into one single data frame.
 #'
 #' @examples
@@ -58,9 +62,19 @@ surv_median <- function(fit, combine = FALSE){
     }
     .table$strata <- rownames(.table)
 
+    # summary()$table names the confidence-limit columns "<level>LCL"/"<level>UCL"
+    # (e.g. "0.95LCL", or "0.9LCL" for conf.int = 0.9); a fit stored without CI
+    # (conf.type = "none") has neither. The old code hard-coded "0.95LCL"/"0.95UCL",
+    # so it errored both on a no-CI fit and on a non-default confidence level (#818).
+    # Detect the columns by suffix and fall back to NA when absent, so the median is
+    # always returned -- without limits for a no-CI fit. The default 0.95 case is
+    # unchanged (the same LCL/UCL values, renamed to lower/upper).
+    .lcl <- grep("LCL$", colnames(.table), value = TRUE)
+    .ucl <- grep("UCL$", colnames(.table), value = TRUE)
+    .table$lower <- if (length(.lcl) >= 1L) .table[[.lcl[1]]] else NA_real_
+    .table$upper <- if (length(.ucl) >= 1L) .table[[.ucl[1]]] else NA_real_
     .table <- .table %>%
-      dplyr::select(dplyr::all_of(c("strata",  "median", "0.95LCL", "0.95UCL")))
-    colnames(.table) <- c("strata", "median", "lower", "upper")
+      dplyr::select(dplyr::all_of(c("strata", "median", "lower", "upper")))
     rownames(.table) <- NULL
     .table
   }

--- a/man/surv_median.Rd
+++ b/man/surv_median.Rd
@@ -15,13 +15,17 @@ If TRUE, combine the results for multiple fits.}
 \value{
 Returns for each fit, a data frame with the following column:
  \itemize{ \item strata: strata/group names \item median: median survival of
- each group \item lower: 95\% lower confidence limit \item upper: 95\% upper
- confidence limit }Returns a list of data frames when the input is a
+ each group \item lower: lower confidence limit of the median \item upper:
+ upper confidence limit of the median }The confidence limits use the fit's own
+ confidence level (95\% by default), and are \code{NA} for a fit built without
+ confidence limits. Returns a list of data frames when the input is a
  list of survfit objects. If combine = TRUE, results are combined into one single data frame.
 }
 \description{
 Returns the median survival with upper and lower confidence
- limits for the median at 95\% confidence levels.
+ limits for the median. The confidence limits are taken at the confidence
+ level the survfit was built with (95\% by default); a fit stored without
+ confidence limits (e.g. \code{conf.type = "none"}) returns \code{NA} limits.
 }
 \examples{
 

--- a/tests/testthat/test-surv_median-noci-818.R
+++ b/tests/testthat/test-surv_median-noci-818.R
@@ -1,0 +1,44 @@
+context("surv_median() on a fit without / non-default confidence limits (#818)")
+
+# surv_median() hard-coded the "0.95LCL"/"0.95UCL" columns of summary()$table, so
+# it errored on a survfit stored without CI (conf.type = "none") AND on a
+# non-default confidence level (conf.int = 0.9 names them "0.9LCL"/"0.9UCL"). The
+# CI columns are now detected by suffix, with NA fallback when absent.
+library(survival)
+
+test_that("surv_median() returns NA limits for a no-CI fit instead of erroring (#818)", {
+  fit <- survfit(Surv(time, status) ~ rx, data = colon, conf.type = "none")
+  expect_error(m <- surv_median(fit), NA)
+  expect_true(all(is.na(m$lower)))
+  expect_true(all(is.na(m$upper)))
+  expect_false(all(is.na(m$median)))                 # medians still computed
+  expect_equal(nrow(m), length(fit$strata))
+})
+
+test_that("surv_median() uses the real limits for a non-default confidence level (#818)", {
+  # a naive NA-fill would silently drop the true 0.90 CI; it must be used.
+  f90 <- survfit(Surv(time, status) ~ rx, data = colon, conf.int = 0.90)
+  m90 <- surv_median(f90)
+  tab <- as.data.frame(summary(f90)$table)
+  expect_equal(m90$lower, unname(tab[["0.9LCL"]]))
+  expect_equal(m90$upper, unname(tab[["0.9UCL"]]))
+  # 90% interval is narrower than the 95% interval for the same fit
+  m95 <- surv_median(survfit(Surv(time, status) ~ rx, data = colon))
+  ok <- !is.na(m90$lower) & !is.na(m95$lower)
+  expect_true(all((m90$upper - m90$lower)[ok] <= (m95$upper - m95$lower)[ok]))
+})
+
+test_that("no-regression: default 0.95 surv_median is unchanged (#818)", {
+  m <- surv_median(survfit(Surv(time, status) ~ rx, data = colon))
+  expect_identical(colnames(m), c("strata", "median", "lower", "upper"))
+  expect_false(any(is.na(m$lower[m$strata != "rx=Lev+5FU"])))   # real limits present
+})
+
+test_that("combine = TRUE and single-group ~1 handle a no-CI fit (#818)", {
+  expect_error(
+    surv_median(list(a = survfit(Surv(time, status) ~ sex, data = colon,
+                                 conf.type = "none")), combine = TRUE), NA)
+  m1 <- surv_median(survfit(Surv(time, status) ~ 1, data = colon, conf.type = "none"))
+  expect_equal(m1$strata, "All")
+  expect_true(is.na(m1$lower))
+})


### PR DESCRIPTION
## Bug

`surv_median()` hard-coded the `"0.95LCL"`/`"0.95UCL"` columns of `summary()$table`, so it errored on:
- a `survfit` stored without confidence limits (`conf.type = "none"`) — no such columns, and
- a non-default confidence level (`conf.int = 0.9` names them `"0.9LCL"`/`"0.9UCL"`).

```r
surv_median(survfit(Surv(time, status) ~ rx, colon, conf.type = "none"))
surv_median(survfit(Surv(time, status) ~ rx, colon, conf.int = 0.9))
#> Error in `dplyr::all_of()`: Elements `0.95LCL` and `0.95UCL` don't exist.
```

Found while fixing #639 (a no-CI fit crashing `ggsurvplot()`); this is a distinct, pre-existing gap in the exported `surv_median()`.

## Fix

Detect the CI columns by suffix (`LCL`/`UCL`) instead of a hard-coded level, with `NA` fallback when absent. A `0.9` fit now returns its **real** limits (not `NA` — a naive fill would have silently dropped them), a no-CI fit returns the median with `NA` limits, and the default `0.95` output is byte-identical (same values, renamed to `lower`/`upper`). Roxygen updated to say the limits are at the fit's own confidence level.

## Verification

- **Correctness (independently recomputed):** `0.90`/`0.99`/`0.80` fits return their actual `summary()$table` limits (0.90 narrower than 0.95, correct direction); medians unchanged; no-CI → `NA` limits, median still computed.
- **No regression:** `surv_median()` byte-identical to `master` across grouped / `~1` / cox / cox-`newdata` / list / `combine=TRUE` / `group.by` / multi-strata; 13-call harness byte-identical; `surv.median.line` build data identical. Full suite green (91 files, 0 failures); new tests fail on `master`.
- Docs hand-edited to the pinned RoxygenNote; `checkRd` clean.

Two independent reviewers (regression + correctness, the latter recomputing every value) returned safe-to-merge with no findings.

Fixes #818
