### PR TITLE
Document a publication-ready ggforest() recipe

### DIFF
--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -73,6 +73,10 @@
 #' ggforest(bigmodel, palette = "#0073C2",
 #'   refLabel = c(sex = "female (ref)", rx = "Obs (ref)"))
 #'
+#' # a clean, publication-ready look: one accent colour and a slightly larger
+#' # font. Add global.stats = FALSE when placing several forests in one figure.
+#' ggforest(bigmodel, palette = "#0073C2", fontsize = 0.9)
+#'
 #' @export
 #' @import broom
 #' @import grid

--- a/man/ggforest.Rd
+++ b/man/ggforest.Rd
@@ -104,6 +104,10 @@ ggforest(bigmodel)
 ggforest(bigmodel, palette = "#0073C2",
   refLabel = c(sex = "female (ref)", rx = "Obs (ref)"))
 
+# a clean, publication-ready look: one accent colour and a slightly larger
+# font. Add global.stats = FALSE when placing several forests in one figure.
+ggforest(bigmodel, palette = "#0073C2", fontsize = 0.9)
+
 }
 \author{
 Przemyslaw Biecek (\email{przemyslaw.biecek@gmail.com}),


### PR DESCRIPTION
Adds an example to ggforest()'s help showing a clean, publication-ready figure: a single accent colour (palette) plus a slightly larger fontsize, with a note to set global.stats = FALSE when arranging several forests in one panel. Documentation only.