### PR TITLE
Scope the faceted-risk-table NEWS issue refs to what it resolves

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,8 +14,9 @@
   colours are not a reliable row identifier, so the text label carries the identity), and
   `pval.in.label` reuses the same p-value text as the on-panel label (so it also reflects
   `p.adjust.method`). This is the
-  long-standing request to combine faceting with a risk table (#587, #330, #370, #478,
-  #511, #539, #620). Both are for a single `facet.by` variable: `pval.in.label` with two
+  long-standing request to combine faceting with a risk table (#587, #330, #539; the
+  single-variable case of #370 and #511). Both are for a single `facet.by` variable:
+  `pval.in.label` with two
   variables warns and draws the p-value on the panels, and `risk.table` with two warns and
   returns the plot without a table (a two-way `facet_grid` shares one y axis per row, so
   the per-panel strata cannot be labelled correctly).


### PR DESCRIPTION
Doc-only follow-up to #705. The faceted-risk-table NEWS entry listed #478 and #620 among the "combine faceting with a risk table" requests, but two independent pre-close reviews of the merged feature found those are different features:

- **#478** asks for a risk table under **Cox-adjusted** curves (`survfit(coxph, newdata=)` / `ggadjustedcurves`), which have no real per-group at-risk counts. The faceted KM risk table does not apply.
- **#620** asks for a single **strata-grouped combined** Risk/Censored/Events table (BMJ layout), not a faceting feature.

Both are kept open. This narrows the NEWS reference to the issues the feature actually resolves (#587, #330, #539 fully; the single-`facet.by` case of #370 and #511). No code change.
