### PR TITLE
Lock risk/censor tables to the curve x-axis with a guarded shared helper

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -163,6 +163,8 @@
 
 ## Minor changes
 
+- The number-at-risk, cumulative-events and censor tables are now locked to the survival curve's x-axis by an explicit, guarded column-width equalization shared with the faceted path, replacing the previous panel-index heuristic. Rendered output is unchanged; the alignment is now robust to `ggplot2` layout changes rather than relying on an incidental gtable layout.
+
 - `ggsurvplot()` now emits an informative message when `risk.table.y.text = TRUE` is explicitly set together with `risk.table.pos = "in"`, instead of silently ignoring it. An in-plot risk table is drawn over the survival panel's own y-axis, so its rows are coloured by strata (matching the curves) rather than labelled; the message explains this and points to `risk.table.pos = "out"` for text strata labels. It fires only when both arguments are explicitly passed, so default in-plot tables (which carry `risk.table.y.text = TRUE` by default) are unaffected. Reported by @Swechhya (#211).
 
 - `surv_median()` no longer errors on a `survfit` stored without confidence limits (`conf.type = "none"`) or fitted at a non-default confidence level (e.g. `conf.int = 0.9`). It hard-coded the `0.95LCL`/`0.95UCL` columns of `summary()$table`; these are now detected by suffix, so a `0.9` fit returns its real limits and a no-CI fit returns the median with `NA` limits instead of failing. Default (0.95) output is unchanged. Found alongside #639 (#818).

--- a/R/ggsurvplot_core.R
+++ b/R/ggsurvplot_core.R
@@ -431,36 +431,12 @@ build_ggsurvplot <- function(x, surv.plot.height = NULL,
 
   heights <- unlist(heights)[names(x)] # get the height of each component in x
   plots <- x
-  grobs <- widths <- list()
-  for (i in 1:length(plots)) {
-    if(ggplot2::is_ggplot(plots[[i]])){
-      grobs[[i]] <- ggplotGrob(plots[[i]])
-      # Find panel columns dynamically instead of hardcoding [2:5]
-      panel_cols <- which(grepl("panel", grobs[[i]]$layout$name))
-      if(length(panel_cols) == 0) {
-        # Fallback to traditional approach if no panel found
-        panel_range <- 2:min(5, ncol(grobs[[i]]))
-      } else {
-        # Use actual panel column range
-        panel_range <- min(panel_cols):max(panel_cols)
-      }
-      widths[[i]] <- grobs[[i]]$widths[panel_range]
-    }
-  }
-  maxwidth <- do.call(grid::unit.pmax, widths)
-  for (i in 1:length(grobs)) {
-    if(!is.null(grobs[[i]])){
-      # Apply same panel range logic for setting widths
-      panel_cols <- which(grepl("panel", grobs[[i]]$layout$name))
-      if(length(panel_cols) == 0) {
-        panel_range <- 2:min(5, ncol(grobs[[i]]))
-      } else {
-        panel_range <- min(panel_cols):max(panel_cols)
-      }
-      grobs[[i]]$widths[panel_range] <- as.list(maxwidth)
-    }
-  }
-
+  # Convert each panel (curve + risk/censor tables) to a grob, then lock them to a
+  # common left column layout so their x-axes align exactly. .align_panel_widths()
+  # equalizes the full width vector (guarded to the common column count) -- robust
+  # to ggplot2 layout changes and shared with the facet path.
+  grobs <- lapply(plots, function(p) if(ggplot2::is_ggplot(p)) ggplotGrob(p) else NULL)
+  grobs <- .align_panel_widths(grobs)
 
   ggsurv <- gridExtra::arrangeGrob(grobs = grobs, nrow = nplot, heights = unlist(heights))
 

--- a/R/ggsurvplot_facet.R
+++ b/R/ggsurvplot_facet.R
@@ -559,13 +559,16 @@ ggsurvplot_facet <- function(fit, data, facet.by,
                    panel.labs.font.x = panel.labs.font.x,
                    panel.labs.font.y = panel.labs.font.y,
                    labeller = labeller)
-      # Stack the aligned plot and table grobs, honouring the height ratio.
-      p.grob <- ggplot2::ggplotGrob(p)
-      t.grob <- ggplot2::ggplotGrob(tp)
+      # Stack the aligned plot and table grobs, honouring the height ratio. Lock
+      # both to a common left column layout first (shared with the classic path) so
+      # their x-axes align, then row-bind.
+      aligned <- .align_panel_widths(list(ggplot2::ggplotGrob(p),
+                                          ggplot2::ggplotGrob(tp)))
+      p.grob <- aligned[[1]]
+      t.grob <- aligned[[2]]
       ncol.min <- min(ncol(p.grob), ncol(t.grob))
       g <- gridExtra::gtable_rbind(p.grob[, seq_len(ncol.min)],
                                    t.grob[, seq_len(ncol.min)], size = "max")
-      g$widths <- grid::unit.pmax(p.grob$widths, t.grob$widths)
       # Set the plot vs table panel-row heights to surv.plot.height : risk.table.height.
       # After gtable_rbind the plot's panel rows keep their positions and the table's
       # rows are offset by nrow(p.grob); read each grob's own panel rows rather than

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -39,6 +39,21 @@ is_pkg_version_sup<- function(pkg, version){
   nplot
 }
 
+# Lock stacked panels (survival curve + risk/censor tables) to a common left
+# layout so they share an identical x-axis. Equalizes the full width vector across
+# every grob, guarded to their common column count (`ncmin`) so it can never
+# recycle mismatched-length units. This is intentional and robust to ggplot2
+# layout changes, unlike keying on panel-row indices. The same primitive backs the
+# classic assembly (.build_ggsurvplot) and the facet stack (ggsurvplot_facet).
+.align_panel_widths <- function(grobs){
+  grobs <- grobs[!vapply(grobs, is.null, logical(1))]
+  if(length(grobs) < 2) return(grobs)
+  ncmin <- min(vapply(grobs, function(g) length(g$widths), integer(1)))
+  maxwidth <- do.call(grid::unit.pmax, lapply(grobs, function(g) g$widths[seq_len(ncmin)]))
+  for(i in seq_along(grobs)) grobs[[i]]$widths[seq_len(ncmin)] <- as.list(maxwidth)
+  grobs
+}
+
 # Extract legend from a ggplot
 .get_legend <- function(myggplot){
   tmp <- ggplot_gtable(ggplot_build(myggplot))

--- a/tests/testthat/test-risktable-panel-align.R
+++ b/tests/testthat/test-risktable-panel-align.R
@@ -1,0 +1,61 @@
+# Risk-table / curve x-axis alignment: the survival panel and the table panel must
+# share an identical left column layout so their x-axes line up. Guards against a
+# future ggplot2 layout change silently reintroducing the misalignment class
+# (#102/#302/#348/#649/#676).
+
+skip_if_not_installed("survival")
+
+# left width (mm) before the first panel column of a gtable
+.left_mm <- function(gr) {
+  pc <- min(gr$layout$l[grepl("panel", gr$layout$name)])
+  if (pc <= 1) return(0)
+  sum(as.numeric(grid::convertWidth(gr$widths[seq_len(pc - 1)], "mm")))
+}
+
+test_that(".align_panel_widths equalizes the common left columns and is guarded", {
+  library(survival)
+  grDevices::pdf(NULL)                 # deterministic device for convertWidth
+  on.exit(grDevices::dev.off())
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  p <- ggsurvplot(fit, data = lung, risk.table = TRUE,
+                  legend.labs = c("A very long stratum label one",
+                                  "A very long stratum label two"))
+  cg <- ggplot2::ggplotGrob(p$plot)
+  tg <- ggplot2::ggplotGrob(p$table)
+  aligned <- survminer:::.align_panel_widths(list(cg, tg))
+  ncmin <- min(length(cg$widths), length(tg$widths))
+  w1 <- as.numeric(grid::convertWidth(aligned[[1]]$widths[seq_len(ncmin)], "mm"))
+  w2 <- as.numeric(grid::convertWidth(aligned[[2]]$widths[seq_len(ncmin)], "mm"))
+  expect_equal(w1, w2, tolerance = 1e-6)
+
+  # guards: NULL entries dropped; fewer than two grobs returned unchanged
+  expect_length(survminer:::.align_panel_widths(list(cg, NULL)), 1L)
+  expect_length(survminer:::.align_panel_widths(list()), 0L)
+})
+
+test_that("built curve and risk table share the same panel left offset", {
+  library(survival)
+  fit <- survfit(Surv(time, status) ~ sex, data = lung)
+  grDevices::pdf(NULL)            # a device for convertWidth
+  on.exit(grDevices::dev.off())
+
+  cases <- list(
+    default   = list(risk.table = TRUE),
+    longlabel = list(risk.table = TRUE,
+                     legend.labs = c("Male treatment arm (control)",
+                                     "Female treatment arm (experimental)"),
+                     xlim = c(0, 800)),
+    xscale    = list(risk.table = TRUE, xscale = 30.44, break.time.by = 182.5),
+    threetab  = list(risk.table = TRUE, cumevents = TRUE, cumcensor = TRUE)
+  )
+  for (nm in names(cases)) {
+    p <- do.call(ggsurvplot, c(list(fit, data = lung), cases[[nm]]))
+    built <- survminer:::.build_ggsurvplot(p)
+    kids <- built$grobs[vapply(built$grobs,
+                               function(g) inherits(g, "gtable") &&
+                                 any(grepl("panel", g$layout$name)), logical(1))]
+    lefts <- vapply(kids, .left_mm, numeric(1))
+    expect_gt(length(lefts), 1L)                       # curve + at least one table
+    expect_lt(max(lefts) - min(lefts), 0.01)           # panels share the left edge
+  }
+})


### PR DESCRIPTION
## What

`.build_ggsurvplot()` aligned the survival curve and the number-at-risk / cumulative-events / censor tables by detecting gtable panel-**row** indices and using them as width-**column** indices. That only lined the panels up by an incidental `ggplot2` layout coincidence (the panel row index happening to equal the left y-axis-text column index).

This replaces it with a small helper, `.align_panel_widths()`, that equalizes the full left column layout across every stacked panel, truncated to the panels' common column count so it can never recycle mismatched-length units. `ggsurvplot_facet()` now shares the same helper (and drops a redundant `unit.pmax()` line that could silently recycle when the curve and table grobs had different column counts).

## Effect

Rendered output is unchanged. The number-at-risk / cumulative-events / censor tables stay locked to the curve's x-axis, and that alignment no longer depends on an incidental gtable layout, so it holds if a future `ggplot2` changes the panel column arrangement. Adds regression tests asserting the curve and table panels share the same left offset (long strata labels, `xscale`, `break.time.by`, three stacked tables).

Verified byte-identical across the table configurations (default, long labels, `xscale`, `break.time.by`, `ncensor.plot`, three tables, side legends, single group, `tables.y.text = FALSE`, `risk.table.pos = "in"`, percentage) and the `ggsurvplot_combine()` / `ggsurvplot_df()` / `ggadjustedcurves()` / `gglandmark()` / `ggmilestone()` / `arrange_ggsurvplots()` paths.

Refs #102, #302, #348, #649, #676 (the historical misalignment reports this hardens against a recurrence of).
