### PR TITLE
Add competing-risks features to ggcompetingrisks() (Gray's test, tidycmprsk, naive-KM overlay)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Suggests:
     knitr,
     flexsurv,
     cmprsk,
+    tidycmprsk,
     markdown,
     testthat,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,16 @@
 
 ## New features
 
+- `ggcompetingrisks()` gains competing-risks features. It now accepts a
+  `tidycmprsk::cuminc` object (with proper pointwise confidence limits and the
+  data). `pval = TRUE` annotates Gray's test p-value for each cause as a subtitle
+  (for `cmprsk`/`tidycmprsk` inputs with more than one group). `add.naive.km = TRUE`
+  overlays, for one `cause`, the naive complement-of-Kaplan-Meier that censors the
+  competing events and therefore overestimates the cumulative incidence -- the
+  classic teaching contrast. The `conf.int` confidence band is kept within
+  `[0, 1]`. The default output for existing `cuminc`/`survfitms` inputs is
+  unchanged.
+
 - New `ggcoxnph()` draws a multi-panel diagnostic for the proportional-hazards
   assumption of a Cox model, for one covariate of interest: log-cumulative-hazard
   vs log-time by group, the scaled Schoenfeld residuals with a smoothed estimate

--- a/R/ggcompetingrisks.R
+++ b/R/ggcompetingrisks.R
@@ -2,7 +2,13 @@
 #' @importFrom survival survfit
 #' @description This function plots Cumulative Incidence Curves. For \code{cuminc} objects it's a \code{ggplot2} version of \code{plot.cuminc}.
 #' For \code{survfitms} objects a different geometry is used, as suggested by \code{@@teigentler}.
-#' @param fit an object of a class \code{cmprsk::cuminc} - created with \code{cmprsk::cuminc} function or \code{survfitms} created with \link[survival]{survfit} function.
+#' It also accepts a \code{\link[tidycmprsk]{cuminc}} object from the \pkg{tidycmprsk}
+#' package (which carries proper pointwise confidence limits and the data), can
+#' annotate Gray's test, and can overlay the naive complement-of-Kaplan-Meier for
+#' teaching.
+#' @param fit a cumulative-incidence object: a \code{cmprsk::cuminc}, a
+#'  \code{\link[tidycmprsk]{cuminc}} (\pkg{tidycmprsk}), or a \code{survfitms} from
+#'  \code{\link[survival]{survfit}}.
 #' @param gnames a vector with group names. If not supplied then will be extracted from \code{fit} object (\code{cuminc} only).
 #' @param gsep a separator that extracts group names and event names from \code{gnames} object (\code{cuminc} only).
 #' @param multiple_panels if \code{TRUE} then groups will be plotted in different panels (\code{cuminc} only).
@@ -11,7 +17,31 @@
 #' @param ... further arguments passed to the function \code{\link[ggpubr]{ggpar}} for customizing the plot.
 #' @param conf.int if \code{TRUE} then additional layer (\code{geom_ribbon}) is added around the point estimate. The ribon is plotted with boundries +- \code{coef}*standard deviation.
 #' @param coef see \code{conf.int}, scaling actor for the ribbon. The default value is 1.96.
-#' @return Returns an object of class \code{gg}.
+#' @param pval logical or a character string. If \code{TRUE}, annotate Gray's test
+#'  p-value for each cause (comparing the groups) as a subtitle; a character string
+#'  is used verbatim as the subtitle. Gray's test is available only for a
+#'  \code{cmprsk} / \code{tidycmprsk} \code{cuminc} object with more than one group;
+#'  for other inputs \code{pval} is ignored with a message (Gray, 1988).
+#' @param add.naive.km logical. If \code{TRUE}, overlay the naive
+#'  complement-of-Kaplan-Meier for one cause (a dashed line), which censors the
+#'  competing events and therefore \emph{overestimates} the cumulative incidence --
+#'  the classic teaching contrast (Putter, Fiocco and Geskus, 2007). Supported for a
+#'  \code{\link[tidycmprsk]{cuminc}} object (which carries the data) on the faceted
+#'  layout; ignored with a message otherwise.
+#' @param cause the cause to overlay when \code{add.naive.km = TRUE}. Required when
+#'  the model has more than one cause.
+#' @return Returns an object of class \code{gg}. The cumulative-incidence data and,
+#'  where computed, Gray's test table and the naive-KM data are attached as
+#'  \code{attr(x, "cr.data")}, \code{attr(x, "grays.test")} and
+#'  \code{attr(x, "naive.km")}.
+#'
+#' @references Gray, R. J. (1988). A class of K-sample tests for comparing the
+#'  cumulative incidence of a competing risk. \emph{The Annals of Statistics},
+#'  16(3), 1141-1154. \doi{10.1214/aos/1176350951}.
+#'
+#'  Putter, H., Fiocco, M. and Geskus, R. B. (2007). Tutorial in biostatistics:
+#'  competing risks and multi-state models. \emph{Statistics in Medicine}, 26(11),
+#'  2389-2430. \doi{10.1002/sim.2712}.
 #'
 #' @author Przemyslaw Biecek, \email{przemyslaw.biecek@@gmail.com}
 #'
@@ -39,6 +69,14 @@
 #' ggcompetingrisks(fit2)
 #' fit3 <- survfit(Surv(time, status, type="mstate") ~ group, data=df)
 #' ggcompetingrisks(fit3)
+#'
+#' # tidycmprsk input: Gray's test p-value and the naive-KM teaching overlay
+#' if (require("tidycmprsk")) {
+#'   dd <- data.frame(time = ss, group = gg, status = cc)
+#'   tfit <- tidycmprsk::cuminc(Surv(time, status) ~ group, data = dd)
+#'   ggcompetingrisks(tfit, pval = TRUE)
+#'   ggcompetingrisks(tfit, add.naive.km = TRUE, cause = "death")
+#' }
 #' }
 #'
 #'   library(ggsci)
@@ -50,21 +88,67 @@
 ggcompetingrisks <- function(fit, gnames = NULL, gsep=" ",
                              multiple_panels = TRUE,
                              ggtheme = theme_survminer(),
-                             coef = 1.96, conf.int = FALSE, ...) {
-  stopifnot(any(class(fit) %in% c("cuminc", "survfitms")))
+                             coef = 1.96, conf.int = FALSE,
+                             pval = FALSE, add.naive.km = FALSE, cause = NULL, ...) {
+  stopifnot(inherits(fit, c("cuminc", "tidycuminc", "survfitms")))
 
-  if (any(class(fit) == "cuminc")) {
-   pl <- ggcompetingrisks.cuminc(fit = fit, gnames=gnames,
-                                  gsep=gsep, multiple_panels=multiple_panels,
-                                 coef = coef, conf.int = conf.int)
-  }
-  if (any(class(fit) == "survfitms")) {
+  gray <- NULL              # Gray's-test table, for the p-value subtitle + attr
+  if (inherits(fit, "tidycuminc")) {
+    pl   <- ggcompetingrisks.tidycuminc(fit, multiple_panels = multiple_panels,
+                                        conf.int = conf.int)
+    gray <- fit$cmprsk$Tests
+  } else if (inherits(fit, "cuminc")) {
+    pl   <- ggcompetingrisks.cuminc(fit = fit, gnames = gnames, gsep = gsep,
+                                    multiple_panels = multiple_panels,
+                                    coef = coef, conf.int = conf.int)
+    gray <- fit$Tests
+  } else {
     pl <- ggcompetingrisks.survfitms(fit = fit)
   }
 
   pl <- pl + ggtheme +
     ylab("Probability of an event") + xlab("Time") +
     ggtitle("Cumulative incidence functions")
+
+  cr.data <- pl$data
+
+  # Gray's-test p-value (subtitle). Gray's test is a between-group test on the
+  # cumulative incidence of each cause; it lives only on the cmprsk / tidycmprsk
+  # inputs. A single-group fit carries no test, and a survfitms/Aalen-Johansen
+  # object has none -- say so rather than fake it (Gray, 1988).
+  if (isTRUE(pval) || is.character(pval)) {
+    sub <- .cr_gray_subtitle(fit, pval)
+    if (is.null(sub))
+      message("ggcompetingrisks(): no Gray's test available for this input ",
+              "(it needs a multi-group cmprsk / tidycmprsk cuminc object); ",
+              "`pval` ignored.")
+    else pl <- pl + ggplot2::labs(subtitle = sub)
+  }
+
+  # Naive 1-KM overlay (teaching): the complement of a Kaplan-Meier that censors
+  # the competing events overestimates the cumulative incidence (Putter, Fiocco
+  # and Geskus, 2007). Needs the raw data, so it is supported for a
+  # tidycmprsk::cuminc (which carries `data`/`formula`), for a single chosen
+  # cause, on the faceted layout.
+  if (isTRUE(add.naive.km)) {
+    naive <- .cr_naive_km(fit, cause = cause, multiple_panels = multiple_panels)
+    if (!is.null(naive)) {
+      # the naive curve is dashed and in the same colour as its cause's CIF, so it
+      # sits visibly above the solid CIF. Keep `linetype` a fixed constant (not an
+      # aesthetic) so the colour legend is not joined by a mismatched key -- the
+      # caption states what the dashed line is.
+      pl <- pl +
+        ggplot2::geom_line(data = naive,
+                           ggplot2::aes(x = .data$time, y = .data$est,
+                                        colour = .data$event),
+                           linetype = "dashed") +
+        ggplot2::labs(caption = "dashed: naive 1-KM (overestimates the CIF)")
+      attr(pl, "naive.km") <- naive
+    }
+  }
+
+  attr(pl, "cr.data") <- cr.data
+  if (!is.null(gray)) attr(pl, "grays.test") <- gray
   ggpubr::ggpar(pl, ...)
 }
 
@@ -95,8 +179,11 @@ ggcompetingrisks.cuminc <- function(fit, gnames = NULL, gsep=" ",
     # Group the ribbon by event AND group. Mapping only fill=event makes the
     # ribbon's implicit grouping ignore `group`, so in a single panel the bands
     # jump between groups of the same event (#490). interaction(event, group) is
-    # a no-op for the faceted case (one group per panel).
-    pl <- pl + geom_ribbon(aes(ymin = est - coef*std, ymax = est + coef*std,
+    # a no-op for the faceted case (one group per panel). Clamp the band to
+    # [0, 1]: `est +- coef*std` is symmetric on the probability scale and can run
+    # below 0 or above 1, which is not a valid incidence probability.
+    pl <- pl + geom_ribbon(aes(ymin = pmax(0, est - coef*std),
+                               ymax = pmin(1, est + coef*std),
                                fill = event, group = interaction(event, group)),
                            alpha = 0.2, linetype = 0)
   }
@@ -146,6 +233,106 @@ ggcompetingrisks.survfitms <- function(fit) {
   ggplot(pstal, aes(times, value, fill=event)) +
     geom_area() + facet_wrap(~strata)
 
+}
+
+# CIF plot from a tidycmprsk::cuminc object. Reads the stored `$tidy` frame (the
+# cumulative incidence with proper, transformed pointwise confidence limits) so
+# no call into tidycmprsk is needed at run time. Same geometry as the cmprsk
+# path: colour = cause, facet by group (or linetype = group in a single panel).
+ggcompetingrisks.tidycuminc <- function(fit, multiple_panels = TRUE, conf.int = FALSE) {
+  td <- fit$tidy
+  if (is.null(td) || !all(c("time", "estimate", "outcome") %in% names(td)))
+    stop("This tidycmprsk object is not in the expected form; update survminer ",
+         "or tidycmprsk.", call. = FALSE)
+  # an ungrouped fit (Surv(...) ~ 1) has no `strata` column -> one "all" group,
+  # matching the cmprsk / survfitms single-group behaviour.
+  strata <- if ("strata" %in% names(td)) as.character(td$strata) else "all"
+  df <- data.frame(time = td$time, est = td$estimate,
+                   event = factor(td$outcome, levels = names(fit$failcode)),
+                   group = factor(strata, levels = unique(strata)),
+                   lo = td$conf.low, hi = td$conf.high)
+  df <- df[!is.na(df$est), , drop = FALSE]      # drop non-plottable rows quietly
+  # the pointwise CI is undefined at t = 0 (est = 0); set a zero-width band there
+  # so the ribbon does not drop rows with a warning.
+  df$lo[is.na(df$lo)] <- df$est[is.na(df$lo)]
+  df$hi[is.na(df$hi)] <- df$est[is.na(df$hi)]
+  time <- est <- event <- group <- NULL
+  if (multiple_panels)
+    pl <- ggplot(df, aes(time, est, color = event)) + facet_wrap(~group)
+  else
+    pl <- ggplot(df, aes(time, est, color = event, linetype = group))
+  if (conf.int)
+    pl <- pl + geom_ribbon(aes(ymin = .data$lo, ymax = .data$hi, fill = event,
+                               group = interaction(event, group)),
+                           alpha = 0.2, linetype = 0)
+  pl + geom_line()
+}
+
+# Gray's-test p-values as a one-line subtitle, or NULL when no test applies.
+# `pval` may be a custom string (used verbatim). cmprsk `$Tests` rows are named
+# by cause; tidycmprsk `$cmprsk$Tests` rows are cause codes, mapped back to the
+# cause labels via `$failcode`.
+.cr_gray_subtitle <- function(fit, pval) {
+  if (is.character(pval)) return(pval)
+  if (inherits(fit, "tidycuminc")) {
+    gray <- fit$cmprsk$Tests
+    if (is.null(gray) || nrow(gray) == 0) return(NULL)
+    labs <- names(fit$failcode)
+    if (length(labs) != nrow(gray)) labs <- rownames(gray)
+  } else if (inherits(fit, "cuminc")) {
+    gray <- fit$Tests
+    if (is.null(gray) || nrow(gray) == 0) return(NULL)
+    labs <- rownames(gray)
+  } else return(NULL)
+  pv <- format.pval(gray[, "pv"], digits = 2, eps = 1e-4)
+  paste0("Gray's test    ", paste0(labs, ": p = ", pv, collapse = "     "))
+}
+
+# Naive complement-of-KM (competing events censored) for one cause, per group, as
+# a long data frame (time, est, event, group) matching the CIF plot's factors so
+# the overlay lines take the cause's colour. tidycmprsk input only (it carries
+# the data + formula); returns NULL with a message otherwise.
+.cr_naive_km <- function(fit, cause, multiple_panels) {
+  if (!inherits(fit, "tidycuminc")) {
+    message("ggcompetingrisks(): `add.naive.km` needs a tidycmprsk::cuminc object ",
+            "(it carries the data); ignored.")
+    return(NULL)
+  }
+  if (!isTRUE(multiple_panels)) {
+    message("ggcompetingrisks(): `add.naive.km` is drawn only on the faceted ",
+            "layout (multiple_panels = TRUE); ignored.")
+    return(NULL)
+  }
+  causes <- names(fit$failcode)
+  if (is.null(cause)) {
+    if (length(causes) == 1L) cause <- causes
+    else stop("`add.naive.km = TRUE` overlays a single cause; set `cause` to one ",
+              "of: ", paste(causes, collapse = ", "), ".", call. = FALSE)
+  }
+  if (length(cause) != 1L || !cause %in% causes)
+    stop("`cause` must be one of the model's causes: ",
+         paste(causes, collapse = ", "), ".", call. = FALSE)
+
+  data <- fit$data
+  tvar <- all.vars(fit$formula[[2]])[1]
+  svar <- all.vars(fit$formula[[2]])[2]
+  gvars <- all.vars(fit$formula[[3]])
+  ev <- as.numeric(as.character(data[[svar]]) == cause)
+  if (length(gvars) == 0L) {
+    # ungrouped fit (Surv(...) ~ 1): a single "all" group, matching the plot
+    km <- survival::survfit(survival::Surv(data[[tvar]], ev) ~ 1)
+    glevels <- "all"
+    gid <- rep("all", length(km$time))
+  } else {
+    grp <- data[[gvars[1]]]
+    km <- survival::survfit(survival::Surv(data[[tvar]], ev) ~ grp)
+    glevels <- levels(factor(grp))
+    gid <- if (is.null(km$strata)) rep(as.character(grp)[1], length(km$time))
+           else rep(sub("^[^=]*=", "", names(km$strata)), km$strata)
+  }
+  data.frame(time = km$time, est = 1 - km$surv,
+             event = factor(cause, levels = names(fit$failcode)),
+             group = factor(gid, levels = glevels))
 }
 
 .rename_empty_colname <- function(df, newname = "."){

--- a/man/ggcompetingrisks.Rd
+++ b/man/ggcompetingrisks.Rd
@@ -12,11 +12,16 @@ ggcompetingrisks(
   ggtheme = theme_survminer(),
   coef = 1.96,
   conf.int = FALSE,
+  pval = FALSE,
+  add.naive.km = FALSE,
+  cause = NULL,
   ...
 )
 }
 \arguments{
-\item{fit}{an object of a class \code{cmprsk::cuminc} - created with \code{cmprsk::cuminc} function or \code{survfitms} created with \link[survival]{survfit} function.}
+\item{fit}{a cumulative-incidence object: a \code{cmprsk::cuminc}, a
+\code{\link[tidycmprsk]{cuminc}} (\pkg{tidycmprsk}), or a \code{survfitms} from
+\code{\link[survival]{survfit}}.}
 
 \item{gnames}{a vector with group names. If not supplied then will be extracted from \code{fit} object (\code{cuminc} only).}
 
@@ -31,14 +36,37 @@ Allowed values include ggplot2 official themes: see \code{\link[ggplot2]{theme}}
 
 \item{conf.int}{if \code{TRUE} then additional layer (\code{geom_ribbon}) is added around the point estimate. The ribon is plotted with boundries +- \code{coef}*standard deviation.}
 
+\item{pval}{logical or a character string. If \code{TRUE}, annotate Gray's test
+p-value for each cause (comparing the groups) as a subtitle; a character string
+is used verbatim as the subtitle. Gray's test is available only for a
+\code{cmprsk} / \code{tidycmprsk} \code{cuminc} object with more than one group;
+for other inputs \code{pval} is ignored with a message (Gray, 1988).}
+
+\item{add.naive.km}{logical. If \code{TRUE}, overlay the naive
+complement-of-Kaplan-Meier for one cause (a dashed line), which censors the
+competing events and therefore \emph{overestimates} the cumulative incidence --
+the classic teaching contrast (Putter, Fiocco and Geskus, 2007). Supported for a
+\code{\link[tidycmprsk]{cuminc}} object (which carries the data) on the faceted
+layout; ignored with a message otherwise.}
+
+\item{cause}{the cause to overlay when \code{add.naive.km = TRUE}. Required when
+the model has more than one cause.}
+
 \item{...}{further arguments passed to the function \code{\link[ggpubr]{ggpar}} for customizing the plot.}
 }
 \value{
-Returns an object of class \code{gg}.
+Returns an object of class \code{gg}. The cumulative-incidence data and,
+ where computed, Gray's test table and the naive-KM data are attached as
+ \code{attr(x, "cr.data")}, \code{attr(x, "grays.test")} and
+ \code{attr(x, "naive.km")}.
 }
 \description{
 This function plots Cumulative Incidence Curves. For \code{cuminc} objects it's a \code{ggplot2} version of \code{plot.cuminc}.
 For \code{survfitms} objects a different geometry is used, as suggested by \code{@teigentler}.
+It also accepts a \code{\link[tidycmprsk]{cuminc}} object from the \pkg{tidycmprsk}
+package (which carries proper pointwise confidence limits and the data), can
+annotate Gray's test, and can overlay the naive complement-of-Kaplan-Meier for
+teaching.
 }
 \examples{
 \dontrun{
@@ -64,12 +92,29 @@ fit2 <- survfit(Surv(time, status, type="mstate") ~ 1, data=df)
 ggcompetingrisks(fit2)
 fit3 <- survfit(Surv(time, status, type="mstate") ~ group, data=df)
 ggcompetingrisks(fit3)
+
+# tidycmprsk input: Gray's test p-value and the naive-KM teaching overlay
+if (require("tidycmprsk")) {
+  dd <- data.frame(time = ss, group = gg, status = cc)
+  tfit <- tidycmprsk::cuminc(Surv(time, status) ~ group, data = dd)
+  ggcompetingrisks(tfit, pval = TRUE)
+  ggcompetingrisks(tfit, add.naive.km = TRUE, cause = "death")
+}
 }
 
   library(ggsci)
   library(cowplot)
   ggcompetingrisks(fit3) + theme_cowplot() + scale_fill_jco()
 }
+}
+\references{
+Gray, R. J. (1988). A class of K-sample tests for comparing the
+ cumulative incidence of a competing risk. \emph{The Annals of Statistics},
+ 16(3), 1141-1154. \doi{10.1214/aos/1176350951}.
+
+ Putter, H., Fiocco, M. and Geskus, R. B. (2007). Tutorial in biostatistics:
+ competing risks and multi-state models. \emph{Statistics in Medicine}, 26(11),
+ 2389-2430. \doi{10.1002/sim.2712}.
 }
 \author{
 Przemyslaw Biecek, \email{przemyslaw.biecek@gmail.com}

--- a/tests/testthat/test-ggcompetingrisks-cr.R
+++ b/tests/testthat/test-ggcompetingrisks-cr.R
@@ -1,0 +1,122 @@
+# Modernized ggcompetingrisks(): tidycmprsk input, Gray's test, naive-KM overlay.
+
+library(survival)
+
+.cr_data <- function() {
+  set.seed(2)
+  n <- 250
+  data.frame(time = rexp(n),
+             grp = factor(sample(c("A", "B"), n, replace = TRUE)),
+             status = factor(sample(0:2, n, replace = TRUE), 0:2,
+                             c("censor", "death", "relapse")))
+}
+
+test_that("a tidycmprsk::cuminc object is accepted and plotted", {
+  skip_if_not_installed("tidycmprsk")
+  d <- .cr_data()
+  tc <- tidycmprsk::cuminc(Surv(time, status) ~ grp, data = d)
+  p <- ggcompetingrisks(tc)
+  expect_s3_class(p, "ggplot")
+  # the CIF data covers both causes and both groups
+  cr <- attr(p, "cr.data")
+  expect_setequal(as.character(unique(cr$event)), c("death", "relapse"))
+  expect_setequal(as.character(unique(cr$group)), c("A", "B"))
+})
+
+test_that("an ungrouped (~1) tidycmprsk::cuminc renders as one group", {
+  skip_if_not_installed("tidycmprsk")
+  d <- .cr_data()
+  tc1 <- tidycmprsk::cuminc(Surv(time, status) ~ 1, data = d)
+  expect_silent(p <- ggcompetingrisks(tc1))
+  expect_s3_class(p, "ggplot")
+  expect_setequal(as.character(unique(attr(p, "cr.data")$group)), "all")
+  # pval has no between-group test to show, so it is skipped with a message
+  expect_message(ggcompetingrisks(tc1, pval = TRUE), "no Gray's test")
+  # the naive overlay works on the single cohort (the natural teaching case)
+  expect_silent(p2 <- ggcompetingrisks(tc1, add.naive.km = TRUE, cause = "death"))
+  expect_setequal(as.character(unique(attr(p2, "naive.km")$group)), "all")
+})
+
+test_that("pval annotates Gray's test with the correct per-cause p-values", {
+  skip_if_not_installed("tidycmprsk")
+  d <- .cr_data()
+  tc <- tidycmprsk::cuminc(Surv(time, status) ~ grp, data = d)
+  p <- ggcompetingrisks(tc, pval = TRUE)
+  expect_match(p$labels$subtitle, "Gray's test")
+  expect_match(p$labels$subtitle, "death")
+  expect_match(p$labels$subtitle, "relapse")
+  # the numbers equal cmprsk's Gray test
+  gt <- attr(p, "grays.test")
+  expect_equal(unname(gt[, "pv"]), unname(tc$cmprsk$Tests[, "pv"]))
+  # a custom string is used verbatim
+  p2 <- ggcompetingrisks(tc, pval = "Gray p = 0.04")
+  expect_equal(p2$labels$subtitle, "Gray p = 0.04")
+})
+
+test_that("Gray's test is skipped (message) for survfitms and single-group inputs", {
+  d <- .cr_data()
+  f2 <- survfit(Surv(time, status, type = "mstate") ~ grp, data = d)
+  expect_message(p <- ggcompetingrisks(f2, pval = TRUE), "no Gray's test")
+  expect_null(p$labels$subtitle)
+})
+
+test_that("add.naive.km overlays a naive 1-KM that overestimates the CIF", {
+  skip_if_not_installed("tidycmprsk")
+  d <- .cr_data()
+  tc <- tidycmprsk::cuminc(Surv(time, status) ~ grp, data = d)
+  p <- ggcompetingrisks(tc, add.naive.km = TRUE, cause = "death")
+  naive <- attr(p, "naive.km")
+  expect_true(!is.null(naive))
+  expect_setequal(as.character(unique(naive$event)), "death")
+  # the naive curve is >= the CIF for the same cause/group at matched times
+  cr <- attr(p, "cr.data")
+  for (g in levels(naive$group)) {
+    cif_g <- cr[cr$event == "death" & cr$group == g, ]
+    nv_g  <- naive[naive$group == g, ]
+    # step-interpolate the CIF to the naive times and compare
+    cif_at <- stats::approx(cif_g$time, cif_g$est, xout = nv_g$time,
+                            method = "constant", rule = 2)$y
+    expect_true(all(nv_g$est >= cif_at - 1e-8))
+  }
+})
+
+test_that("add.naive.km requires a cause when there are several", {
+  skip_if_not_installed("tidycmprsk")
+  d <- .cr_data()
+  tc <- tidycmprsk::cuminc(Surv(time, status) ~ grp, data = d)
+  expect_error(ggcompetingrisks(tc, add.naive.km = TRUE), "single cause")
+  expect_error(ggcompetingrisks(tc, add.naive.km = TRUE, cause = "nope"),
+               "must be one of")
+})
+
+test_that("add.naive.km is ignored (message) for a plain cmprsk::cuminc", {
+  skip_if_not_installed("cmprsk")
+  d <- .cr_data()
+  cc <- cmprsk::cuminc(d$time, d$status, d$grp)
+  expect_message(ggcompetingrisks(cc, add.naive.km = TRUE, cause = "death"),
+                 "needs a tidycmprsk")
+})
+
+test_that("the conf.int ribbon stays within [0, 1]", {
+  skip_if_not_installed("cmprsk")
+  d <- .cr_data()
+  cc <- cmprsk::cuminc(d$time, d$status, d$grp)
+  p <- ggcompetingrisks(cc, conf.int = TRUE)
+  b <- ggplot2::ggplot_build(p)
+  rib <- b$data[[which(vapply(b$data, function(x) "ymin" %in% names(x),
+                              logical(1)))[1]]]
+  expect_gte(min(rib$ymin, na.rm = TRUE), 0)
+  expect_lte(max(rib$ymax, na.rm = TRUE), 1)
+})
+
+test_that("default cuminc / survfitms output is unchanged (no new layers)", {
+  skip_if_not_installed("cmprsk")
+  d <- .cr_data()
+  cc <- cmprsk::cuminc(d$time, d$status, d$grp)
+  p <- ggcompetingrisks(cc)
+  # exactly one line layer, no ribbon, no subtitle/caption by default
+  geoms <- vapply(p$layers, function(l) class(l$geom)[1], character(1))
+  expect_true("GeomLine" %in% geoms)
+  expect_false("GeomRibbon" %in% geoms)
+  expect_null(p$labels$subtitle)
+})


### PR DESCRIPTION
`ggcompetingrisks()` gains competing-risks features, all opt-in so the default
output for existing `cuminc` / `survfitms` inputs is unchanged.

```r
library(survival)
library(tidycmprsk)
tfit <- cuminc(Surv(ttdeath, death_cr) ~ trt, data = trial)

# Gray's test p per cause + the naive-1KM teaching overlay for one cause
ggcompetingrisks(tfit, pval = TRUE, add.naive.km = TRUE, cause = "death from cancer")
```

![competing-risks plot with Gray's test and naive-KM overlay](https://i.imgur.com/SiunbX0.png)

- **Accepts a `tidycmprsk::cuminc` object** — its stored cumulative incidence (with
  proper transformed pointwise confidence limits) and data are used directly.
- **`pval = TRUE`** annotates Gray's test p-value for each cause (the between-group
  comparison) as a subtitle, mapping each p to its cause. For `cmprsk` / `tidycmprsk`
  objects with more than one group; other inputs are skipped with a message. A
  character `pval` is used verbatim.
- **`add.naive.km = TRUE`** overlays, for one `cause`, the naive
  complement-of-Kaplan-Meier that censors the competing events and therefore
  overestimates the cumulative incidence — the classic teaching contrast. Drawn as a
  dashed line in the cause's colour, so it sits visibly above the proper CIF.
  Supported for a `tidycmprsk::cuminc` (which carries the data), for one cause, on
  the faceted layout (including an ungrouped cohort).
- The `conf.int` band is kept within `[0, 1]` (`est ± coef·std` is symmetric on the
  probability scale and could otherwise run out of range).
- The computed cumulative-incidence, Gray's-test and naive-KM data are attached as
  `attr(x, "cr.data")`, `attr(x, "grays.test")` and `attr(x, "naive.km")`.

References: Gray (1988) for the test; Putter, Fiocco & Geskus (2007) for the naive-KM
teaching contrast. The at-risk risk table remains a separate track.
