### PR TITLE
Add detailed = TRUE to pairwise_survdiff() for per-pair statistics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## New features
 
+- `pairwise_survdiff()` gains `detailed = TRUE`, attaching a per-pair table (`res$detailed`) with the test statistic (chi-square) and its degrees of freedom, the raw and adjusted p-values, and a Cox proportional-hazards hazard ratio with 95% confidence interval for each pair. The default (`detailed = FALSE`) returns the usual p-value matrix only.
+
 - `ggcompetingrisks()` gains `risk.table = TRUE`, drawing a per-group number-at-risk table beneath the cumulative-incidence curves, locked to the same time axis. It is available for a `tidycmprsk::cuminc` object on the overlaid single-panel layout; the at-risk count is the number still event-free and under observation (competing events count as leaving the risk set), matching the Kaplan-Meier at-risk convention of `ggsurvplot()`. `risk.table` also accepts the `ggsurvplot()` content strings (`"percentage"`, `"nrisk_cumcensor"`, ...), and `break.time.by` controls the shared axis breaks. With `risk.table = TRUE` the function returns a compound object that prints the curves above the aligned table and works with `ggsave()` (#838).
 
 - New `gglandmark()` draws a landmark analysis: the Kaplan-Meier curves are

--- a/R/pairwise_survdiff.R
+++ b/R/pairwise_survdiff.R
@@ -29,9 +29,19 @@ NULL
 #'  and the p-values are adjusted over just those comparisons -- useful for a
 #'  many-treatments-vs-one-control design, which needs a smaller multiple-testing
 #'  correction. The default \code{NULL} performs all pairwise comparisons.
+#'@param detailed logical. If \code{TRUE}, attach a per-pair table
+#'  \code{res$detailed} with the test statistic (chi-square) and its degrees of
+#'  freedom, the raw and adjusted p-values, and a Cox proportional-hazards hazard
+#'  ratio with 95\% confidence interval for each pair (the hazard of
+#'  \code{group2} relative to \code{group1}). The default \code{FALSE} returns the
+#'  usual p-value matrix only. The hazard ratio and its interval can be unstable or
+#'  infinite for a pair with (near-)complete separation; such a pair returns
+#'  \code{NA} if the Cox model does not fit.
 #'@seealso survival::survdiff
 #'@return Returns an object of class "pairwise.htest", which is a list
-#'  containing the p values.
+#'  containing the p values. With \code{detailed = TRUE} it also carries a
+#'  \code{detailed} data frame of per-pair statistics, degrees of freedom,
+#'  p-values and Cox hazard ratios.
 #'
 #'@author Alboukadel Kassambara, \email{alboukadel.kassambara@@gmail.com}
 #'
@@ -55,7 +65,7 @@ NULL
 #'@rdname pairwise_survdiff
 #'@export
 pairwise_survdiff <- function(formula, data, p.adjust.method = "BH", na.action, rho = 0,
-                              method = "survdiff", ref.group = NULL)
+                              method = "survdiff", ref.group = NULL, detailed = FALSE)
 
 {
   if(missing(na.action)) na.action <- options()$na.action
@@ -164,8 +174,58 @@ pairwise_survdiff <- function(formula, data, p.adjust.method = "BH", na.action, 
 
   res <- list(method = METHOD, data.name = DNAME, p.value = PVAL,
               p.adjust.method = p.adjust.method)
+
+  # Per-pair statistics (opt-in). The chi-square and df are already computed in
+  # compare.levels() but discarded there; detailed = TRUE surfaces them together
+  # with the raw and adjusted p-values and a Cox hazard ratio for each pair.
+  if (isTRUE(detailed) && nlevels(group) >= 2L) {
+    pairs <- if (is.null(ref.group))
+      utils::combn(levels(group), 2L, simplify = FALSE)
+    else lapply(others, function(g) c(ref.group, g))
+    res$detailed <- do.call(rbind, lapply(pairs, function(pr)
+      .pairwise_detail(pr, group, data, formula, rhs, method, rho, na.action, PVAL)))
+    rownames(res$detailed) <- NULL
+  }
+
   class(res) <- "pairwise.htest"
   res
+}
+
+# Per-pair statistic, df, raw + adjusted p-value and Cox HR (group2 vs group1).
+.pairwise_detail <- function(pr, group, data, formula, rhs, method, rho, na.action, PVAL){
+  a <- pr[1]; b <- pr[2]
+  sub_data <- data[group %in% c(a, b), , drop = FALSE]
+  if (method == "survdiff") {
+    sdif <- survival::survdiff(formula, data = sub_data, rho = rho, na.action = na.action)
+    statistic <- unname(sdif$chisq); df <- length(sdif$n) - 1L
+    p.raw <- stats::pchisq(statistic, df, lower.tail = FALSE)
+  } else {
+    wt <- .weighted_logrank_test(formula, data = sub_data, method = method)
+    statistic <- unname(wt$statistic); df <- wt$df; p.raw <- wt$pvalue
+  }
+  # Cox HR of b relative to a (a = reference); NA if the model cannot be fit
+  hr <- lo <- hi <- NA_real_
+  sub_data[[rhs]] <- factor(as.character(sub_data[[rhs]]), levels = c(a, b))
+  cox <- tryCatch(survival::coxph(formula, data = sub_data), error = function(e) NULL)
+  if (!is.null(cox)) {
+    ci <- summary(cox)$conf.int
+    ridx <- which(startsWith(rownames(ci), rhs))
+    if (length(ridx)) {
+      hr <- ci[ridx[1], "exp(coef)"]
+      lo <- ci[ridx[1], "lower .95"]; hi <- ci[ridx[1], "upper .95"]
+    }
+  }
+  data.frame(group1 = a, group2 = b, statistic = statistic, df = as.integer(df),
+             p.value = p.raw, p.adj = .pval_lookup(PVAL, a, b),
+             hr = hr, hr.lower = lo, hr.upper = hi, stringsAsFactors = FALSE)
+}
+
+# Adjusted p-value for a pair from the pairwise.table matrix (either dimname order).
+.pval_lookup <- function(PVAL, a, b){
+  rn <- rownames(PVAL); cn <- colnames(PVAL)
+  if (b %in% rn && a %in% cn && !is.na(PVAL[b, a])) return(PVAL[b, a])
+  if (a %in% rn && b %in% cn && !is.na(PVAL[a, b])) return(PVAL[a, b])
+  NA_real_
 }
 
 

--- a/man/pairwise_survdiff.Rd
+++ b/man/pairwise_survdiff.Rd
@@ -11,7 +11,8 @@ pairwise_survdiff(
   na.action,
   rho = 0,
   method = "survdiff",
-  ref.group = NULL
+  ref.group = NULL,
+  detailed = FALSE
 )
 }
 \arguments{
@@ -47,10 +48,21 @@ compared against this one group only (rather than all pairwise comparisons),
 and the p-values are adjusted over just those comparisons -- useful for a
 many-treatments-vs-one-control design, which needs a smaller multiple-testing
 correction. The default \code{NULL} performs all pairwise comparisons.}
+
+\item{detailed}{logical. If \code{TRUE}, attach a per-pair table
+\code{res$detailed} with the test statistic (chi-square) and its degrees of
+freedom, the raw and adjusted p-values, and a Cox proportional-hazards hazard
+ratio with 95\% confidence interval for each pair (the hazard of
+\code{group2} relative to \code{group1}). The default \code{FALSE} returns the
+usual p-value matrix only. The hazard ratio and its interval can be unstable or
+infinite for a pair with (near-)complete separation; such a pair returns
+\code{NA} if the Cox model does not fit.}
 }
 \value{
 Returns an object of class "pairwise.htest", which is a list
- containing the p values.
+ containing the p values. With \code{detailed = TRUE} it also carries a
+ \code{detailed} data frame of per-pair statistics, degrees of freedom,
+ p-values and Cox hazard ratios.
 }
 \description{
 Calculate pairwise comparisons between group levels with

--- a/tests/testthat/test-pairwise_survdiff.R
+++ b/tests/testthat/test-pairwise_survdiff.R
@@ -192,3 +192,61 @@ test_that("an invalid ref.group errors clearly (#364)", {
                       ref.group = c("MAF", "MMSET")),
     "single grouping level")
 })
+
+# detailed = TRUE: per-pair statistics
+
+test_that("detailed = FALSE is unchanged (no detailed element)", {
+  library(survival); data(myeloma)
+  a <- pairwise_survdiff(Surv(time, event) ~ molecular_group, data = myeloma)
+  b <- pairwise_survdiff(Surv(time, event) ~ molecular_group, data = myeloma,
+                         detailed = FALSE)
+  expect_null(a$detailed)
+  expect_equal(a, b)
+})
+
+test_that("detailed = TRUE returns per-pair statistic, df, p and Cox HR", {
+  library(survival); data(myeloma)
+  r <- pairwise_survdiff(Surv(time, event) ~ molecular_group, data = myeloma,
+                         detailed = TRUE)
+  d <- r$detailed
+  expect_s3_class(d, "data.frame")
+  expect_setequal(names(d), c("group1", "group2", "statistic", "df",
+                              "p.value", "p.adj", "hr", "hr.lower", "hr.upper"))
+  # one row per pair (k*(k-1)/2)
+  k <- nlevels(factor(myeloma$molecular_group))
+  expect_equal(nrow(d), k * (k - 1) / 2)
+  # statistic equals a direct survdiff chi-square; HR equals a direct coxph
+  pr <- d[1, ]
+  sub <- myeloma[myeloma$molecular_group %in% c(pr$group1, pr$group2), ]
+  sd <- survival::survdiff(Surv(time, event) ~ molecular_group, data = sub)
+  expect_equal(pr$statistic, unname(sd$chisq))
+  expect_equal(pr$df, length(sd$n) - 1)
+  cx <- survival::coxph(
+    Surv(time, event) ~ factor(molecular_group, levels = c(pr$group1, pr$group2)),
+    data = sub)
+  expect_equal(pr$hr, unname(summary(cx)$conf.int[1, "exp(coef)"]), tolerance = 1e-6)
+  # adjusted p matches the p-value matrix
+  expect_equal(pr$p.adj, r$p.value[pr$group2, pr$group1], tolerance = 1e-8)
+})
+
+test_that("detailed = TRUE honours ref.group and weighted methods", {
+  library(survival); data(myeloma)
+  r <- pairwise_survdiff(Surv(time, event) ~ molecular_group, data = myeloma,
+                         ref.group = "Cyclin D-1", detailed = TRUE)
+  expect_true(all(r$detailed$group1 == "Cyclin D-1"))
+  expect_equal(nrow(r$detailed), nlevels(factor(myeloma$molecular_group)) - 1)
+  rw <- pairwise_survdiff(Surv(time, event) ~ molecular_group, data = myeloma,
+                          method = "FH_p=1_q=1", detailed = TRUE)
+  expect_true(all(rw$detailed$df == 1))
+  expect_true(all(is.finite(rw$detailed$statistic)))
+})
+
+test_that("detailed = TRUE does not crash on a single-level grouping variable", {
+  library(survival); data(myeloma)
+  d <- myeloma[myeloma$molecular_group == myeloma$molecular_group[1], ]
+  expect_error(
+    r <- suppressWarnings(pairwise_survdiff(Surv(time, event) ~ molecular_group,
+                                            data = d, detailed = TRUE)),
+    NA)
+  expect_null(r$detailed)     # nothing to compare -> no detailed table
+})


### PR DESCRIPTION
`pairwise_survdiff()` computes the pairwise chi-square and its degrees of freedom internally but returns only the p-value matrix. `detailed = TRUE` surfaces the rest.

```r
library(survival); data(myeloma)
res <- pairwise_survdiff(Surv(time, event) ~ molecular_group, data = myeloma,
                         detailed = TRUE)
res$detailed
#>       group1        group2 statistic df p.value p.adj    hr hr.lower hr.upper
#> 1 Cyclin D-1    Cyclin D-2     0.241  1   0.623 0.785 0.740    0.232    2.36
#> ...
```

`res$detailed` is a per-pair data frame with the test statistic (chi-square), its degrees of freedom, the raw and adjusted p-values, and a Cox hazard ratio with 95% confidence interval (the hazard of `group2` relative to `group1`). It honours `ref.group` and the weighted log-rank `method`s; a pair with (near-)complete separation returns `NA` for the hazard ratio.

The default `detailed = FALSE` returns the usual `pairwise.htest` p-value matrix, unchanged.

A small, opt-in completeness addition.
