### PR TITLE
Un-deprecate the formula argument of ggcoxfunctional()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -167,6 +167,8 @@
 
 ## Minor changes
 
+- `ggcoxfunctional()` no longer deprecates the `formula` argument. Passing a formula plus `data` is equivalent to passing a fitted `coxph` model (the functional-form diagnostic uses only the model formula), so both forms are now supported without a warning.
+
 - The number-at-risk, cumulative-events and censor tables are now locked to the survival curve's x-axis by an explicit, guarded column-width equalization shared with the faceted path, replacing the previous panel-index heuristic. Rendered output is unchanged; the alignment is now robust to `ggplot2` layout changes rather than relying on an incidental gtable layout.
 
 - `ggsurvplot()` now emits an informative message when `risk.table.y.text = TRUE` is explicitly set together with `risk.table.pos = "in"`, instead of silently ignoring it. An in-plot risk table is drawn over the survival panel's own y-axis, so its rows are coloured by strata (matching the curves) rather than labelled; the message explains this and points to `risk.table.pos = "out"` for text strata labels. It fires only when both arguments are explicitly passed, so default in-plot tables (which carry `risk.table.y.text = TRUE` by default) are unaffected. Reported by @Swechhya (#211).

--- a/R/ggcoxfunctional.R
+++ b/R/ggcoxfunctional.R
@@ -10,8 +10,13 @@ NULL
 #'cox proportional hazards model, for each term in of the right side of \code{formula}. This might help to properly
 #'choose the functional form of continuous variable in cox model (\link[survival]{coxph}). Fitted lines with \link[stats]{lowess} function
 #'should be linear to satisfy cox proportional hazards model assumptions.
-#'@param fit an object of class \link[survival]{coxph.object} - created with \link[survival]{coxph} function.
-#'@param formula a formula object, with the response on the left of a ~ operator, and the terms on the right. The response must be a survival object as returned by the \link[survival]{Surv} function.
+#'@param fit an object of class \link[survival]{coxph.object} - created with the
+#'  \link[survival]{coxph} function. Provide either \code{fit}, or \code{formula}
+#'  and \code{data}; the diagnostic is identical (it uses only the model formula).
+#'@param formula a formula object, with the response on the left of a ~ operator,
+#'  and the terms on the right. The response must be a survival object as returned
+#'  by the \link[survival]{Surv} function. An alternative to \code{fit} when you
+#'  have not fitted a \code{coxph} model; supply \code{data} as well.
 #'@param data a \code{data.frame} in which to interpret the variables named in the formula,
 #'@param iter parameter of \link[stats]{lowess}.
 #'@param f parameter of \link[stats]{lowess}.
@@ -37,6 +42,10 @@ NULL
 #' ggcoxfunctional(res.cox, data = mgus, point.col = "blue", point.alpha = 0.5,
 #'                 title = "Pass the title", caption = "Pass the caption")
 #'
+#' # equivalently, from a formula + data (no fitted model needed)
+#' ggcoxfunctional(Surv(futime, death) ~ mspike + log(mspike) + age,
+#'                 data = mgus)
+#'
 #'
 #'@describeIn ggcoxfunctional Functional Form of Continuous Variable in Cox Proportional Hazards Model.
 #'@export
@@ -47,14 +56,13 @@ ggcoxfunctional <- function (formula, data = NULL, fit, iter = 0, f = 0.6,
                              title = NULL, caption = NULL,
                              ggtheme = theme_survminer(), ...){
 
+  # Accept either a fitted coxph model or a formula + data. The functional-form
+  # diagnostic uses only the model formula (the martingale residuals come from the
+  # NULL Cox model, not the fitted coefficients), so the two forms are equivalent.
+  # A coxph passed as the first positional argument is treated as `fit`.
   if(!missing(formula)){
     if(inherits(formula, "coxph")) fit <- formula
-    else{
-      warning("arguments formula is deprecated; ",
-              "will be removed in the next version; ",
-              "please use fit instead.", call. = FALSE)
-      fit <- list(formula = formula, call = list(data = data))
-    }
+    else fit <- list(formula = formula, call = list(data = data))
   }
   formula <- fit$formula
   data <- .get_data(fit, data)

--- a/man/ggcoxfunctional.Rd
+++ b/man/ggcoxfunctional.Rd
@@ -27,11 +27,16 @@ ggcoxfunctional(
 \method{print}{ggcoxfunctional}(x, ..., newpage = TRUE)
 }
 \arguments{
-\item{formula}{a formula object, with the response on the left of a ~ operator, and the terms on the right. The response must be a survival object as returned by the \link[survival]{Surv} function.}
+\item{formula}{a formula object, with the response on the left of a ~ operator,
+and the terms on the right. The response must be a survival object as returned
+by the \link[survival]{Surv} function. An alternative to \code{fit} when you
+have not fitted a \code{coxph} model; supply \code{data} as well.}
 
 \item{data}{a \code{data.frame} in which to interpret the variables named in the formula,}
 
-\item{fit}{an object of class \link[survival]{coxph.object} - created with \link[survival]{coxph} function.}
+\item{fit}{an object of class \link[survival]{coxph.object} - created with the
+\link[survival]{coxph} function. Provide either \code{fit}, or \code{formula}
+and \code{data}; the diagnostic is identical (it uses only the model formula).}
 
 \item{iter}{parameter of \link[stats]{lowess}.}
 
@@ -79,6 +84,10 @@ res.cox <- coxph(Surv(futime, death) ~ mspike + log(mspike) + I(mspike^2) +
 ggcoxfunctional(res.cox,  data = mgus, point.col = "blue", point.alpha = 0.5)
 ggcoxfunctional(res.cox, data = mgus, point.col = "blue", point.alpha = 0.5,
                 title = "Pass the title", caption = "Pass the caption")
+
+# equivalently, from a formula + data (no fitted model needed)
+ggcoxfunctional(Surv(futime, death) ~ mspike + log(mspike) + age,
+                data = mgus)
 
 
 }

--- a/tests/testthat/test-ggcoxfunctional-formula.R
+++ b/tests/testthat/test-ggcoxfunctional-formula.R
@@ -1,0 +1,23 @@
+# ggcoxfunctional() accepts either a fitted coxph or a formula + data, without a
+# deprecation warning (the diagnostic uses only the model formula, so the two are
+# equivalent).
+
+skip_if_not_installed("survival")
+
+test_that("the formula form works and no longer warns", {
+  library(survival)
+  f <- Surv(time, status) ~ age + wt.loss
+  # formula form: no deprecation (or any) warning
+  expect_silent(p_formula <- ggcoxfunctional(f, data = lung))
+  expect_s3_class(p_formula, "ggcoxfunctional")
+
+  # fit form: identical result
+  fit <- coxph(f, data = lung)
+  p_fit <- ggcoxfunctional(fit, data = lung)
+  expect_equal(length(p_formula), length(p_fit))
+  expect_equal(names(p_formula), names(p_fit))
+  # the plotted martingale-residual data matches between the two entry points,
+  # for every term (the diagnostic uses only the formula, not the fitted coefs)
+  for (i in seq_along(p_fit))
+    expect_equal(p_formula[[i]]$data, p_fit[[i]]$data)
+})


### PR DESCRIPTION
`ggcoxfunctional()` warned that the `formula` argument was deprecated and told users to pass a fitted `coxph` model via `fit` instead. That deprecation adds no value: the functional-form diagnostic plots the martingale residuals of the **null** Cox model against each covariate, so it depends only on the model formula and data, not on the fitted coefficients — a formula + data call and a fitted-model call produce identical output.

This drops the deprecation warning and documents both entry points as supported:

```r
library(survival)
res.cox <- coxph(Surv(futime, death) ~ mspike + log(mspike) + age, data = mgus)
ggcoxfunctional(res.cox, data = mgus)                       # fitted model
ggcoxfunctional(Surv(futime, death) ~ mspike + log(mspike) + age, data = mgus)  # formula
```

The fitted-model form is unchanged. A regression test asserts the two forms give identical martingale-residual data for every term.
