### PR TITLE
Add pooled stratified log-rank p to ggsurvplot_facet() (pval.stratified)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## New features
 
+- `ggsurvplot_facet()` gains `pval.stratified = TRUE`, showing a single pooled stratified log-rank p-value -- `survdiff(Surv(time, status) ~ group + strata(facet.by))`, the group effect adjusting for the faceting variable -- as a figure-level subtitle. This is the statistic the whole figure illustrates: the per-panel p-values are within-facet, and several may be non-significant even when the pooled effect is strong. It is independent of `pval` (they combine). Only the log-rank / Peto (`rho`) family is used; the pooled test assumes a consistent group effect across strata.
+
 - `ggforest()` gains a `palette` argument to colour the hazard-ratio points and confidence intervals (a single colour for one accent, or a palette to colour by variable; default `NULL` keeps them black), and its `refLabel` now also accepts a named character vector to set per-variable reference labels (e.g. `c(sex = "female (ref)")`). This also fixes the reference-row label alignment when a custom `refLabel` is used.
 
 - `pairwise_survdiff()` gains `detailed = TRUE`, attaching a per-pair table (`res$detailed`) with the test statistic (chi-square) and its degrees of freedom, the raw and adjusted p-values, and a Cox proportional-hazards hazard ratio with 95% confidence interval for each pair. The default (`detailed = FALSE`) returns the usual p-value matrix only.

--- a/R/ggsurvplot_facet.R
+++ b/R/ggsurvplot_facet.R
@@ -56,6 +56,20 @@ NULL
 #'  two faceting variables the p-value is drawn on the panels instead, with a
 #'  warning). If a \code{labeller} is also supplied it takes precedence and the
 #'  p-value is not added to the label.
+#'@param pval.stratified logical value. Default is FALSE. If TRUE, a single
+#'  \strong{pooled stratified log-rank} p-value -- \code{survdiff(Surv(time, status)
+#'  ~ group + strata(facet.by))}, the group effect adjusting for the faceting
+#'  variable -- is shown as a figure-level subtitle. This is the statistic the whole
+#'  figure illustrates: the per-panel p-values (\code{pval = TRUE}) are within-facet
+#'  and several may be non-significant even when the pooled effect is strong.
+#'  \code{pval.stratified} is independent of \code{pval} and can be combined with it.
+#'  Several \code{facet.by} variables are combined into one \code{strata()}. The
+#'  pooled test is the log-rank / Peto family (a weighted Fleming-Harrington
+#'  \code{method} is ignored, as \code{survdiff} has no stratified
+#'  Fleming-Harrington). \strong{Caveat:} the stratified log-rank assumes the group
+#'  effect is consistent across the facet strata; it sums the score over strata, so
+#'  opposite-direction effects cancel and it is \emph{not} a test of a group-by-facet
+#'  interaction (Klein & Moeschberger, 2003).
 #'@param risk.table logical value. Default is FALSE. If TRUE, a number-at-risk
 #'  table is drawn below the faceted curves, faceted with the same structure so
 #'  each panel's table aligns under its curves. Supported for a single
@@ -99,6 +113,11 @@ NULL
 #'ggsurvplot_facet(fit, colon, facet.by = "rx",
 #'                 palette = "jco", pval = TRUE, pval.in.label = TRUE)
 #'
+#'# Pooled stratified log-rank p (figure-level), with the per-panel p-values
+#'#::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+#'ggsurvplot_facet(fit, colon, facet.by = "rx",
+#'                 palette = "jco", pval = TRUE, pval.stratified = TRUE)
+#'
 #'# Faceted number-at-risk table
 #'#::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 #'ggsurvplot_facet(fit, colon, facet.by = "rx",
@@ -116,7 +135,7 @@ ggsurvplot_facet <- function(fit, data, facet.by,
                              legend.labs = NULL,
                              pval = FALSE, pval.method = FALSE, pval.size = 5,
                              pval.coord = NULL, pval.method.coord = NULL,
-                             pval.in.label = FALSE,
+                             pval.in.label = FALSE, pval.stratified = FALSE,
                              p.adjust.method = "none", p.adjust.label = "adj.p =",
                              nrow = NULL, ncol = NULL,
                              scales = "fixed",
@@ -431,6 +450,14 @@ ggsurvplot_facet <- function(fit, data, facet.by,
               panel.labs.font.y = panel.labs.font.y,
               labeller = strip.labeller)
 
+  # Pooled stratified log-rank p (a single, figure-level statistic), independent of
+  # the per-panel `pval`. Added to `p` here so it reaches both the plain return and
+  # the risk-table grob assembly below.
+  #:::::::::::::::::::::::::::::::::::::::::
+  if(isTRUE(pval.stratified))
+    p <- .facet_stratified_pval(p, surv.obj, vars.notin.groupby, facet.by, data,
+                                dots = list(...))
+
   # Draw the p-values on the panels unless they were placed in the labels
   #:::::::::::::::::::::::::::::::::::::::::
   if(draw.pval && !add.pval.to.label){
@@ -642,6 +669,46 @@ print.ggsurvplot_facet <- function(x, newpage = TRUE, ...) {
   if(newpage) grid::grid.newpage()
   grid::grid.draw(x)
   invisible(x)
+}
+
+# Append a pooled stratified log-rank p-value as a figure-level subtitle. The test
+# is survdiff(Surv ~ group + strata(facet.by)) -- the group effect adjusting for the
+# facet variable, the statistic the whole figure illustrates. GROUP is the vetted
+# grouping set (vars.notin.groupby) and FACET is facet.by; several facet variables
+# are combined into one strata(). Only the log-rank / Peto (rho) family is available
+# (survdiff has no stratified Fleming-Harrington), so a weighted `method` falls back
+# to rho with a message. The pooled test assumes a consistent group effect across
+# strata; it cannot detect a group x facet interaction (opposite-direction effects
+# cancel) -- see the caveat in the ggsurvplot_facet() documentation.
+.facet_stratified_pval <- function(p, surv.obj, group.vars, facet.by, data, dots){
+  if(length(group.vars) == 0L){
+    message("ggsurvplot_facet(): `pval.stratified = TRUE` needs a grouping variable ",
+            "(the fit is ~ 1); no pooled p drawn.")
+    return(p)
+  }
+  if("method" %in% names(dots) &&
+     !identical(.resolve_logrank_method(dots$method), "survdiff"))
+    message("ggsurvplot_facet(): the pooled stratified test uses the log-rank / ",
+            "Peto (rho) family only (survdiff has no stratified Fleming-Harrington); ",
+            "the pooled p ignores `method`.")
+  rho <- if("rho" %in% names(dots)) dots$rho else 0
+  strata.term <- paste0("strata(", paste(facet.by, collapse = ", "), ")")
+  form <- .build_formula(surv.obj, paste(c(group.vars, strata.term), collapse = " + "))
+  sdiff <- tryCatch(survival::survdiff(form, data = data, rho = rho),
+                    error = function(e) NULL)
+  if(is.null(sdiff) || length(sdiff$n) < 2L){
+    message("ggsurvplot_facet(): the pooled stratified log-rank test is not defined ",
+            "here (a single group, or a non-plain grouping term); no pooled p drawn.")
+    return(p)
+  }
+  df <- length(sdiff$n) - 1L
+  pv <- stats::pchisq(sdiff$chisq, df, lower.tail = FALSE)
+  ptxt <- if(pv < 1e-4) "p < 0.0001" else paste0("p = ", format.pval(pv, digits = 2))
+  label <- sprintf("Stratified log-rank %s (stratified by %s)",
+                   ptxt, paste(facet.by, collapse = ", "))
+  old.sub <- p$labels$subtitle
+  p + ggplot2::labs(subtitle = if(is.null(old.sub)) label
+                    else paste0(old.sub, "\n", label))
 }
 
 

--- a/man/ggsurvplot_facet.Rd
+++ b/man/ggsurvplot_facet.Rd
@@ -18,6 +18,7 @@ ggsurvplot_facet(
   pval.coord = NULL,
   pval.method.coord = NULL,
   pval.in.label = FALSE,
+  pval.stratified = FALSE,
   p.adjust.method = "none",
   p.adjust.label = "adj.p =",
   nrow = NULL,
@@ -96,6 +97,21 @@ panel. Requires \code{pval = TRUE} and a single \code{facet.by} variable (with
 two faceting variables the p-value is drawn on the panels instead, with a
 warning). If a \code{labeller} is also supplied it takes precedence and the
 p-value is not added to the label.}
+
+\item{pval.stratified}{logical value. Default is FALSE. If TRUE, a single
+\strong{pooled stratified log-rank} p-value -- \code{survdiff(Surv(time, status)
+~ group + strata(facet.by))}, the group effect adjusting for the faceting
+variable -- is shown as a figure-level subtitle. This is the statistic the whole
+figure illustrates: the per-panel p-values (\code{pval = TRUE}) are within-facet
+and several may be non-significant even when the pooled effect is strong.
+\code{pval.stratified} is independent of \code{pval} and can be combined with it.
+Several \code{facet.by} variables are combined into one \code{strata()}. The
+pooled test is the log-rank / Peto family (a weighted Fleming-Harrington
+\code{method} is ignored, as \code{survdiff} has no stratified
+Fleming-Harrington). \strong{Caveat:} the stratified log-rank assumes the group
+effect is consistent across the facet strata; it sums the score over strata, so
+opposite-direction effects cancel and it is \emph{not} a test of a group-by-facet
+interaction (Klein & Moeschberger, 2003).}
 
 \item{p.adjust.method}{method for adjusting the per-panel p-values for multiple
 comparisons across panels, passed to \code{\link[stats]{p.adjust}()} (e.g.
@@ -202,6 +218,11 @@ ggsurvplot_facet(fit, colon, facet.by = c("rx", "adhere"),
 #::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ggsurvplot_facet(fit, colon, facet.by = "rx",
                 palette = "jco", pval = TRUE, pval.in.label = TRUE)
+
+# Pooled stratified log-rank p (figure-level), with the per-panel p-values
+#::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+ggsurvplot_facet(fit, colon, facet.by = "rx",
+                palette = "jco", pval = TRUE, pval.stratified = TRUE)
 
 # Faceted number-at-risk table
 #::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/tests/testthat/test-ggsurvplot-facet-stratified-pval.R
+++ b/tests/testthat/test-ggsurvplot-facet-stratified-pval.R
@@ -1,0 +1,74 @@
+# ggsurvplot_facet(pval.stratified = TRUE): pooled stratified log-rank p as a
+# figure-level subtitle. Default (FALSE) is unchanged.
+
+skip_if_not_installed("survival")
+
+.fac_fit <- function() {
+  d <- survival::lung
+  d <- d[!is.na(d$ph.ecog) & d$ph.ecog < 3, ]
+  d$ph.ecog <- factor(d$ph.ecog)
+  list(fit = survival::survfit(survival::Surv(time, status) ~ sex, data = d), data = d)
+}
+
+test_that("the pooled p matches a hand survdiff(~ group + strata(facet))", {
+  f <- .fac_fit()
+  p <- ggsurvplot_facet(f$fit, f$data, facet.by = "ph.ecog", pval.stratified = TRUE)
+  sd <- survival::survdiff(survival::Surv(time, status) ~ sex + strata(ph.ecog),
+                           data = f$data)
+  pv <- stats::pchisq(sd$chisq, length(sd$n) - 1, lower.tail = FALSE)
+  expect_true(grepl("Stratified log-rank", p$labels$subtitle))
+  expect_true(grepl(format.pval(pv, digits = 2, eps = 1e-4), p$labels$subtitle,
+                    fixed = TRUE))
+  expect_true(grepl("ph.ecog", p$labels$subtitle))
+})
+
+test_that("pval.stratified is independent of and combinable with per-panel pval", {
+  f <- .fac_fit()
+  # stratified only: subtitle present, no per-panel geom_text
+  p1 <- ggsurvplot_facet(f$fit, f$data, facet.by = "ph.ecog", pval.stratified = TRUE)
+  has_text1 <- any(vapply(p1$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))
+  expect_false(has_text1)
+  # both: subtitle AND per-panel p
+  p2 <- ggsurvplot_facet(f$fit, f$data, facet.by = "ph.ecog",
+                         pval = TRUE, pval.stratified = TRUE)
+  has_text2 <- any(vapply(p2$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))
+  expect_true(has_text2)
+  expect_true(grepl("Stratified log-rank", p2$labels$subtitle))
+})
+
+test_that("a user subtitle is preserved (appended, not clobbered)", {
+  f <- .fac_fit()
+  p <- ggsurvplot_facet(f$fit, f$data, facet.by = "ph.ecog",
+                        pval.stratified = TRUE, subtitle = "My subtitle")
+  expect_true(grepl("My subtitle", p$labels$subtitle))
+  expect_true(grepl("Stratified log-rank", p$labels$subtitle))
+})
+
+test_that("several facet variables are combined into one strata()", {
+  fit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::colon)
+  p <- ggsurvplot_facet(fit, survival::colon, facet.by = c("rx", "adhere"),
+                        pval.stratified = TRUE)
+  sd <- survival::survdiff(survival::Surv(time, status) ~ sex + strata(rx, adhere),
+                           data = survival::colon)
+  pv <- stats::pchisq(sd$chisq, length(sd$n) - 1, lower.tail = FALSE)
+  expect_true(grepl(format.pval(pv, digits = 2, eps = 1e-4), p$labels$subtitle,
+                    fixed = TRUE))
+  expect_true(grepl("rx, adhere", p$labels$subtitle))
+})
+
+test_that("a ~ 1 fit (no group) is skipped with a message, no subtitle", {
+  f <- .fac_fit()
+  f1 <- survival::survfit(survival::Surv(time, status) ~ 1, data = f$data)
+  expect_message(
+    p <- ggsurvplot_facet(f1, f$data, facet.by = "ph.ecog", pval.stratified = TRUE),
+    "needs a grouping variable")
+  expect_null(p$labels$subtitle)
+})
+
+test_that("a weighted method is ignored for the pooled test with a message", {
+  fit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::colon)
+  expect_message(
+    suppressWarnings(ggsurvplot_facet(fit, survival::colon, facet.by = "rx",
+                     pval.stratified = TRUE, method = "FH_p=1_q=1")),
+    "log-rank / Peto")
+})


### PR DESCRIPTION
Adds `pval.stratified = TRUE` to `ggsurvplot_facet()`.

With `pval = TRUE`, each panel shows its own *within-facet* log-rank p — and several can be non-significant even when the group effect is strong, which misleads. `pval.stratified = TRUE` shows the single **pooled stratified log-rank** p — `survdiff(Surv(time, status) ~ group + strata(facet.by))`, the group effect adjusting for the faceting variable — as a figure-level subtitle. It is the statistic the whole figure illustrates.

```r
library(survival)
fit <- survfit(Surv(time, status) ~ sex, data = lung)
ggsurvplot_facet(fit, lung, facet.by = "ph.ecog",
                 pval.stratified = TRUE, palette = "jco")
```

![faceted curves with a pooled stratified log-rank p](https://i.imgur.com/JRxv4iM.png)

- Independent of `pval` and combines with it (per-panel p's *and* the pooled subtitle).
- Several `facet.by` variables are combined into one `strata()`; multi-variable grouping is crossed exactly as the faceted curves are drawn.
- Log-rank / Peto family only (`survdiff` has no stratified Fleming-Harrington; a weighted `method` is ignored for the pooled test with a message).
- The stratified log-rank assumes a consistent group effect across strata (it cannot detect a group-by-facet interaction) — documented.

Default (`pval.stratified = FALSE`) output is unchanged.
