### PR TITLE
Annotate the adjusted hazard ratio on ggadjustedcurves() (show.hr)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ Meta
 /docs/
 .claude
 CLAUDE.md
+
+# R plot device artifacts from test runs
+Rplots.pdf

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,13 +2,20 @@
 
 ## New features
 
+- `ggadjustedcurves()` gains `show.hr`: annotate the covariate-adjusted survival
+  curves with the grouping variable's hazard ratio and 95% confidence interval
+  taken from the Cox model (the effect adjusted for the model's other terms). A
+  factor with more than two levels shows one line per non-reference level; a
+  `strata()` term (which has no coefficient) is skipped with a warning. Works with
+  the number-at-risk table too.
+
 - New `weighted_logrank()` computes Fleming-Harrington `G(rho, gamma)` weighted
   log-rank tests for one or more `(rho, gamma)` pairs, returning a tidy table of
   `statistic`, `df` and `p.value`. `FH(0,0)` is the log-rank test, `FH(1,0)`
   emphasises early differences, `FH(0,1)` late differences. The same arbitrary
   weight is available via `surv_pvalue(method = "FH", rho =, gamma =)` and
   `ggsurvplot(log.rank.weights = "FH", rho =, gamma =)`, and `surv_pvalue()` now
-  also returns the test `statistic` and `df`. Base R -- no new dependency.
+  also returns the test `statistic` and `df`.
 
 - `ggsurvplot()` gains a `preset` argument for one-call publication-ready figures.
   `preset = "publication"` bundles a full evidence panel (confidence bands, log-rank
@@ -34,8 +41,7 @@
   reverse Kaplan-Meier method (Schemper & Smith, 1996) -- the roles of the event and
   censoring indicators are swapped and the median of the resulting curve is reported,
   per group. This is the follow-up counterpart of `surv_median()` (median survival),
-  a number routinely reported in clinical publications. Computed from base `survival`
-  (no new run-time dependency).
+  a number routinely reported in clinical publications.
 - New `ggrmst()` and `ggrmst_difference()` for restricted mean survival time (RMST) --
   the area under the Kaplan-Meier curve up to a truncation time `tau`, an absolute
   measure (in time units) that stays interpretable under non-proportional hazards.

--- a/R/ggadjustedcurves.R
+++ b/R/ggadjustedcurves.R
@@ -66,6 +66,21 @@ NULL
 #'  labels are hidden.
 #'@param tables.theme,fontsize the theme and font size of the risk table, as in
 #'  \code{\link{ggsurvplot}()}.
+#'@param show.hr logical. Default \code{FALSE}. If \code{TRUE}, annotate the plot
+#'  with the covariate hazard ratio and 95\% confidence interval for the grouping
+#'  \code{variable}, taken from the Cox model \code{fit} -- i.e. the hazard ratio
+#'  \emph{adjusted} for the model's other terms. Drawn only when \code{variable}
+#'  is an estimated model coefficient (not a \code{strata()} term, an interaction,
+#'  or a non-treatment contrast such as an ordered factor); a factor with more
+#'  than two levels shows one line per non-reference level.
+#'@param hr.coord numeric vector \code{c(x, y)} giving a time and survival point
+#'  at which to place the hazard-ratio annotation \emph{inside} the panel, in a
+#'  translucent box. This is manual placement: on a small figure a label near the
+#'  panel centre can run past an edge, so adjust the coordinate or the figure size
+#'  if it does. Default \code{NULL} draws the annotation as a subtitle above the
+#'  plot instead, which keeps it clear of the curves at the usual figure sizes and
+#'  for any \code{fun} transform.
+#'@param hr.size the font size of the hazard-ratio annotation. Default 4.
 #'@inheritParams ggpubr::ggpar
 #'@param ... further arguments passed to the function \code{\link[ggpubr]{ggpar}} for customizing the plot.
 #'@return Returns an object of class \code{gg} (a \code{ggplot}); when
@@ -146,7 +161,8 @@ ggadjustedcurves <- function(fit,
                                 xlim = NULL,
                                 tables.y.text = TRUE,
                                 tables.theme = theme_survminer(),
-                                fontsize = 4.5, ...) {
+                                fontsize = 4.5,
+                                show.hr = FALSE, hr.coord = NULL, hr.size = 4, ...) {
   stopifnot(method %in% c("marginal", "average", "conditional", "single"))
   draw.table <- !is.null(risk.table) && !isFALSE(risk.table) && !identical(risk.table, "")
 
@@ -190,6 +206,44 @@ ggadjustedcurves <- function(fit,
   if (method == "single")
     pl <- pl + theme(legend.position = "none")
 
+  # Resolve the grouping variable (the argument, else a strata() term). Shared by
+  # the optional HR annotation and the risk table below.
+  .var <- variable
+  if (is.null(.var)) {
+    .tl <- attr(stats::terms(fit$formula), "term.labels")
+    .st <- grep("strata(", .tl, fixed = TRUE, value = TRUE)
+    if (length(.st) > 0)
+      .var <- gsub("[\\) ]", "", gsub("strata(", "", .st[1], fixed = TRUE))
+  }
+
+  # Optional adjusted hazard-ratio annotation: the covariate hazard ratio with
+  # 95% CI from the Cox model -- adjusted for the model's other terms. By default
+  # it is a subtitle (outside the panel, so it stays clear of the curves at the
+  # usual sizes and for any `fun` transform); pass `hr.coord` to place it inside
+  # the panel at a chosen (time, survival) point instead.
+  if (isTRUE(show.hr)) {
+    hr.lab <- .adjusted_hr_label(fit, .var)
+    if (!is.null(hr.lab)) {
+      txt <- paste(hr.lab, collapse = "\n")
+      if (is.null(hr.coord)) {
+        pl <- pl + ggplot2::labs(subtitle = txt) +
+          ggplot2::theme(plot.subtitle = ggplot2::element_text(size = hr.size * 2.5))
+      } else {
+        xr <- range(curve$time, na.rm = TRUE)
+        # right-align when the anchor is past the mid-time, so a long label grows
+        # left into the panel instead of clipping at the right edge.
+        hj <- if (hr.coord[1] > xr[1] + 0.5 * diff(xr)) 1 else 0
+        # a translucent white box keeps the label legible where it sits over the
+        # curves (borderless, so it reads as a highlight rather than a box).
+        pl <- pl + ggplot2::geom_label(
+          data = data.frame(x = hr.coord[1], y = hr.coord[2], label = txt),
+          mapping = ggplot2::aes(x = .data$x, y = .data$y, label = .data$label),
+          inherit.aes = FALSE, hjust = hj, vjust = 1, size = hr.size,
+          linewidth = 0, fill = grDevices::adjustcolor("white", 0.7))
+      }
+    }
+  }
+
   # Default (no risk table): return the plain adjusted-curves ggplot, unchanged.
   # `xlim` is only forwarded to ggpar() when the user supplied it, so an ordinary
   # call (xlim = NULL) is byte-identical to before.
@@ -215,17 +269,9 @@ ggadjustedcurves <- function(fit,
   # this count is the raw Kaplan-Meier number at risk (documented).
   adj.plot <- ggpubr::ggpar(pl, palette = palette, ...)
 
-  # Resolve the grouping variable exactly as surv_adjustedcurves() does: the
-  # argument, else a strata() term; a model with neither gives a single curve and
-  # an overall (~ 1) table.
-  .var <- variable
-  if (is.null(.var)) {
-    .tl <- attr(stats::terms(fit$formula), "term.labels")
-    .st <- grep("strata(", .tl, fixed = TRUE, value = TRUE)
-    if (length(.st) > 0)
-      .var <- gsub("[\\) ]", "",
-                   gsub("strata(", "", .st[1], fixed = TRUE))
-  }
+  # `.var` (the grouping variable) was resolved above, shared with the HR
+  # annotation. A model with neither an argument nor a strata() term gives a
+  # single curve and an overall (~ 1) table.
 
   # Restrict the KM fit to the model's rows (complete cases on the model variables)
   # so the number at risk describes the population the adjusted curves are built on.
@@ -462,3 +508,76 @@ ggadjustedcurves.conditional <- function(data, fit, variable, size = 1) {
   curve
 }
 
+
+
+# Adjusted hazard-ratio label(s) for the grouping `variable`, taken from the
+# coxph fit: exp(coef) with a 95% CI, adjusted for the model's other terms.
+# Returns a character vector (one line per estimated level of a factor) or NULL
+# (with a warning) when no hazard ratio is available -- no grouping variable, or
+# a strata()/non-coefficient term.
+.adjusted_hr_label <- function(fit, variable) {
+  if (is.null(variable)) {
+    warning("`show.hr = TRUE` needs a grouping `variable` that is a model ",
+            "coefficient; no hazard ratio drawn.", call. = FALSE)
+    return(NULL)
+  }
+  # Coefficient index for the term, backtick-safe (a non-syntactic name is stored
+  # quoted in names(fit$assign)).
+  idx <- fit$assign[[variable]]
+  if (is.null(idx)) {
+    pos <- which(gsub("`", "", names(fit$assign)) == variable)
+    if (length(pos) == 1L) idx <- fit$assign[[pos]]
+  }
+  if (is.null(idx) || length(idx) == 0L) {
+    warning("No adjusted hazard ratio for `", variable, "`: it is a strata() ",
+            "term or not a main-effect coefficient in the model; no hazard ratio ",
+            "drawn.", call. = FALSE)
+    return(NULL)
+  }
+  # If `variable` is part of an interaction, a single adjusted hazard ratio is not
+  # well defined -- exp(coef) is the effect at the other term's reference/zero, not
+  # an adjusted HR -- so refuse rather than annotate a misleading number.
+  .terms <- attr(stats::terms(fit), "term.labels")
+  .inter <- grep(":", .terms, fixed = TRUE, value = TRUE)
+  if (any(vapply(.inter, function(t)
+        variable %in% gsub("`", "", strsplit(t, ":", fixed = TRUE)[[1]]),
+        logical(1)))) {
+    warning("`", variable, "` appears in an interaction term, so a single ",
+            "adjusted hazard ratio is not well defined; no hazard ratio drawn.",
+            call. = FALSE)
+    return(NULL)
+  }
+  tid <- broom::tidy(fit, conf.int = TRUE, exponentiate = TRUE)
+  rows <- tid[idx, , drop = FALSE]
+  ref <- fit$xlevels[[variable]][1]                 # NULL for a numeric covariate
+  val <- sprintf("%.2f (95%% CI %.2f to %.2f)",
+                 rows$estimate, rows$conf.low, rows$conf.high)
+  # each HR is a "contrast:" line then a "value" line; wrap a long contrast onto
+  # extra lines so the annotation fits a narrow panel / small figure without
+  # clipping (short labels stay on one line). Vectorised: one element per level.
+  fmt <- function(head) mapply(function(h, v)
+      paste0(paste(strwrap(h, width = 32), collapse = "\n"), "\n", v),
+      head, val, USE.NAMES = FALSE)
+  if (is.null(ref)) {
+    fmt(sprintf("Adjusted HR (%s, per unit):", variable))
+  } else {
+    # strip the term's "variable" prefix to get the level name; the coefficient is
+    # named "variableLevel", or "`variable`Level" for a non-syntactic name.
+    bt <- paste0("`", variable, "`")
+    lvl <- ifelse(startsWith(rows$term, bt),
+                  substring(rows$term, nchar(bt) + 1L),
+                  substring(rows$term, nchar(variable) + 1L))
+    # only a treatment-style "level vs reference" contrast can be read as a
+    # pairwise HR. An ordered factor (or any non-default contrast) gives
+    # polynomial/Helmert coefficients (.L, .Q, ...) whose stripped name is not a
+    # real level -- exp(coef) is then not a level-to-reference hazard ratio, so
+    # refuse rather than mislabel it.
+    if (!all(lvl %in% fit$xlevels[[variable]])) {
+      warning("`", variable, "` does not use treatment contrasts (e.g. an ",
+              "ordered factor), so its coefficients are not level-vs-reference ",
+              "hazard ratios; no hazard ratio drawn.", call. = FALSE)
+      return(NULL)
+    }
+    fmt(sprintf("Adjusted HR (%s vs %s):", lvl, ref))
+  }
+}

--- a/man/ggadjustedcurves.Rd
+++ b/man/ggadjustedcurves.Rd
@@ -24,6 +24,9 @@ ggadjustedcurves(
   tables.y.text = TRUE,
   tables.theme = theme_survminer(),
   fontsize = 4.5,
+  show.hr = FALSE,
+  hr.coord = NULL,
+  hr.size = 4,
   ...
 )
 
@@ -104,6 +107,24 @@ labels are hidden.}
 
 \item{tables.theme, fontsize}{the theme and font size of the risk table, as in
 \code{\link{ggsurvplot}()}.}
+
+\item{show.hr}{logical. Default \code{FALSE}. If \code{TRUE}, annotate the plot
+with the covariate hazard ratio and 95\% confidence interval for the grouping
+\code{variable}, taken from the Cox model \code{fit} -- i.e. the hazard ratio
+\emph{adjusted} for the model's other terms. Drawn only when \code{variable}
+is an estimated model coefficient (not a \code{strata()} term, an interaction,
+or a non-treatment contrast such as an ordered factor); a factor with more
+than two levels shows one line per non-reference level.}
+
+\item{hr.coord}{numeric vector \code{c(x, y)} giving a time and survival point
+at which to place the hazard-ratio annotation \emph{inside} the panel, in a
+translucent box. This is manual placement: on a small figure a label near the
+panel centre can run past an edge, so adjust the coordinate or the figure size
+if it does. Default \code{NULL} draws the annotation as a subtitle above the
+plot instead, which keeps it clear of the curves at the usual figure sizes and
+for any \code{fun} transform.}
+
+\item{hr.size}{the font size of the hazard-ratio annotation. Default 4.}
 
 \item{...}{further arguments passed to the function \code{\link[ggpubr]{ggpar}} for customizing the plot.}
 }

--- a/tests/testthat/test-ggadjustedcurves-hr.R
+++ b/tests/testthat/test-ggadjustedcurves-hr.R
@@ -1,0 +1,112 @@
+# Adjusted hazard-ratio annotation on ggadjustedcurves() (show.hr).
+
+library(survival)
+
+.lung2 <- function() {
+  d <- lung
+  d$sex <- factor(d$sex, labels = c("Male", "Female"))
+  d
+}
+.geoms <- function(p) vapply(p$layers, function(l) class(l$geom)[1], character(1))
+
+test_that("the adjusted HR label matches exp(coef) and its confidence interval", {
+  d <- .lung2()
+  fit <- coxph(Surv(time, status) ~ sex + age, data = d)
+  lab <- survminer:::.adjusted_hr_label(fit, "sex")
+  # reference: the model's own adjusted HR for sexFemale
+  hr <- unname(exp(coef(fit)["sexFemale"]))
+  ci <- exp(confint(fit)["sexFemale", ])
+  expect_match(lab, sprintf("%.2f", hr))
+  expect_match(lab, sprintf("%.2f", ci[1]))
+  expect_match(lab, sprintf("%.2f", ci[2]))
+  expect_match(lab, "Female vs Male")
+})
+
+test_that("a factor with >2 levels gives one HR line per non-reference level", {
+  d <- lung[!is.na(lung$ph.ecog) & lung$ph.ecog %in% 0:2, ]
+  d$ph.ecog <- factor(d$ph.ecog)
+  fit <- coxph(Surv(time, status) ~ ph.ecog + age, data = d)
+  lab <- survminer:::.adjusted_hr_label(fit, "ph.ecog")
+  expect_length(lab, 2L)
+  expect_match(lab[1], "1 vs 0")
+  expect_match(lab[2], "2 vs 0")
+  # numbers equal the model coefficients
+  hr <- unname(exp(coef(fit))[c("ph.ecog1", "ph.ecog2")])
+  expect_match(lab[1], sprintf("%.2f", hr[1]))
+  expect_match(lab[2], sprintf("%.2f", hr[2]))
+})
+
+test_that("a numeric covariate is labelled without a reference level", {
+  d <- .lung2()
+  fit <- coxph(Surv(time, status) ~ age + sex, data = d)
+  lab <- survminer:::.adjusted_hr_label(fit, "age")
+  expect_length(lab, 1L)
+  expect_match(lab, "Adjusted HR \\(age, per unit\\)")
+  expect_match(lab, sprintf("%.2f", unname(exp(coef(fit)["age"]))))
+})
+
+test_that("no HR is drawn for a strata() term or a missing variable (with a warning)", {
+  d <- .lung2()
+  fit <- coxph(Surv(time, status) ~ age + strata(sex), data = d)
+  expect_warning(r <- survminer:::.adjusted_hr_label(fit, "sex"), "strata")
+  expect_null(r)
+  expect_warning(r2 <- survminer:::.adjusted_hr_label(fit, NULL), "needs a grouping")
+  expect_null(r2)
+})
+
+test_that("show.hr = FALSE (default) is unchanged; TRUE annotates a subtitle", {
+  d <- .lung2()
+  fit <- coxph(Surv(time, status) ~ sex + age, data = d)
+  p0 <- ggadjustedcurves(fit, data = d, method = "average", variable = "sex")
+  expect_false("GeomText" %in% .geoms(p0))
+  expect_null(p0$labels$subtitle)
+  # default: the HR is a subtitle (outside the panel, collision/clip-proof)
+  p1 <- ggadjustedcurves(fit, data = d, method = "average", variable = "sex",
+                         show.hr = TRUE)
+  expect_match(p1$labels$subtitle, "Adjusted HR")
+  expect_false("GeomLabel" %in% .geoms(p1))
+  # hr.coord: an in-panel text annotation (boxed label) at the chosen point
+  p2 <- ggadjustedcurves(fit, data = d, method = "average", variable = "sex",
+                         show.hr = TRUE, hr.coord = c(100, 0.9))
+  expect_true("GeomLabel" %in% .geoms(p2))
+  txt <- p2$layers[[which(.geoms(p2) == "GeomLabel")]]
+  expect_equal(txt$data$x, 100)
+  expect_equal(txt$data$y, 0.9)
+})
+
+test_that("no HR is drawn (with a warning) for a non-treatment-contrast factor", {
+  d <- lung[!is.na(lung$ph.ecog) & lung$ph.ecog %in% 0:2, ]
+  d$ph.ecog <- ordered(factor(d$ph.ecog))   # polynomial contrasts (.L, .Q)
+  fit <- coxph(Surv(time, status) ~ ph.ecog + age, data = d)
+  expect_warning(r <- survminer:::.adjusted_hr_label(fit, "ph.ecog"),
+                 "treatment contrasts")
+  expect_null(r)
+})
+
+test_that("a long factor-level name wraps instead of running off one line", {
+  d <- lung
+  d$sex <- factor(d$sex, labels = c("Male patients cohort", "Female patients cohort"))
+  fit <- coxph(Surv(time, status) ~ sex + age, data = d)
+  lab <- survminer:::.adjusted_hr_label(fit, "sex")
+  # the full contrast is present once the wrap newlines are flattened to spaces
+  flat <- gsub("[\n]+", " ", lab)
+  expect_match(flat, "Female patients cohort vs Male patients cohort")
+  # every physical line stays within the wrap width (no run-off single line)
+  expect_true(all(nchar(strsplit(lab, "\n", fixed = TRUE)[[1]]) <= 34))
+})
+
+test_that("no HR is drawn (with a warning) when the variable is in an interaction", {
+  d <- .lung2()
+  fit <- coxph(Surv(time, status) ~ sex * age, data = d)
+  expect_warning(r <- survminer:::.adjusted_hr_label(fit, "sex"), "interaction")
+  expect_null(r)
+})
+
+test_that("show.hr works together with a risk table", {
+  d <- .lung2()
+  fit <- coxph(Surv(time, status) ~ sex + age, data = d)
+  p <- ggadjustedcurves(fit, data = d, method = "average", variable = "sex",
+                        show.hr = TRUE, risk.table = TRUE)
+  expect_s3_class(p, "ggsurvplot")
+  expect_match(p$plot$labels$subtitle, "Adjusted HR")   # HR subtitle on the curve panel
+})


### PR DESCRIPTION
`ggadjustedcurves()` draws covariate-adjusted survival curves but never reported
the effect size. `show.hr = TRUE` annotates the grouping variable's hazard ratio
and 95% confidence interval from the Cox model — the effect adjusted for the
model's other terms.

```r
library(survival)
d <- lung; d$sex <- factor(d$sex, labels = c("Male", "Female"))
fit <- coxph(Surv(time, status) ~ sex + age + ph.ecog, data = d)

# adjusted HR as a subtitle (default)
ggadjustedcurves(fit, data = d, method = "average", variable = "sex",
                 show.hr = TRUE)
```

![Adjusted survival curves with the adjusted HR as a subtitle](https://i.imgur.com/rOfHdNN.png)

```r
# place it inside the panel instead
ggadjustedcurves(fit, data = d, method = "average", variable = "sex",
                 show.hr = TRUE, hr.coord = c(400, 0.85))
```

![Adjusted survival curves with the adjusted HR in a translucent in-panel box](https://i.imgur.com/esVhkqh.png)

The label is `exp(coef)` with its confidence interval: a two-level factor or
numeric covariate gives one line, a factor with more than two levels one line per
non-reference level. Each hazard ratio is written on two lines and a long
contrast wraps, so it fits a narrow panel or small figure. The default subtitle
stays clear of the curves at the usual sizes and for any `fun` transform;
`hr.coord` draws it inside the panel in a translucent box.

A single adjusted hazard ratio is only well defined for a plain level-vs-reference
contrast, so a variable in an interaction, an ordered factor (or any
non-treatment contrast), a `strata()` term, and a call with no grouping variable
are each skipped with a warning. `show.hr = FALSE` (default) leaves every existing
call unchanged. Works with the number-at-risk table too.
