### PR TITLE
Set curve line width via linewidth, not the deprecated size aesthetic

### DIFF
--- a/.github/scripts/check-deprecations.R
+++ b/.github/scripts/check-deprecations.R
@@ -1,0 +1,109 @@
+# Fail the build on any ggplot2/lifecycle deprecation triggered by survminer's
+# public plotting API. Meant to run against ggplot2-devel so we get lead time
+# before a deprecation becomes a removal -- the package's main upstream-breakage
+# risk.
+#
+# `lifecycle_verbosity = "error"` turns every deprecation into an error, so we do
+# not depend on warnings propagating out of testthat (which captures them) or on
+# ggplot2's imperfect "likely used in the <pkg>" attribution. We exercise the API
+# directly and force a full ggplot_build() so draw-time deprecations surface too.
+# A deprecation reached through a helper (e.g. `size` forwarded into
+# ggpubr::geom_exec) throws here just the same, which is the class of bug this
+# guard exists to catch. The API is deprecation-clean today; if a dependency
+# later introduces one we cannot fix, waive that specific call here rather than
+# dropping the guard.
+
+options(lifecycle_verbosity = "error")
+suppressPackageStartupMessages({
+  library(survival)
+  pkgload::load_all(".", quiet = TRUE)
+})
+
+set.seed(1)                              # keep the competing-risks case reproducible
+lung2 <- lung
+lung2$sex     <- factor(lung2$sex, labels = c("Male", "Female"))
+lung2$ph.ecog <- factor(lung2$ph.ecog)
+lung2 <- lung2[!is.na(lung2$ph.ecog) & lung2$ph.ecog %in% c("0", "1", "2"), ]
+lung2$ph.ecog <- droplevels(lung2$ph.ecog)
+km  <- survfit(Surv(time, status) ~ sex, data = lung2)
+cox <- coxph(Surv(time, status) ~ sex + age + ph.ecog, data = lung2)
+
+# each entry: a label and a thunk that returns a plot object (or a list of them).
+# Aim to touch every exported plotting function, so a stray deprecated aesthetic
+# anywhere in the drawing code is caught, not just in the curve engine.
+cases <- list(
+  "ggsurvplot"                = function() ggsurvplot(km, data = lung2),
+  "ggsurvplot(size=)"         = function() ggsurvplot(km, data = lung2, size = 1.5),
+  "ggsurvplot(conf.int,pval,risk.table)" =
+                                function() ggsurvplot(km, data = lung2, conf.int = TRUE,
+                                                      pval = TRUE, risk.table = TRUE,
+                                                      ncensor.plot = TRUE),
+  "ggsurvplot(fun=cumhaz)"    = function() ggsurvplot(km, data = lung2, fun = "cumhaz", size = 0.8),
+  "ggsurvplot(fun=event)"     = function() ggsurvplot(km, data = lung2, fun = "event"),
+  "ggsurvplot(ci step)"       = function() ggsurvplot(km, data = lung2, conf.int = TRUE,
+                                                      conf.int.style = "step", size = 0.8),
+  "ggsurvplot_facet"          = function() ggsurvplot_facet(km, data = lung2, facet.by = "sex"),
+  "ggsurvplot_combine"        = function() ggsurvplot_combine(
+                                  list(all = survfit(Surv(time, status) ~ 1, data = lung2),
+                                       sex = km), data = lung2),
+  "ggsurvtable"               = function() ggsurvtable(km, data = lung2),
+  "ggrisktable"               = function() ggrisktable(km, data = lung2),
+  "ggcumevents"               = function() ggcumevents(km, data = lung2),
+  "ggcumcensor"               = function() ggcumcensor(km, data = lung2),
+  "ggsurvevents"              = function() ggsurvevents(fit = km, data = lung2),
+  "ggcoxzph"                  = function() ggcoxzph(cox.zph(cox)),
+  "ggcoxdiagnostics"          = function() ggcoxdiagnostics(cox),
+  "ggcoxfunctional"           = function() ggcoxfunctional(Surv(time, status) ~ age, data = lung2),
+  "ggforest"                  = function() ggforest(cox, data = lung2),
+  "ggforest_subgroup"         = function() ggforest_subgroup(cox, data = lung2,
+                                             treatment = "sex", subgroups = "ph.ecog"),
+  "ggadjustedcurves"          = function() ggadjustedcurves(cox, data = lung2,
+                                                            method = "average", variable = "sex",
+                                                            show.hr = TRUE),
+  "ggrmst"                    = function() ggrmst(km, data = lung2, tau = 500),
+  "ggcompetingrisks"          = function() {
+      df <- data.frame(time = lung$time,
+                       status = factor(ifelse(lung$status == 2, "death", "other"),
+                                       levels = c("censored", "death", "other")))
+      df$status[sample(nrow(df), 40)] <- "censored"
+      ggcompetingrisks(survfit(Surv(time, status) ~ 1, data = df))
+  }
+)
+if (requireNamespace("flexsurv", quietly = TRUE)) {
+  cases[["ggflexsurvplot"]] <- function() {
+    fit <- flexsurv::flexsurvreg(Surv(time, status) ~ sex, data = lung2, dist = "weibull")
+    ggflexsurvplot(fit, data = lung2, conf.int.flex = TRUE)
+  }
+}
+
+# Force drawing so build-time deprecations surface too. Descends into ggsurvplot
+# objects (which hold several ggplots -- plot, table, ncensor) and into any list
+# of ggplots (e.g. ggcoxzph returns one plot per covariate), building each.
+force_build <- function(x) {
+  if (inherits(x, "ggplot")) {
+    invisible(ggplot2::ggplot_build(x))
+  } else if (is.list(x) && !is.data.frame(x)) {
+    for (el in x) force_build(el)
+  }
+  invisible(NULL)
+}
+
+failures <- character()
+for (nm in names(cases)) {
+  res <- tryCatch({ force_build(cases[[nm]]()); NULL },
+                  error = function(e) conditionMessage(e))
+  if (!is.null(res) && grepl("deprecat", res, ignore.case = TRUE)) {
+    failures <- c(failures, sprintf("%s: %s", nm, gsub("[\r\n]+", " ", res)))
+  } else if (!is.null(res)) {
+    # a non-deprecation error (e.g. dev ggplot2 removed an API) is also a real
+    # break we want to surface.
+    failures <- c(failures, sprintf("%s [ERROR]: %s", nm, gsub("[\r\n]+", " ", res)))
+  }
+}
+
+if (length(failures) > 0) {
+  cat("::error::survminer plotting hit", length(failures), "deprecation(s)/break(s):\n")
+  for (m in failures) cat(" - ", substr(m, 1, 240), "\n", sep = "")
+  quit(status = 1)
+}
+cat("survminer plotting API is deprecation-clean under the current ggplot2. ✓\n")

--- a/.github/workflows/deprecation-check.yaml
+++ b/.github/workflows/deprecation-check.yaml
@@ -1,0 +1,47 @@
+# Early warning for upstream breakage: run survminer's plotting API against the
+# development version of ggplot2 with every deprecation turned into an error, so
+# a feature ggplot2 is about to remove is caught here with lead time rather than
+# on the next CRAN ggplot2 release. See .github/scripts/check-deprecations.R.
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+name: deprecation-check.yaml
+
+permissions: read-all
+
+jobs:
+  deprecation-check:
+    runs-on: ubuntu-latest
+    name: deprecation-check (ggplot2-devel)
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          # install the package's deps (incl. Suggests, so ggflexsurvplot works),
+          # pkgload for load_all(), and the development ggplot2 on top.
+          extra-packages: |
+            any::pkgload
+            github::tidyverse/ggplot2
+          needs: check
+
+      - name: ggplot2 version
+        run: Rscript -e 'cat("ggplot2", as.character(packageVersion("ggplot2")), "\n")'
+
+      - name: Run deprecation guard
+        run: Rscript .github/scripts/check-deprecations.R

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ CLAUDE.md
 
 # R plot device artifacts from test runs
 Rplots.pdf
+
+# local scratch/working files
+scratchpad/

--- a/NEWS.md
+++ b/NEWS.md
@@ -176,6 +176,8 @@
 
 ## Bug fixes
 
+- `ggsurvplot()` and `ggflexsurvplot()` no longer emit a ggplot2 deprecation warning when you set the curve line width with `size`. The width was already applied through `linewidth`, but `size` was also passed on to the line geom, where it is a deprecated aesthetic (as of ggplot2 3.4.0). It is no longer forwarded; the drawn line width is unchanged.
+
 - `ggflexsurvplot()` now honors a user-supplied `summary.flexsurv` and the `fun` argument for a single-stratum fit. The single-stratum branch of the internal summary helper recomputed `summary(fit)` with the default time grid and type, so a `summary.flexsurv` meant to extend the fitted curve to a wider `xlim` was ignored (the curve stopped at the last observed time), and `fun = "cumhaz"` fell back to the survival curve. It now uses the already-selected summary. Multi-stratum fits and the default single-stratum survival curve are unchanged (#400).
 
 - `ggsurvplot()` now accepts a per-strata `linetype` vector that contains a hex dash pattern, e.g. `linetype = c("solid", "F1")`. Only all-base-name or all-numeric vectors were mapped to a manual per-strata scale; a vector with a hex pattern fell through and crashed with "the condition has length > 1". Any length-1 value (including a single hex pattern or `"strata"`) is unchanged (#344).

--- a/R/ggflexsurvplot.R
+++ b/R/ggflexsurvplot.R
@@ -93,14 +93,14 @@ ggflexsurvplot <- function(fit, data = NULL,
   time <- est <- strata <- lcl <- ucl <- NULL
   ggsurv$plot <- ggsurv$plot +
     geom_line(aes(time, est, color = strata),
-              data = summ, size = size)
+              data = summ, linewidth = size)
 
   if(conf.int.flex)
     ggsurv$plot <- ggsurv$plot +
     geom_line(aes(time, lcl, color = strata), data = summ,
-              size = 0.5, linetype = "dashed")+
+              linewidth = 0.5, linetype = "dashed")+
     geom_line(aes(time, ucl, color = strata), data = summ,
-              size = 0.5, linetype = "dashed")
+              linewidth = 0.5, linetype = "dashed")
 
 
   ggsurv

--- a/R/ggsurvplot_df.R
+++ b/R/ggsurvplot_df.R
@@ -207,7 +207,15 @@ ggsurvplot_df <- function(fit, fun = NULL,
   #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   df[, .strata.var] <- factor( df[, .strata.var], levels = .levels(.strata), labels = legend.labs)
 
-  surv.layer <- ggpubr::geom_exec(surv.geom, data = df, linewidth = size, color = color, linetype = linetype, ...)
+  # `size` is captured above and forwarded as `linewidth`; drop it from the extra
+  # dots so ggpubr::geom_exec() does not also set the deprecated `size` line
+  # aesthetic (deprecated in ggplot2 3.4.0). `linewidth` already carries the value,
+  # so the drawn width is unchanged.
+  .extra <- list(...)
+  .extra$size <- NULL
+  surv.layer <- do.call(ggpubr::geom_exec,
+                        c(list(surv.geom, data = df, linewidth = size,
+                               color = color, linetype = linetype), .extra))
   # ggpubr::geom_exec() does not forward `linejoin` to the step geom, so set it
   # directly on the built layer. The default "round" reproduces geom_step()'s own
   # default, so the curve is byte-identical unless the user opts into another join

--- a/tests/testthat/test-deprecations.R
+++ b/tests/testthat/test-deprecations.R
@@ -1,0 +1,44 @@
+# survminer's own code should not trigger ggplot2/lifecycle deprecation warnings.
+# Regression guard for the `size` line aesthetic (deprecated in ggplot2 3.4.0):
+# passing `size` to ggsurvplot()/ggflexsurvplot() must set `linewidth`, not the
+# deprecated `size` aesthetic on the line geom.
+
+library(survival)
+
+# collect deprecation warnings emitted while evaluating `expr`
+.deprecations <- function(expr) {
+  old <- options(lifecycle_verbosity = "warning")
+  on.exit(options(old), add = TRUE)
+  msgs <- character()
+  withCallingHandlers(
+    force(expr),
+    warning = function(w) {
+      m <- conditionMessage(w)
+      if (grepl("deprecat", m, ignore.case = TRUE)) msgs <<- c(msgs, m)
+      invokeRestart("muffleWarning")
+    }
+  )
+  msgs
+}
+
+test_that("ggsurvplot(size=) sets linewidth, not the deprecated size aesthetic", {
+  km <- survfit(Surv(time, status) ~ sex, data = lung)
+  for (s in c(0.5, 1, 2)) {
+    p <- ggsurvplot(km, data = lung, size = s)
+    lyr <- p$plot$layers[[1]]
+    expect_equal(lyr$aes_params$linewidth, s)
+    expect_false("size" %in% names(lyr$aes_params))
+  }
+  # and building the plot emits no deprecation warning from our code
+  msgs <- .deprecations(ggplot2::ggplot_build(
+    ggsurvplot(km, data = lung, size = 0.8)$plot))
+  expect_false(any(grepl("size", msgs) & grepl("deprecat", msgs, ignore.case = TRUE)))
+})
+
+test_that("ggflexsurvplot() draws lines without the deprecated size aesthetic", {
+  skip_if_not_installed("flexsurv")
+  fit <- flexsurv::flexsurvreg(Surv(time, status) ~ sex, data = lung, dist = "weibull")
+  msgs <- .deprecations(
+    ggplot2::ggplot_build(ggflexsurvplot(fit, data = lung, conf.int.flex = TRUE)$plot))
+  expect_false(any(grepl("deprecat", msgs, ignore.case = TRUE)))
+})


### PR DESCRIPTION
Passing `size` to set the survival-curve line width triggered a ggplot2
deprecation warning:

```
Using `size` aesthetic for lines was deprecated in ggplot2 3.4.0.
ℹ Please use `linewidth` instead.
```

`ggsurvplot()` already applied the width through `linewidth`, but it also
forwarded the user's `size` to the line geom, where `size` is the deprecated line
aesthetic. `ggsurvplot(size = ...)` and `ggflexsurvplot()` (which passes `size`
on) both emitted the warning. The redundant `size` is no longer forwarded; because
`linewidth` already carried the value, the drawn line width is unchanged. The
three `geom_line(size = ...)` calls inside `ggflexsurvplot()` now use `linewidth`.

```r
library(survival)
fit <- survfit(Surv(time, status) ~ sex, data = lung)
# previously warned; now clean, same line width
ggsurvplot(fit, data = lung, size = 1.5)
```

Also adds a CI job (`deprecation-check.yaml`) that runs the plotting API against
the development version of ggplot2 with deprecations turned into errors, so a
feature ggplot2 is about to remove surfaces here with lead time instead of on the
next ggplot2 release. It exercises the exported plotting functions and fails if
any trips a deprecation.

Suggest keeping this job as an informational check rather than a required one for
merge: the development ggplot2 can occasionally fail to build or change for reasons
outside this package.
