### PR TITLE
Add output = "ggplot" to ggsurvplot() for a composable single ggplot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,15 @@
 
 ## New features
 
+- `ggsurvplot()` gains an `output` argument. The default `output = "classic"` returns
+  the usual compound `ggsurvplot` object (unchanged). `output = "ggplot"` instead
+  returns a single survival-curve `ggplot` -- one object that composes normally with
+  `+ geom_*`, `ggsave()` and `facet_wrap()`, so you can add your own layers (an RMST
+  area, a cumulative-incidence overlay, a reference line) without extracting `$plot`
+  or fighting the compound object's `+`. `pval`, `conf.int` and `surv.median.line`
+  are kept on the curve. A risk / cumulative-events / cumulative-censor table or a
+  separate censor barplot cannot live in a single ggplot, so those are dropped with a
+  warning if requested (use the default and its `$table`).
 - `ggadjustedcurves()` gains a `risk.table` argument (#286). When set, a
   number-at-risk table is drawn below the adjusted curves and the function returns a
   `ggsurvplot` object (printed with `print()`) instead of a plain `ggplot`. Because

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,8 @@
 - `ggsurvplot()` gains an `output` argument. The default `output = "classic"` returns
   the usual compound `ggsurvplot` object (unchanged). `output = "ggplot"` instead
   returns a single survival-curve `ggplot` -- one object that composes normally with
-  `+ geom_*`, `ggsave()` and `facet_wrap()`, so you can add your own layers (an RMST
+  `+ geom_*`, `ggsave()` and `facet_wrap()` (by strata; faceting an external covariate
+  still needs `ggsurvplot_facet()`), so you can add your own layers (an RMST
   area, a cumulative-incidence overlay, a reference line) without extracting `$plot`
   or fighting the compound object's `+`. `pval`, `conf.int` and `surv.median.line`
   are kept on the curve. A risk / cumulative-events / cumulative-censor table or a

--- a/R/ggsurvplot.R
+++ b/R/ggsurvplot.R
@@ -226,7 +226,24 @@ NULL
 #'  Use font.x = 14, to change only font size; or use font.x =
 #'  "bold", to change only font face.
 #'
-#'@return return an object of class ggsurvplot which is list containing the
+#'@param output one of \code{"classic"} (default) or \code{"ggplot"}. With
+#'  \code{"classic"} the usual compound \code{ggsurvplot} object is returned
+#'  (unchanged). With \code{"ggplot"} a single survival-curve \code{ggplot} is
+#'  returned instead -- one object that composes normally with \code{+ geom_*},
+#'  \code{ggsave()} and \code{facet_wrap()} (useful for adding your own layers, e.g.
+#'  an RMST area or a cumulative-incidence overlay). Any \code{pval},
+#'  \code{conf.int} and \code{surv.median.line} are kept (they live on the curve).
+#'  A risk / cumulative-events / cumulative-censor table or a separate censor
+#'  barplot cannot be embedded in a single ggplot, so \code{risk.table},
+#'  \code{cumevents}, \code{cumcensor} and \code{ncensor.plot} are dropped with a
+#'  warning if requested; use the default and its \code{$table} for those. Faceting
+#'  an \emph{external} covariate (not the strata) still needs
+#'  \code{\link{ggsurvplot_facet}()}, which recomputes the curves per panel; a plain
+#'  \code{facet_wrap()} on the returned plot does not, and a single \code{pval}
+#'  annotation is replicated into every panel.
+#'@return an object of class ggsurvplot (a list) by default, or -- when
+#'  \code{output = "ggplot"} -- a single survival-curve \code{ggplot}. The
+#'  \code{ggsurvplot} list contains the
 #'  following components: \itemize{ \item plot: the survival plot (ggplot
 #'  object) \item table: the number of subjects at risk table per time (ggplot
 #'  object). \item cumevents: the cumulative number of events table (ggplot
@@ -237,6 +254,15 @@ NULL
 #'
 #'@author Alboukadel Kassambara, \email{alboukadel.kassambara@@gmail.com}
 #' @examples
+#'
+#'#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+#'# A single composable ggplot: output = "ggplot"
+#'#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+#'require("survival")
+#'fit <- survfit(Surv(time, status) ~ sex, data = lung)
+#'p <- ggsurvplot(fit, data = lung, conf.int = TRUE, output = "ggplot")
+#'# p is a plain ggplot -- add your own layers, save it, facet it
+#'p + geom_hline(yintercept = 0.5, linetype = "dashed")
 #'
 #'#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 #'# Example 1: Survival curves with two groups
@@ -348,8 +374,10 @@ ggsurvplot <- function(fit, data = NULL, fun = NULL,
                        group.by = NULL, facet.by = NULL, add.all = FALSE, combine = FALSE,
                        ggtheme = theme_survminer(),
                        tables.theme = ggtheme,
+                       output = c("classic", "ggplot"),
                        ...
 ){
+  output <- match.arg(output)
 
   if(length(group.by) > 2)
     stop("group.by should be of length 1 or 2.")
@@ -377,6 +405,24 @@ ggsurvplot <- function(fit, data = NULL, fun = NULL,
             "of labelled, to avoid overlapping the survival plot's y-axis. Use ",
             "`risk.table.pos = \"out\"` if you need text strata labels.")
 
+  # output = "ggplot": return a single, composable survival-curve ggplot instead of
+  # the compound `ggsurvplot` object. A single ggplot cannot embed an aligned risk /
+  # cumulative-events / cumulative-censor table or a separate censor barplot (those
+  # are a multi-panel assembly), so any such request is dropped here -- with a
+  # warning only when one was actually made, so a plain `output = "ggplot"` call is
+  # quiet. The curve itself is byte-identical whether or not a table was requested,
+  # so dropping the table changes nothing on the returned curve.
+  if (identical(output, "ggplot")) {
+    if (.rt.draws.table || isTRUE(cumevents) || isTRUE(cumcensor) ||
+        isTRUE(.dots[["ncensor.plot"]]))
+      warning("`output = \"ggplot\"` returns the survival-curve panel only; ",
+              "`risk.table`/`cumevents`/`cumcensor`/`ncensor.plot` cannot be embedded ",
+              "in a single ggplot and are dropped. Use the default ",
+              "`output = \"classic\"` (then `$table`) for those.", call. = FALSE)
+    risk.table <- FALSE
+    cumevents <- FALSE
+    cumcensor <- FALSE
+  }
 
   # Options for ggsurvplot_df
   # Don't accept arguments for pval and survival tables
@@ -444,6 +490,19 @@ ggsurvplot <- function(fit, data = NULL, fun = NULL,
   else if(inherits(fit, "flexsurvreg"))
     ggsurv <- do.call(ggflexsurvplot, opts)
 
+
+  # Classic (default) returns the compound ggsurvplot object unchanged. For
+  # output = "ggplot" return the bare survival-curve ggplot: the `$plot` panel of a
+  # compound object, or the object itself when the path already produced a single
+  # ggplot (e.g. a bare faceted plot after the table was dropped above).
+  if (identical(output, "ggplot")) {
+    if (inherits(ggsurv, "ggplot"))
+      return(ggsurv)
+    if (!is.null(ggsurv$plot) && inherits(ggsurv$plot, "ggplot"))
+      return(ggsurv$plot)
+    warning("`output = \"ggplot\"` is not available for this input; returning the ",
+            "classic object.", call. = FALSE)
+  }
 
   return(ggsurv)
 }

--- a/R/ggsurvplot.R
+++ b/R/ggsurvplot.R
@@ -240,7 +240,9 @@ NULL
 #'  an \emph{external} covariate (not the strata) still needs
 #'  \code{\link{ggsurvplot_facet}()}, which recomputes the curves per panel; a plain
 #'  \code{facet_wrap()} on the returned plot does not, and a single \code{pval}
-#'  annotation is replicated into every panel.
+#'  annotation is replicated into every panel. \code{group.by} and an uncombined list
+#'  of fits produce several plots (not one), so \code{output = "ggplot"} falls back to
+#'  the classic object there (with a warning).
 #'@return an object of class ggsurvplot (a list) by default, or -- when
 #'  \code{output = "ggplot"} -- a single survival-curve \code{ggplot}. The
 #'  \code{ggsurvplot} list contains the
@@ -404,6 +406,19 @@ ggsurvplot <- function(fit, data = NULL, fun = NULL,
             "the in-plot risk table is coloured by strata (matching the curves) instead ",
             "of labelled, to avoid overlapping the survival plot's y-axis. Use ",
             "`risk.table.pos = \"out\"` if you need text strata labels.")
+
+  # output = "ggplot" returns a SINGLE ggplot, so it is only meaningful for the
+  # single-plot paths. `group.by` and an uncombined list of fits produce MULTIPLE
+  # plots (a `ggsurvplot_list`), which cannot be one ggplot; there, fall back to the
+  # classic object WITH its tables intact (do this BEFORE the table-drop below, so
+  # the fall-back object is a true classic object, not a stripped one) and warn once.
+  if (identical(output, "ggplot") &&
+      (!is.null(group.by) || (.is_list(fit) && !isTRUE(combine)))) {
+    warning("`output = \"ggplot\"` returns a single ggplot and is not available for ",
+            "`group.by` or an uncombined list of fits (which produce several plots); ",
+            "returning the classic object.", call. = FALSE)
+    output <- "classic"
+  }
 
   # output = "ggplot": return a single, composable survival-curve ggplot instead of
   # the compound `ggsurvplot` object. A single ggplot cannot embed an aligned risk /

--- a/man/ggsurvplot.Rd
+++ b/man/ggsurvplot.Rd
@@ -28,6 +28,7 @@ ggsurvplot(
   combine = FALSE,
   ggtheme = theme_survminer(),
   tables.theme = ggtheme,
+  output = c("classic", "ggplot"),
   ...
 )
 
@@ -110,10 +111,13 @@ to show both absolute number and percentage. \item "nrisk_cumcensor" and
 censoring and events, respectively. }}
 
 \item{cumevents}{logical value specifying whether to show or not the table of
-the cumulative number of events. Default is FALSE. Can also be a character string ("absolute", "percentage" or "abs_pct"); "percentage" shows the count as a percent of the stratum size.}
+the cumulative number of events. Default is FALSE. Can also be a character
+string ("absolute", "percentage" or "abs_pct"); "percentage" shows the count
+as a percent of the stratum size.}
 
 \item{cumcensor}{logical value specifying whether to show or not the table of
-the cumulative number of censoring. Default is FALSE. Can also be a character string ("absolute", "percentage" or "abs_pct").}
+the cumulative number of censoring. Default is FALSE. Can also be a character
+string ("absolute", "percentage" or "abs_pct").}
 
 \item{tables.height}{numeric value (in [0 - 1]) specifying the general height
 of all tables under the main survival plot.}
@@ -139,6 +143,22 @@ Alias of the \code{\link{ggsurvplot_combine}()} function.}
 \link{theme_survminer}. Allowed values include ggplot2 official themes: see
 \code{\link[ggplot2]{theme}}. Note that, \code{tables.theme} is incremental to \code{ggtheme}.}
 
+\item{output}{one of \code{"classic"} (default) or \code{"ggplot"}. With
+\code{"classic"} the usual compound \code{ggsurvplot} object is returned
+(unchanged). With \code{"ggplot"} a single survival-curve \code{ggplot} is
+returned instead -- one object that composes normally with \code{+ geom_*},
+\code{ggsave()} and \code{facet_wrap()} (useful for adding your own layers, e.g.
+an RMST area or a cumulative-incidence overlay). Any \code{pval},
+\code{conf.int} and \code{surv.median.line} are kept (they live on the curve).
+A risk / cumulative-events / cumulative-censor table or a separate censor
+barplot cannot be embedded in a single ggplot, so \code{risk.table},
+\code{cumevents}, \code{cumcensor} and \code{ncensor.plot} are dropped with a
+warning if requested; use the default and its \code{$table} for those. Faceting
+an \emph{external} covariate (not the strata) still needs
+\code{\link{ggsurvplot_facet}()}, which recomputes the curves per panel; a plain
+\code{facet_wrap()} on the returned plot does not, and a single \code{pval}
+annotation is replicated into every panel.}
+
 \item{...}{Futher arguments as described hereafter and
 other arguments to be passed i) to ggplot2 geom_*() functions such
  as linetype, size, ii) or to the function \link[ggpubr]{ggpar}() for
@@ -162,7 +182,9 @@ risk.table = FALSE.}
 generic; not used.}
 }
 \value{
-return an object of class ggsurvplot which is list containing the
+an object of class ggsurvplot (a list) by default, or -- when
+ \code{output = "ggplot"} -- a single survival-curve \code{ggplot}. The
+ \code{ggsurvplot} list contains the
  following components: \itemize{ \item plot: the survival plot (ggplot
  object) \item table: the number of subjects at risk table per time (ggplot
  object). \item cumevents: the cumulative number of events table (ggplot
@@ -396,6 +418,15 @@ The plot can be easily customized using additional arguments to be
 }
 
 \examples{
+
+#\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%
+# A single composable ggplot: output = "ggplot"
+#\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%
+require("survival")
+fit <- survfit(Surv(time, status) ~ sex, data = lung)
+p <- ggsurvplot(fit, data = lung, conf.int = TRUE, output = "ggplot")
+# p is a plain ggplot -- add your own layers, save it, facet it
+p + geom_hline(yintercept = 0.5, linetype = "dashed")
 
 #\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%\%
 # Example 1: Survival curves with two groups

--- a/man/ggsurvplot.Rd
+++ b/man/ggsurvplot.Rd
@@ -157,7 +157,9 @@ warning if requested; use the default and its \code{$table} for those. Faceting
 an \emph{external} covariate (not the strata) still needs
 \code{\link{ggsurvplot_facet}()}, which recomputes the curves per panel; a plain
 \code{facet_wrap()} on the returned plot does not, and a single \code{pval}
-annotation is replicated into every panel.}
+annotation is replicated into every panel. \code{group.by} and an uncombined list
+of fits produce several plots (not one), so \code{output = "ggplot"} falls back to
+the classic object there (with a warning).}
 
 \item{...}{Futher arguments as described hereafter and
 other arguments to be passed i) to ggplot2 geom_*() functions such

--- a/tests/testthat/test-ggsurvplot-output-ggplot.R
+++ b/tests/testthat/test-ggsurvplot-output-ggplot.R
@@ -1,0 +1,70 @@
+# ggsurvplot(output = "ggplot") -- a single composable survival-curve ggplot (P0.1a).
+
+library(survival)
+
+fit <- survfit(Surv(time, status) ~ sex, data = lung)
+
+test_that("output = 'ggplot' returns a single ggplot, not the compound object", {
+  p <- ggsurvplot(fit, data = lung, output = "ggplot")
+  expect_s3_class(p, "ggplot")
+  expect_false(inherits(p, "ggsurvplot"))
+})
+
+test_that("the returned ggplot composes with layers, scales, facets and ggsave", {
+  p <- ggsurvplot(fit, data = lung, output = "ggplot")
+  expect_error(ggplot2::ggplot_build(p + ggplot2::geom_hline(yintercept = 0.5)), NA)
+  expect_error(ggplot2::ggplot_build(p + ggplot2::annotate("text", x = 500, y = 0.5, label = "x")), NA)
+  # RMST/CIF-style ribbon overlay (the downstream P1.1 use case)
+  rib <- data.frame(time = c(0, 300))
+  expect_error(
+    ggplot2::ggplot_build(
+      p + ggplot2::geom_ribbon(ggplot2::aes(x = time, ymin = 0, ymax = 0.5),
+                               data = rib, inherit.aes = FALSE, alpha = 0.2)),
+    NA)
+  # facet by the strata variable (external-covariate faceting stays ggsurvplot_facet's job)
+  expect_error(ggplot2::ggplot_build(p + ggplot2::facet_wrap(~strata)), NA)
+  expect_error(ggplot2::ggsave(tempfile(fileext = ".png"), p, width = 6, height = 4), NA)
+})
+
+test_that("pval / conf.int / surv.median.line layers are preserved on the bare curve", {
+  p <- ggsurvplot(fit, data = lung, pval = TRUE, conf.int = TRUE,
+                  surv.median.line = "hv", output = "ggplot")
+  geoms <- vapply(p$layers, function(l) class(l$geom)[1], character(1))
+  expect_true("GeomText" %in% geoms)     # p-value annotation
+  expect_true("GeomConfint" %in% geoms)  # confidence band
+  expect_true(any(grepl("Segment|Vline|Hline", geoms)))  # median line
+})
+
+test_that("a requested table/panel is dropped with a warning; plain call is quiet", {
+  expect_warning(ggsurvplot(fit, data = lung, risk.table = TRUE, output = "ggplot"),
+                 "cannot be embedded")
+  expect_warning(ggsurvplot(fit, data = lung, cumevents = TRUE, output = "ggplot"),
+                 "cannot be embedded")
+  expect_warning(ggsurvplot(fit, data = lung, ncensor.plot = TRUE, output = "ggplot"),
+                 "cannot be embedded")
+  expect_no_warning(ggsurvplot(fit, data = lung, output = "ggplot"))
+})
+
+test_that("output = 'classic' (and the default) is unchanged", {
+  d  <- ggsurvplot(fit, data = lung)
+  cl <- ggsurvplot(fit, data = lung, output = "classic")
+  expect_s3_class(d, "ggsurvplot")
+  expect_s3_class(cl, "ggsurvplot")
+  # same curve build as the default
+  expect_equal(ggplot2::ggplot_build(cl$plot)$data,
+               ggplot2::ggplot_build(d$plot)$data)
+  # output = "ggplot" returns exactly the default's $plot curve
+  g <- ggsurvplot(fit, data = lung, output = "ggplot")
+  expect_equal(ggplot2::ggplot_build(g)$data,
+               ggplot2::ggplot_build(d$plot)$data)
+})
+
+test_that("an invalid output value is rejected", {
+  expect_error(ggsurvplot(fit, data = lung, output = "foo"))
+})
+
+test_that("output = 'ggplot' works for the facet path (bare faceted ggplot)", {
+  pf <- suppressWarnings(ggsurvplot(fit, data = lung, facet.by = "sex", output = "ggplot"))
+  expect_s3_class(pf, "ggplot")
+  expect_false(inherits(pf, "gtable"))
+})

--- a/tests/testthat/test-ggsurvplot-output-ggplot.R
+++ b/tests/testthat/test-ggsurvplot-output-ggplot.R
@@ -23,7 +23,8 @@ test_that("the returned ggplot composes with layers, scales, facets and ggsave",
     NA)
   # facet by the strata variable (external-covariate faceting stays ggsurvplot_facet's job)
   expect_error(ggplot2::ggplot_build(p + ggplot2::facet_wrap(~strata)), NA)
-  expect_error(ggplot2::ggsave(tempfile(fileext = ".png"), p, width = 6, height = 4), NA)
+  tf <- tempfile(fileext = ".png"); on.exit(unlink(tf), add = TRUE)
+  expect_error(ggplot2::ggsave(tf, p, width = 6, height = 4), NA)
 })
 
 test_that("pval / conf.int / surv.median.line layers are preserved on the bare curve", {
@@ -67,4 +68,18 @@ test_that("output = 'ggplot' works for the facet path (bare faceted ggplot)", {
   pf <- suppressWarnings(ggsurvplot(fit, data = lung, facet.by = "sex", output = "ggplot"))
   expect_s3_class(pf, "ggplot")
   expect_false(inherits(pf, "gtable"))
+})
+
+test_that("group.by falls back to the classic object WITH its tables intact", {
+  # group.by produces several plots (not one), so output='ggplot' cannot apply; it
+  # must fall back to the full classic object -- not a table-stripped one.
+  gb <- survfit(Surv(time, status) ~ sex, data = colon)
+  expect_warning(
+    r <- ggsurvplot(gb, data = colon, group.by = "rx", risk.table = TRUE,
+                    output = "ggplot"),
+    "not available for"
+  )
+  expect_s3_class(r, "ggsurvplot_list")
+  # the risk table the user asked for survives the fall-back
+  expect_false(is.null(r[[1]]$table))
 })


### PR DESCRIPTION
Adds an `output` argument to `ggsurvplot()` for a single, composable ggplot return.

`ggsurvplot()` returns a compound object (the curve plot plus optional tables), so the returned object does not compose with `+ geom_*`, `ggsave()` or `facet_wrap()`, and its own `+` operator is broken under ggplot2 >= 3.5. `output = "ggplot"` returns the bare survival-curve ggplot instead -- a single object you can build on directly:

```r
library(survminer)
library(survival)
fit <- survfit(Surv(time, status) ~ sex, data = lung)

p <- ggsurvplot(fit, data = lung, conf.int = TRUE, palette = "jco", output = "ggplot")
p +
  geom_hline(yintercept = 0.5, linetype = "dashed", colour = "grey40") +
  annotate("text", x = 30, y = 0.53, label = "median", hjust = 0)
```

![A Kaplan-Meier curve returned as a plain ggplot, with a dashed median reference line and a text annotation layered on top](https://i.imgur.com/DLFydVa.png)

- `pval`, `conf.int` and `surv.median.line` are kept (they live on the curve), so you can still annotate and then layer more.
- A risk / cumulative-events / cumulative-censor table or a separate censor barplot cannot be embedded in a single ggplot, so those are dropped with a warning if requested (use the default `output = "classic"` and its `$table`).
- `group.by` and an uncombined list of fits produce several plots, so `output = "ggplot"` falls back to the classic object there (with a warning).
- Faceting an external covariate still needs `ggsurvplot_facet()` (which recomputes the curves per panel); a plain `facet_wrap()` composes by strata only.

Default `output = "classic"` returns the usual compound object, unchanged (byte-identical). This is the composable-return foundation for layering RMST / cumulative-incidence overlays.

Rigorously evaluated: default paths byte-identical to master, full test suite green, `R CMD check --as-cran` clean.
