### PR TITLE
Use ggplot2 transform for log-scale axes; drop dead code in ggcoxzph()

### DIFF
--- a/.github/scripts/check-deprecations.R
+++ b/.github/scripts/check-deprecations.R
@@ -39,6 +39,7 @@ cases <- list(
                                                       pval = TRUE, risk.table = TRUE,
                                                       ncensor.plot = TRUE),
   "ggsurvplot(fun=cumhaz)"    = function() ggsurvplot(km, data = lung2, fun = "cumhaz", size = 0.8),
+  "ggsurvplot(fun=cloglog)"   = function() ggsurvplot(km, data = lung2, fun = "cloglog"),
   "ggsurvplot(fun=event)"     = function() ggsurvplot(km, data = lung2, fun = "event"),
   "ggsurvplot(ci step)"       = function() ggsurvplot(km, data = lung2, conf.int = TRUE,
                                                       conf.int.style = "step", size = 0.8),

--- a/NEWS.md
+++ b/NEWS.md
@@ -185,6 +185,10 @@
 
 ## Bug fixes
 
+- The log-scale time axes (`ggsurvplot(fun = "cloglog")`, log-x risk/event tables
+  and the number-at-risk censor plot) no longer use the ggplot2 `trans` scale
+  argument that ggplot2 3.5.0 renamed to `transform`; the axis is unchanged.
+
 - `ggsurvplot()` and `ggflexsurvplot()` no longer emit a ggplot2 deprecation warning when you set the curve line width with `size`. The width was already applied through `linewidth`, but `size` was also passed on to the line geom, where it is a deprecated aesthetic (as of ggplot2 3.4.0). It is no longer forwarded; the drawn line width is unchanged.
 
 - `ggflexsurvplot()` now honors a user-supplied `summary.flexsurv` and the `fun` argument for a single-stratum fit. The single-stratum branch of the internal summary helper recomputed `summary(fit)` with the default time grid and type, so a `summary.flexsurv` meant to extend the fitted curve to a wider `xlim` was ignored (the curve stopped at the last observed time), and `fun = "cumhaz"` fell back to the survival curve. It now uses the already-selected summary. Multi-stratum fits and the default single-stratum survival curve are unchanged (#400).

--- a/R/ggcoxzph.R
+++ b/R/ggcoxzph.R
@@ -83,7 +83,6 @@ ggcoxzph <- function (fit, resid = TRUE, se = TRUE, df = 4, nsmo = 40, var,
 
   xx <- x$x
   yy <- x$y
-  d <- nrow(yy)
   df <- max(df)
   nvar <- ncol(yy)
   pred.x <- seq(from = min(xx), to = max(xx), length = nsmo)
@@ -94,11 +93,9 @@ ggcoxzph <- function (fit, resid = TRUE, se = TRUE, df = 4, nsmo = 40, var,
   qmat <- qr(xmat)
   if (qmat$rank < df)
     stop("Spline fit is singular, try a smaller degrees of freedom")
-  if (se) {
-    bk <- backsolve(qmat$qr[1:df, 1:df], diag(df))
-    xtx <- bk %*% t(bk)
-    seval <- d * ((pmat %*% xtx) * pmat) %*% rep(1, df)
-  }
+  # NB: the pointwise SE band is computed per panel below (from `x$var[i, i]`);
+  # there is no `d` (number of events) factor -- that matches survival's own
+  # plot.cox.zph under survival >= 3.0.
   ylab <- paste("Beta(t) for", dimnames(yy)[[2]])
   # Variable selection. `var_pval` is an alternative to `var`: keep only the terms
   # whose Grambsch-Therneau test p-value (x$table[, 3], per-variable rows, GLOBAL

--- a/R/ggsurvplot_core.R
+++ b/R/ggsurvplot_core.R
@@ -266,7 +266,7 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
 
     if(!pms$xlog) ncensor_plot <- ncensor_plot + scale_x_continuous(breaks = pms$time.breaks,
                                                                     labels = pms$xticklabels, expand = .expand)
-    else ncensor_plot <- ncensor_plot + ggplot2::scale_x_continuous(breaks = pms$time.breaks, trans = "log10", labels = pms$xticklabels)
+    else ncensor_plot <- ncensor_plot + .scale_x_log10(breaks = pms$time.breaks, labels = pms$xticklabels)
 
   }
   else if(cumcensor){

--- a/R/ggsurvplot_df.R
+++ b/R/ggsurvplot_df.R
@@ -251,7 +251,7 @@ ggsurvplot_df <- function(fit, fun = NULL,
     p <- p + ggplot2::scale_x_continuous(breaks = times, labels = xticklabels, expand = .expand) +
       ggplot2::expand_limits(x = 0, y = 0)
   }
-  else p <- p + ggplot2::scale_x_continuous(breaks = times, trans = "log10", labels = xticklabels)
+  else p <- p + .scale_x_log10(breaks = times, labels = xticklabels)
 
   # Add confidence interval
   #::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/R/ggsurvtable.R
+++ b/R/ggsurvtable.R
@@ -419,8 +419,7 @@ ggsurvtable <- function (fit, data = NULL, survtable = c("cumevents",  "cumcenso
   #:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   xticklabels <- .format_xticklabels(labels = times, xscale = xscale)
   if(!xlog) p <- p + ggplot2::scale_x_continuous(breaks = times, labels = xticklabels, expand = .expand)
-  else p <- p + ggplot2::scale_x_continuous(breaks = times,
-                                            trans = "log10", labels = xticklabels)
+  else p <- p + .scale_x_log10(breaks = times, labels = xticklabels)
 
   p <- p + tables.theme
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -835,3 +835,15 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
 
 
 
+
+# A log10 x-axis scale that works across ggplot2 versions: ggplot2 3.5.0 renamed
+# the scale `trans` argument to `transform` and soft-deprecated `trans`. Pick the
+# name the installed ggplot2 understands so the cloglog / log-time axes stay
+# deprecation-free without raising the package's ggplot2 floor.
+.scale_x_log10 <- function(breaks = ggplot2::waiver(),
+                           labels = ggplot2::waiver()) {
+  args <- list(breaks = breaks, labels = labels)
+  arg <- if (utils::packageVersion("ggplot2") >= "3.5.0") "transform" else "trans"
+  args[[arg]] <- "log10"
+  do.call(ggplot2::scale_x_continuous, args)
+}


### PR DESCRIPTION
Two clean-ups surfaced while building `ggcoxnph()`:

**1. Log-scale axes no longer use the deprecated `trans` scale argument.**
`ggsurvplot(fun = "cloglog")`, the log-x risk/event tables, and the number-at-risk
censor plot called `scale_x_continuous(trans = "log10")`. ggplot2 3.5.0 renamed
`trans` to `transform` and soft-deprecated the old name. A small helper now passes
`transform` on ggplot2 ≥ 3.5.0 and `trans` on older versions, so the axis is
unchanged and no deprecation is raised — without raising the package's ggplot2
floor (≥ 3.4.0). The deprecation-check job now also exercises `fun = "cloglog"`,
which is the path that had slipped through.

```r
library(survival)
fit <- survfit(Surv(time, status) ~ sex, data = lung)
ggsurvplot(fit, fun = "cloglog")   # same plot, no deprecation warning
```

**2. Removed dead code in `ggcoxzph()`.** A top-scope block computed a
scaled-Schoenfeld standard error carrying a spurious event-count factor, but the
result was never read — the confidence band is (and was) computed per panel from
the correct formula. Removing it changes nothing in the output; it only removes a
misleading fragment. (This is what made it look, on a first read, as though
`ggcoxzph`'s band was too wide — it never was; the drawn band already matches
`survival::cox.zph`'s own plot.)

Both changes were verified byte-identical: the cloglog/log-axis `ggplot_build()`
output is unchanged, and `ggcoxzph()` output matches the previous version across
every combination of covariate type, `df`, `transform`, `se`, and `add.beta.line`.
