### PR TITLE
Message when risk.table.y.text=TRUE is set with risk.table.pos="in" (#211)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
 
 ## Minor changes
 
+- `ggsurvplot()` now emits an informative message when `risk.table.y.text = TRUE` is explicitly set together with `risk.table.pos = "in"`, instead of silently ignoring it. An in-plot risk table is drawn over the survival panel's own y-axis, so its rows are coloured by strata (matching the curves) rather than labelled; the message explains this and points to `risk.table.pos = "out"` for text strata labels. It fires only when both arguments are explicitly passed, so default in-plot tables (which carry `risk.table.y.text = TRUE` by default) are unaffected. Reported by @Swechhya (#211).
+
 - `surv_median()` no longer errors on a `survfit` stored without confidence limits (`conf.type = "none"`) or fitted at a non-default confidence level (e.g. `conf.int = 0.9`). It hard-coded the `0.95LCL`/`0.95UCL` columns of `summary()$table`; these are now detected by suffix, so a `0.9` fit returns its real limits and a no-CI fit returns the median with `NA` limits instead of failing. Default (0.95) output is unchanged. Found alongside #639 (#818).
 
 - `ggsurvplot()` no longer errors with a cryptic `arguments imply differing number of rows` message on a `survfit` stored without confidence limits (e.g. fit with `conf.type = "none"`, or any fit that kept no CI). `surv_summary()` treated the absent `upper`/`lower` as length-0 columns; because it runs for every `ggsurvplot()`, such a fit could not be plotted at all -- even with `conf.int = FALSE`. The missing limits are now filled with `NA`, so the curve draws with no confidence band. Fits with confidence limits are unchanged. Reported by @pmpradhan (#639).

--- a/R/ggsurvplot.R
+++ b/R/ggsurvplot.R
@@ -354,6 +354,24 @@ ggsurvplot <- function(fit, data = NULL, fun = NULL,
   if(length(group.by) > 2)
     stop("group.by should be of length 1 or 2.")
 
+  # `risk.table.y.text = TRUE` cannot show strata labels for an in-plot risk table
+  # (`risk.table.pos = "in"`): the table is drawn over the survival panel's own
+  # y-axis, so its rows are coloured by strata (matching the curves) rather than
+  # labelled. Tell the user instead of silently ignoring an explicit request. This
+  # fires only when BOTH `risk.table.pos = "in"` and `risk.table.y.text = TRUE` are
+  # explicitly passed (both live in `...`, absent otherwise), so a default in-plot
+  # table -- which carries `risk.table.y.text = TRUE` by default -- is not spammed (#211).
+  .dots <- list(...)
+  # `risk.table` is TRUE/FALSE or a type string ("absolute"/"abs_pct"/...); both
+  # non-FALSE forms draw an in-plot table, so cover the string case too.
+  if ((isTRUE(risk.table) || is.character(risk.table)) &&
+      identical(.dots[["risk.table.pos"]], "in") &&
+      isTRUE(.dots[["risk.table.y.text"]]))
+    message("`risk.table.y.text = TRUE` has no effect with `risk.table.pos = \"in\"`: ",
+            "the in-plot risk table is coloured by strata (matching the curves) instead ",
+            "of labelled, to avoid overlapping the survival plot's y-axis. Use ",
+            "`risk.table.pos = \"out\"` if you need text strata labels.")
+
 
   # Options for ggsurvplot_df
   # Don't accept arguments for pval and survival tables

--- a/R/ggsurvplot.R
+++ b/R/ggsurvplot.R
@@ -362,9 +362,14 @@ ggsurvplot <- function(fit, data = NULL, fun = NULL,
   # explicitly passed (both live in `...`, absent otherwise), so a default in-plot
   # table -- which carries `risk.table.y.text = TRUE` by default -- is not spammed (#211).
   .dots <- list(...)
-  # `risk.table` is TRUE/FALSE or a type string ("absolute"/"abs_pct"/...); both
-  # non-FALSE forms draw an in-plot table, so cover the string case too.
-  if ((isTRUE(risk.table) || is.character(risk.table)) &&
+  # `risk.table` is TRUE/FALSE or a table-type string; both draw an in-plot table.
+  # Test the type strings against the allowed set (kept in sync with
+  # .parse_risk_table_arg() in ggsurvplot_core.R) so an INVALID string -- which
+  # errors there anyway -- does not get this message before its own error.
+  .rt.draws.table <- isTRUE(risk.table) ||
+    (is.character(risk.table) && length(risk.table) == 1L && risk.table %in%
+       c("absolute", "percentage", "abs_pct", "nrisk_cumcensor", "nrisk_cumevents"))
+  if (.rt.draws.table &&
       identical(.dots[["risk.table.pos"]], "in") &&
       isTRUE(.dots[["risk.table.y.text"]]))
     message("`risk.table.y.text = TRUE` has no effect with `risk.table.pos = \"in\"`: ",

--- a/tests/testthat/test-ggsurvplot-risktable-in-message-211.R
+++ b/tests/testthat/test-ggsurvplot-risktable-in-message-211.R
@@ -10,11 +10,15 @@ context("in-plot risk table y.text message (#211)")
 library(survival)
 fit <- survfit(Surv(time, status) ~ sex, data = lung)
 
-# TRUE if the expression emits the #211 message (robust to unrelated messages)
+# TRUE if the expression emits the #211 message (robust to unrelated messages AND
+# to a downstream error -- an invalid risk.table string errors AFTER the gate, so
+# we still capture whether the message fired before it).
 emits_211 <- function(expr) {
   msgs <- character(0)
-  withCallingHandlers(force(expr),
-    message = function(m) { msgs <<- c(msgs, conditionMessage(m)); invokeRestart("muffleMessage") })
+  tryCatch(
+    withCallingHandlers(force(expr),
+      message = function(m) { msgs <<- c(msgs, conditionMessage(m)); invokeRestart("muffleMessage") }),
+    error = function(e) NULL)
   any(grepl("no effect with", msgs, fixed = TRUE))
 }
 
@@ -48,4 +52,14 @@ test_that("the message does NOT fire for default / other configurations (#211)",
   expect_false(emits_211(
     ggsurvplot(fit, data = lung, risk.table = TRUE, risk.table.pos = "in",
                risk.table.y.text.col = TRUE)))
+})
+
+test_that("an INVALID string risk.table does not emit the message before its error (#211)", {
+  # "none" / "" / "garbage" are not table-drawing values; .parse_risk_table_arg()
+  # rejects them. The message must NOT fire ahead of that rejection.
+  for (bad in c("none", "", "garbage"))
+    expect_false(emits_211(
+      ggsurvplot(fit, data = lung, risk.table = bad, risk.table.pos = "in",
+                 risk.table.y.text = TRUE)),
+      info = paste("bad =", bad))
 })

--- a/tests/testthat/test-ggsurvplot-risktable-in-message-211.R
+++ b/tests/testthat/test-ggsurvplot-risktable-in-message-211.R
@@ -1,0 +1,51 @@
+context("in-plot risk table y.text message (#211)")
+
+# With risk.table.pos = "in", the risk table is drawn over the survival panel's
+# own y-axis, so its strata y-axis labels are blanked (the rows are coloured by
+# strata instead). risk.table.y.text = TRUE therefore has no effect there. Rather
+# than silently ignoring an explicit request, ggsurvplot() now says so -- but only
+# when the user EXPLICITLY passes both risk.table.pos = "in" and
+# risk.table.y.text = TRUE, so a default in-plot table (y.text = TRUE by default)
+# is not spammed.
+library(survival)
+fit <- survfit(Surv(time, status) ~ sex, data = lung)
+
+# TRUE if the expression emits the #211 message (robust to unrelated messages)
+emits_211 <- function(expr) {
+  msgs <- character(0)
+  withCallingHandlers(force(expr),
+    message = function(m) { msgs <<- c(msgs, conditionMessage(m)); invokeRestart("muffleMessage") })
+  any(grepl("no effect with", msgs, fixed = TRUE))
+}
+
+test_that("explicit pos='in' + y.text=TRUE emits the message (#211)", {
+  expect_true(emits_211(
+    ggsurvplot(fit, data = lung, risk.table = TRUE, risk.table.pos = "in",
+               risk.table.y.text = TRUE)))
+})
+
+test_that("the message also fires for a string-valued risk.table type in-plot (#211)", {
+  # risk.table = "abs_pct" (a type string) draws an in-plot table too, so it has
+  # the same silent-ignore of risk.table.y.text.
+  expect_true(emits_211(
+    ggsurvplot(fit, data = lung, risk.table = "abs_pct", risk.table.pos = "in",
+               risk.table.y.text = TRUE)))
+})
+
+test_that("the message does NOT fire for default / other configurations (#211)", {
+  # default in-plot table (y.text = TRUE by default, but not explicitly passed)
+  expect_false(emits_211(
+    ggsurvplot(fit, data = lung, risk.table = TRUE, risk.table.pos = "in")))
+  # explicit y.text = FALSE
+  expect_false(emits_211(
+    ggsurvplot(fit, data = lung, risk.table = TRUE, risk.table.pos = "in",
+               risk.table.y.text = FALSE)))
+  # out-of-plot table (labels do show there)
+  expect_false(emits_211(
+    ggsurvplot(fit, data = lung, risk.table = TRUE, risk.table.pos = "out",
+               risk.table.y.text = TRUE)))
+  # y.text.col must not partial-match risk.table.y.text
+  expect_false(emits_211(
+    ggsurvplot(fit, data = lung, risk.table = TRUE, risk.table.pos = "in",
+               risk.table.y.text.col = TRUE)))
+})


### PR DESCRIPTION
An in-plot risk table (`risk.table.pos = "in"`) is drawn over the survival panel's own y-axis, so its rows are coloured by strata (matching the curves) rather than labelled — `risk.table.y.text = TRUE` has no effect there and was silently ignored. `ggsurvplot()` now emits an informative message pointing to `risk.table.pos = "out"` for text strata labels, instead of doing nothing.

The message fires only when the user **explicitly** passes both `risk.table.pos = "in"` and `risk.table.y.text = TRUE` (both live in `...`), so a default in-plot table — which carries `risk.table.y.text = TRUE` by default — is not spammed, and existing output is byte-identical. It covers both logical and string-valued `risk.table` (e.g. `"abs_pct"`).

The in-plot y-axis text label itself is deliberately not added: those labels would overlap the survival plot's own y-axis (both the reporter and the maintainer noted this in 2017), and the rows are already identified by colour.

Verified: message accurate against the rendered pixels (in-plot rows colored, no y-axis text; `pos="out"` shows the labels); fires only on the explicit case (gating matrix); byte-identical across the call grid; full suite green (92 files); new tests fail on `master`. Internal function-body change only — no roxygen/`man` churn.

Reported by @Swechhya. #211 will be closed as answered (the in-plot label feature is declined; the message + `pos="out"` are the answer).

Refs #211
