### PR TITLE
Add palette and per-variable reference labels to ggforest()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## New features
 
+- `ggforest()` gains a `palette` argument to colour the hazard-ratio points and confidence intervals (a single colour for one accent, or a palette to colour by variable; default `NULL` keeps them black), and its `refLabel` now also accepts a named character vector to set per-variable reference labels (e.g. `c(sex = "female (ref)")`). This also fixes the reference-row label alignment when a custom `refLabel` is used.
+
 - `pairwise_survdiff()` gains `detailed = TRUE`, attaching a per-pair table (`res$detailed`) with the test statistic (chi-square) and its degrees of freedom, the raw and adjusted p-values, and a Cox proportional-hazards hazard ratio with 95% confidence interval for each pair. The default (`detailed = FALSE`) returns the usual p-value matrix only.
 
 - `ggcompetingrisks()` gains `risk.table = TRUE`, drawing a per-group number-at-risk table beneath the cumulative-incidence curves, locked to the same time axis. It is available for a `tidycmprsk::cuminc` object on the overlaid single-panel layout; the at-risk count is the number still event-free and under observation (competing events count as leaving the risk set), matching the Kaplan-Meier at-risk convention of `ggsurvplot()`. `risk.table` also accepts the `ggsurvplot()` content strings (`"percentage"`, `"nrisk_cumcensor"`, ...), and `break.time.by` controls the shared axis breaks. With `risk.table = TRUE` the function returns a compound object that prints the curves above the aligned table and works with `ggsave()` (#838).

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -7,7 +7,23 @@
 #' @param main title of the plot.
 #' @param cpositions relative positions of first three columns in the OX scale.
 #' @param fontsize relative size of annotations in the plot. Default value: 0.7.
-#' @param refLabel label for reference levels of factor variables.
+#' @param refLabel label for reference levels of factor variables. Either a single
+#'  string (default \code{"reference"}, applied to every reference level) or a named
+#'  character vector mapping a variable name to its reference label, e.g.
+#'  \code{c(sex = "female (ref)", rx = "Obs (ref)")}; variables not named keep the
+#'  default label. Match is on the model term name (before any \code{var.labels}
+#'  relabelling).
+#' @param palette the colour of the hazard-ratio points and confidence intervals.
+#'  Default \code{NULL} draws them in black (unchanged). A single colour (name or
+#'  hex) draws every point/interval in that one accent colour -- the recommended,
+#'  tasteful choice, since colour on a forest plot does not otherwise carry meaning.
+#'  Alternatively a palette -- a vector of colours or a palette name accepted by
+#'  \code{\link[ggpubr]{get_palette}} (e.g. \code{"npg"}, \code{"lancet"}) --
+#'  colours the points by variable (one colour per variable); no colour legend is
+#'  drawn, as the rows are already labelled. A colour vector longer than the number
+#'  of variables is interpolated (\code{get_palette} behaviour). Prefer a palette
+#'  without grey (e.g. \code{"npg"}) so a point is not low-contrast on the shaded
+#'  rows.
 #' @param noDigits number of digits for estimates and p-values in the plot.
 #' @param global.stats logical value. Default is TRUE. If FALSE, the bottom
 #'   caption reporting the global statistics (number of events, global
@@ -53,6 +69,10 @@
 #'     data = colon )
 #' ggforest(bigmodel)
 #'
+#' # a single accent colour, and per-variable reference labels
+#' ggforest(bigmodel, palette = "#0073C2",
+#'   refLabel = c(sex = "female (ref)", rx = "Obs (ref)"))
+#'
 #' @export
 #' @import broom
 #' @import grid
@@ -64,7 +84,7 @@ ggforest <- function(model, data = NULL,
   main = "Hazard ratio", cpositions=c(0.02, 0.22, 0.4),
   fontsize = 0.7, refLabel = "reference", noDigits=2,
   global.stats = TRUE, ref.display = TRUE, var.labels = NULL,
-  ggtheme = NULL) {
+  palette = NULL, ggtheme = NULL) {
   conf.high <- conf.low <- estimate <- .row <- NULL
   stopifnot(inherits(model, "coxph"))
 
@@ -231,6 +251,11 @@ ggforest <- function(model, data = NULL,
   toShowExpClean <- data.frame(toShow,
     pvalue = signif(toShow[,4],noDigits+1),
     toShowExp)
+  # Reference rows (factor baselines / non-estimable terms) have an NA estimate.
+  # Capture the mask now, before `estimate` is zeroed below, so the reference
+  # label and its text alignment key on this rather than a literal "reference"
+  # string (which broke a custom refLabel).
+  toShowExpClean$.isref <- is.na(toShowExpClean$estimate)
   # ref.display = FALSE drops the rows with no hazard ratio -- factor baselines,
   # plus any non-estimable / aliased or strata() terms -- from both the drawn
   # point and the table, keeping only the estimated levels. These are exactly the
@@ -245,7 +270,16 @@ ggforest <- function(model, data = NULL,
     ifelse(toShowExpClean$p.value < 0.01, "*",""),
     ifelse(toShowExpClean$p.value < 0.001, "*",""))
   toShowExpClean$ci <- paste0("(",toShowExpClean[,"conf.low.1"]," - ",toShowExpClean[,"conf.high.1"],")")
-  toShowExpClean$estimate.1[is.na(toShowExpClean$estimate)] = refLabel
+  # Reference label(s): a single string (default), or a named character vector
+  # keyed by the model term name -- `var` still holds the raw term name here
+  # (the var.labels remap runs below), so keying on it is clean.
+  if (is.null(names(refLabel))) {
+    toShowExpClean$estimate.1[toShowExpClean$.isref] <- refLabel[1]
+  } else {
+    lab <- refLabel[as.character(toShowExpClean$var[toShowExpClean$.isref])]
+    lab[is.na(lab)] <- "reference"
+    toShowExpClean$estimate.1[toShowExpClean$.isref] <- lab
+  }
   toShowExpClean$stars[which(toShowExpClean$p.value < 0.001)] = "<0.001 ***"
   toShowExpClean$stars[is.na(toShowExpClean$estimate)] = ""
   toShowExpClean$ci[is.na(toShowExpClean$estimate)] = ""
@@ -284,6 +318,9 @@ ggforest <- function(model, data = NULL,
     .hit <- toShowExpClean$var %in% names(.map)
     toShowExpClean$var[.hit] <- .map[toShowExpClean$var[.hit]]
   }
+  # Undeduplicated per-variable key for optional colouring (the `var` column below
+  # is blanked for repeated levels, so it cannot be used as a colour group).
+  toShowExpClean$.grp <- factor(toShowExpClean$var, levels = unique(toShowExpClean$var))
   toShowExpClean$var[duplicated(toShowExpClean$var)] = ""
   # make label strings:
   toShowExpClean$N <- paste0("(N=",toShowExpClean$N,")")
@@ -350,15 +387,36 @@ ggforest <- function(model, data = NULL,
   annot_size_mm <- fontsize *
     as.numeric(convertX(unit(theme_get()$text$size, "pt"), "mm"))
 
+  # Hazard-ratio point + interval layers. Default (palette = NULL) keeps the exact
+  # black, no-colour-aesthetic geoms so the output is unchanged; a palette colours
+  # them by variable via a hidden manual colour scale. A single colour recycles to
+  # every variable (one accent); a palette gives one colour per variable.
+  .drawable <- toShowExpClean[!toShowExpClean$.nonfinite, , drop = FALSE]
+  if (is.null(palette)) {
+    .pt <- geom_point(data = .drawable, aes(x = .row, y = exp(estimate)),
+                      pch = 15, size = 4)
+    .eb <- geom_errorbar(data = .drawable,
+                         aes(x = .row, ymin = exp(conf.low), ymax = exp(conf.high)),
+                         width = 0.15)
+    .col_scale <- NULL
+  } else {
+    .cols <- ggpubr::get_palette(palette, length(levels(toShowExpClean$.grp)))
+    .cols <- stats::setNames(.cols, levels(toShowExpClean$.grp))
+    .pt <- geom_point(data = .drawable,
+                      aes(x = .row, y = exp(estimate), colour = .grp),
+                      pch = 15, size = 4)
+    .eb <- geom_errorbar(data = .drawable,
+                         aes(x = .row, ymin = exp(conf.low), ymax = exp(conf.high),
+                             colour = .grp), width = 0.15)
+    .col_scale <- scale_colour_manual(values = .cols, guide = "none")
+  }
+
   p <- ggplot(toShowExpClean, aes(seq_along(var), exp(estimate))) +
     geom_rect(aes(xmin = seq_along(var) - .5, xmax = seq_along(var) + .5,
       ymin = exp(rangeplot[1]), ymax = exp(rangeplot[2]),
       fill = ordered(seq_along(var) %% 2 + 1))) +
     scale_fill_manual(values = c("#FFFFFF33", "#00000033"), guide = "none") +
-    geom_point(data = toShowExpClean[!toShowExpClean$.nonfinite, , drop = FALSE],
-      aes(x = .row, y = exp(estimate)), pch = 15, size = 4) +
-    geom_errorbar(data = toShowExpClean[!toShowExpClean$.nonfinite, , drop = FALSE],
-      aes(x = .row, ymin = exp(conf.low), ymax = exp(conf.high)), width = 0.15) +
+    .pt + .eb + .col_scale +
     geom_hline(yintercept = 1, linetype = 3) +
     coord_flip(ylim = exp(rangeplot)) +
     ggtitle(main) +
@@ -389,7 +447,7 @@ ggforest <- function(model, data = NULL,
       size = annot_size_mm) +
     annotate(geom = "text", x = x_annotate, y = exp(y_cistring),
       label = toShowExpClean$estimate.1, size = annot_size_mm,
-      vjust = ifelse(toShowExpClean$estimate.1 == "reference", .5, -0.1)) +
+      vjust = ifelse(toShowExpClean$.isref, .5, -0.1)) +
     annotate(geom = "text", x = x_annotate, y = exp(y_cistring),
       label = toShowExpClean$ci, size = annot_size_mm,
       vjust = 1.1,  fontface = "italic") +

--- a/man/ggforest.Rd
+++ b/man/ggforest.Rd
@@ -15,6 +15,7 @@ ggforest(
   global.stats = TRUE,
   ref.display = TRUE,
   var.labels = NULL,
+  palette = NULL,
   ggtheme = NULL
 )
 }
@@ -30,20 +31,25 @@ will be extracted from 'fit' object.}
 
 \item{fontsize}{relative size of annotations in the plot. Default value: 0.7.}
 
-\item{refLabel}{label for reference levels of factor variables.}
+\item{refLabel}{label for reference levels of factor variables. Either a single
+string (default \code{"reference"}, applied to every reference level) or a named
+character vector mapping a variable name to its reference label, e.g.
+\code{c(sex = "female (ref)", rx = "Obs (ref)")}; variables not named keep the
+default label. Match is on the model term name (before any \code{var.labels}
+relabelling).}
 
 \item{noDigits}{number of digits for estimates and p-values in the plot.}
 
-\item{global.stats}{logical value. Default is TRUE. If FALSE, the bottom caption
-reporting the global statistics (number of events, global likelihood-ratio-test
-p-value, AIC and concordance index) is omitted. Useful when arranging several
-forest plots in a panel.}
+\item{global.stats}{logical value. Default is TRUE. If FALSE, the bottom
+caption reporting the global statistics (number of events, global
+likelihood-ratio-test p-value, AIC and concordance index) is omitted. Useful
+when arranging several forest plots in a panel.}
 
-\item{ref.display}{logical value. Default is TRUE. If FALSE, the rows that have
-no hazard ratio -- factor baselines, and any non-estimable / aliased or
-\code{strata()} terms, i.e. the rows labelled \code{refLabel} ("reference") --
-are omitted from both the plot and the table, keeping only the estimated levels.
-Default TRUE shows every row (unchanged).}
+\item{ref.display}{logical value. Default is TRUE. If FALSE, the rows that
+have no hazard ratio -- factor baselines, and any non-estimable / aliased or
+\code{strata()} terms, i.e. the rows labelled \code{refLabel} ("reference")
+-- are omitted from both the plot and the table, keeping only the estimated
+levels. Default TRUE shows every row (unchanged).}
 
 \item{var.labels}{a named character vector giving display labels for the
 variable names, e.g. \code{c(age = "Age (years)", sex = "Sex")}. The names
@@ -51,14 +57,26 @@ must match the model term names (as shown in the plot by default); only
 matched terms are relabelled, unmatched terms keep their original name.
 Default \code{NULL} uses the term names unchanged.}
 
+\item{palette}{the colour of the hazard-ratio points and confidence intervals.
+Default \code{NULL} draws them in black (unchanged). A single colour (name or
+hex) draws every point/interval in that one accent colour -- the recommended,
+tasteful choice, since colour on a forest plot does not otherwise carry meaning.
+Alternatively a palette -- a vector of colours or a palette name accepted by
+\code{\link[ggpubr]{get_palette}} (e.g. \code{"npg"}, \code{"lancet"}) --
+colours the points by variable (one colour per variable); no colour legend is
+drawn, as the rows are already labelled. A colour vector longer than the number
+of variables is interpolated (\code{get_palette} behaviour). Prefer a palette
+without grey (e.g. \code{"npg"}) so a point is not low-contrast on the shaded
+rows.}
+
 \item{ggtheme}{a ggplot2 theme (e.g. the result of \code{theme(...)} or a
-complete theme) applied to the forest plot. Because \code{ggforest()} returns
-a rasterised \code{gtable}, a theme added to the returned object has no effect;
-pass it here instead, e.g. \code{ggtheme = theme(text = element_text(size =
-14))}. It is added after the built-in theme: a partial \code{theme(...)}
-overrides only the matching elements, whereas a complete theme (e.g.
-\code{theme_void()}) replaces the built-in look entirely. Default \code{NULL}
-leaves the appearance unchanged.}
+complete theme) applied to the forest plot. Because \code{ggforest()}
+returns a rasterised \code{gtable}, a theme added to the returned object
+has no effect; pass it here instead, e.g.
+\code{ggtheme = theme(text = element_text(size = 14))}. It is added after
+the built-in theme: a partial \code{theme(...)} overrides only the matching
+elements, whereas a complete theme (e.g. \code{theme_void()}) replaces the
+built-in look entirely. Default \code{NULL} leaves the appearance unchanged.}
 }
 \value{
 returns a ggplot2 object (invisibly)
@@ -81,6 +99,10 @@ bigmodel <-
   coxph(Surv(time, status) ~ sex + rx + adhere + differ + extent + node4,
     data = colon )
 ggforest(bigmodel)
+
+# a single accent colour, and per-variable reference labels
+ggforest(bigmodel, palette = "#0073C2",
+  refLabel = c(sex = "female (ref)", rx = "Obs (ref)"))
 
 }
 \author{

--- a/tests/testthat/test-ggforest-palette-reflabel.R
+++ b/tests/testthat/test-ggforest-palette-reflabel.R
@@ -1,0 +1,74 @@
+# ggforest(): colour the HR points/intervals via `palette`, and per-variable
+# reference labels via a named `refLabel`. Defaults are unchanged.
+
+library(survival)
+
+# text labels drawn in a ggforest (grob-forced so annotations are materialised)
+.forest_labels <- function(p) {
+  gt <- grid::grid.force(ggplot2::ggplotGrob(p))
+  labs <- character(0)
+  walk <- function(gr) {
+    if (inherits(gr, "gTree") && !is.null(gr$children))
+      for (nm in names(gr$children)) walk(gr$children[[nm]])
+    if (!is.null(gr$label)) labs <<- c(labs, as.character(gr$label))
+  }
+  walk(gt); unique(labs[nzchar(labs)])
+}
+# colours of the drawn HR points (geom_point -> a points grob with gp$col)
+.forest_point_cols <- function(p) {
+  gt <- grid::grid.force(ggplot2::ggplotGrob(p))
+  cols <- character(0)
+  walk <- function(gr) {
+    if (inherits(gr, "gTree") && !is.null(gr$children))
+      for (nm in names(gr$children)) walk(gr$children[[nm]])
+    if (inherits(gr, "points") && !is.null(gr$gp$col))
+      cols <<- c(cols, gr$gp$col)
+  }
+  walk(gt); unique(cols)
+}
+
+.m <- function() {
+  d <- within(colon, { sex <- factor(sex, labels = c("female", "male")); rx <- factor(rx) })
+  list(fit = coxph(Surv(time, status) ~ sex + rx + age + nodes, data = d), data = d)
+}
+
+.norm_col <- function(x) toupper(sub("^#", "#", x))
+
+test_that("default palette (NULL) draws black points; a single colour recolours them", {
+  mm <- .m()
+  black <- .norm_col(.forest_point_cols(ggforest(mm$fit, data = mm$data)))
+  expect_true("#000000" %in% black)              # default: black points
+  accent <- .norm_col(.forest_point_cols(
+    ggforest(mm$fit, data = mm$data, palette = "#0073C2")))
+  expect_true("#0073C2" %in% accent)             # recoloured
+  expect_false("#000000" %in% accent)            # no black point remains
+})
+
+test_that("a palette colours points by variable (one colour per variable)", {
+  mm <- .m()
+  cols <- .forest_point_cols(ggforest(mm$fit, data = mm$data, palette = "npg"))
+  # 4 variables (sex, rx, age, nodes) -> at least two distinct point colours
+  expect_gte(length(unique(cols)), 2L)
+  expect_false("#000000" %in% .norm_col(cols))
+})
+
+test_that("a named refLabel sets per-variable reference labels; others keep default", {
+  mm <- .m()
+  labs <- .forest_labels(ggforest(mm$fit, data = mm$data,
+                                  refLabel = c(sex = "female (ref)")))
+  expect_true("female (ref)" %in% labs)   # named variable relabelled
+  expect_true("reference" %in% labs)      # rx (unnamed) keeps the default
+})
+
+test_that("a custom scalar refLabel is drawn (and no longer mis-handled)", {
+  mm <- .m()
+  labs <- .forest_labels(ggforest(mm$fit, data = mm$data, refLabel = "Ref"))
+  expect_true("Ref" %in% labs)
+  expect_false("reference" %in% labs)
+})
+
+test_that("palette and refLabel do not error with ref.display = FALSE / global.stats = FALSE", {
+  mm <- .m()
+  expect_error(ggforest(mm$fit, data = mm$data, palette = "jco",
+                        ref.display = FALSE, global.stats = FALSE), NA)
+})


### PR DESCRIPTION
Two additions to `ggforest()`, both opt-in with the default output unchanged.

## `palette` — colour the hazard-ratio points and intervals

`palette = NULL` (default) keeps them black. A single colour draws every point/interval in one accent (the recommended, tasteful choice); a palette (a colour vector or a `get_palette` name such as `"npg"`) colours them by variable, one colour per variable, with no legend (the rows are already labelled).

```r
library(survival)
m <- coxph(Surv(time, status) ~ sex + rx + age + nodes, data = colon)
ggforest(m, data = colon, palette = "#0073C2")
```

![ggforest with a single accent colour](https://i.imgur.com/YNgH1pi.png)

## `refLabel` — per-variable reference labels

`refLabel` now also accepts a named vector keyed by variable, e.g. `c(sex = "female (ref)", rx = "Obs (ref)")`; unnamed variables keep the default "reference". This also fixes a pre-existing bug: the reference-row label was positioned by matching the literal string "reference", so any custom `refLabel` shifted the label off-centre — it is now keyed on the reference-row mask and stays centred.

Default output (`palette = NULL`, scalar `refLabel`) is byte-identical.
