### PR TITLE
Add a columns argument to ggforest() to select which statistics show

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - `ggsurvplot_facet()` gains `pval.stratified = TRUE`, showing a single pooled stratified log-rank p-value -- `survdiff(Surv(time, status) ~ group + strata(facet.by))`, the group effect adjusting for the faceting variable -- as a figure-level subtitle. This is the statistic the whole figure illustrates: the per-panel p-values are within-facet, and several may be non-significant even when the pooled effect is strong. It is independent of `pval` (they combine). Only the log-rank / Peto (`rho`) family is used; the pooled test assumes a consistent group effect across strata.
 
+- `ggforest()` gains a `columns` argument to choose which statistic columns are shown -- any subset of `c("N", "hr", "ci", "p")` (the variable, level and forest are always drawn). A dropped column reflows the rest (a stacked partner re-centres, and the p-value's reserved right margin is reclaimed); the default shows all four and is unchanged.
+
 - `ggforest()` gains a `palette` argument to colour the hazard-ratio points and confidence intervals (a single colour for one accent, or a palette to colour by variable; default `NULL` keeps them black), and its `refLabel` now also accepts a named character vector to set per-variable reference labels (e.g. `c(sex = "female (ref)")`). This also fixes the reference-row label alignment when a custom `refLabel` is used.
 
 - `pairwise_survdiff()` gains `detailed = TRUE`, attaching a per-pair table (`res$detailed`) with the test statistic (chi-square) and its degrees of freedom, the raw and adjusted p-values, and a Cox proportional-hazards hazard ratio with 95% confidence interval for each pair. The default (`detailed = FALSE`) returns the usual p-value matrix only.

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -24,6 +24,14 @@
 #'  of variables is interpolated (\code{get_palette} behaviour). Prefer a palette
 #'  without grey (e.g. \code{"npg"}) so a point is not low-contrast on the shaded
 #'  rows.
+#' @param columns character vector selecting which statistic columns to display,
+#'  any subset of \code{c("N", "hr", "ci", "p")} -- the sample size, the hazard-ratio
+#'  value, the confidence interval, and the p-value / significance stars. The
+#'  variable name, the level and the forest itself are always shown. Case-insensitive;
+#'  order is ignored (the column positions are fixed). A dropped column reflows so a
+#'  stacked partner re-centres and the p-value's reserved right margin is reclaimed;
+#'  the default (all four) is unchanged. Note the reference-level label (\code{refLabel})
+#'  is drawn in the \code{"hr"} column, so omitting \code{"hr"} also hides it.
 #' @param noDigits number of digits for estimates and p-values in the plot.
 #' @param global.stats logical value. Default is TRUE. If FALSE, the bottom
 #'   caption reporting the global statistics (number of events, global
@@ -88,7 +96,18 @@ ggforest <- function(model, data = NULL,
   main = "Hazard ratio", cpositions=c(0.02, 0.22, 0.4),
   fontsize = 0.7, refLabel = "reference", noDigits=2,
   global.stats = TRUE, ref.display = TRUE, var.labels = NULL,
-  palette = NULL, ggtheme = NULL) {
+  palette = NULL, columns = c("N", "hr", "ci", "p"), ggtheme = NULL) {
+
+  # Which statistic columns to draw (the variable name, level and forest are always
+  # shown). Case-insensitive; order is ignored -- the positions are fixed. NULL means
+  # the default (all four), not "none".
+  if (is.null(columns)) columns <- c("N", "hr", "ci", "p")
+  columns <- tolower(columns)
+  .allowed.cols <- c("n", "hr", "ci", "p")
+  .bad <- setdiff(columns, .allowed.cols)
+  if (length(.bad))
+    stop("Unknown `columns` value(s): ", paste(.bad, collapse = ", "),
+         ". Allowed: N, hr, ci, p.", call. = FALSE)
   conf.high <- conf.low <- estimate <- .row <- NULL
   stopifnot(inherits(model, "coxph"))
 
@@ -376,8 +395,10 @@ ggforest <- function(model, data = NULL,
   rangeplot <- rangeb
   # make plot twice as wide as needed to create space for annotations
   rangeplot[1] <- rangeplot[1] - diff(rangeb)
-  # increase white space on right for p-vals:
-  rangeplot[2] <- rangeplot[2] + .15 * diff(rangeb)
+  # increase white space on right for p-vals (only when the p column is drawn, so
+  # dropping it reclaims the band instead of leaving it empty):
+  if ("p" %in% columns)
+    rangeplot[2] <- rangeplot[2] + .15 * diff(rangeb)
 
   width <- diff(rangeplot)
   # y-coordinates for labels:
@@ -444,20 +465,28 @@ ggforest <- function(model, data = NULL,
       label = toShowExpClean$var, fontface = "bold", hjust = 0,
       size = annot_size_mm) +
     annotate(geom = "text", x = x_annotate, y = exp(y_nlevel), hjust = 0,
-      label = toShowExpClean$level, vjust = -0.1, size = annot_size_mm) +
-    annotate(geom = "text", x = x_annotate, y = exp(y_nlevel),
+      label = toShowExpClean$level,
+      vjust = ifelse("n" %in% columns, -0.1, .5), size = annot_size_mm)
+  # Optional statistic columns (N / HR value / CI / p-stars). Each dropped column
+  # reflows so its stacked partner re-centres (via vjust); with all four shown the
+  # vjusts reduce to the previous constants, so the default output is unchanged.
+  if ("n" %in% columns)
+    p <- p + annotate(geom = "text", x = x_annotate, y = exp(y_nlevel),
       label = toShowExpClean$N, fontface = "italic", hjust = 0,
       vjust = ifelse(toShowExpClean$level == "", .5, 1.1),
-      size = annot_size_mm) +
-    annotate(geom = "text", x = x_annotate, y = exp(y_cistring),
+      size = annot_size_mm)
+  if ("hr" %in% columns)
+    p <- p + annotate(geom = "text", x = x_annotate, y = exp(y_cistring),
       label = toShowExpClean$estimate.1, size = annot_size_mm,
-      vjust = ifelse(toShowExpClean$.isref, .5, -0.1)) +
-    annotate(geom = "text", x = x_annotate, y = exp(y_cistring),
+      vjust = ifelse(toShowExpClean$.isref | !("ci" %in% columns), .5, -0.1))
+  if ("ci" %in% columns)
+    p <- p + annotate(geom = "text", x = x_annotate, y = exp(y_cistring),
       label = toShowExpClean$ci, size = annot_size_mm,
-      vjust = 1.1,  fontface = "italic") +
-    annotate(geom = "text", x = x_annotate, y = exp(y_stars),
+      vjust = ifelse("hr" %in% columns, 1.1, .5), fontface = "italic")
+  if ("p" %in% columns)
+    p <- p + annotate(geom = "text", x = x_annotate, y = exp(y_stars),
       label = toShowExpClean$stars, size = annot_size_mm,
-      hjust = -0.2,  fontface = "italic")
+      hjust = -0.2, fontface = "italic")
   # Global statistics caption (# events, global p-value, AIC, concordance).
   # Optional: set global.stats = FALSE to omit it (e.g. panels of forest plots).
   # `broom::glance()$p.value.log` is the p-value of the *likelihood ratio test*

--- a/man/ggforest.Rd
+++ b/man/ggforest.Rd
@@ -16,6 +16,7 @@ ggforest(
   ref.display = TRUE,
   var.labels = NULL,
   palette = NULL,
+  columns = c("N", "hr", "ci", "p"),
   ggtheme = NULL
 )
 }
@@ -68,6 +69,15 @@ drawn, as the rows are already labelled. A colour vector longer than the number
 of variables is interpolated (\code{get_palette} behaviour). Prefer a palette
 without grey (e.g. \code{"npg"}) so a point is not low-contrast on the shaded
 rows.}
+
+\item{columns}{character vector selecting which statistic columns to display,
+any subset of \code{c("N", "hr", "ci", "p")} -- the sample size, the hazard-ratio
+value, the confidence interval, and the p-value / significance stars. The
+variable name, the level and the forest itself are always shown. Case-insensitive;
+order is ignored (the column positions are fixed). A dropped column reflows so a
+stacked partner re-centres and the p-value's reserved right margin is reclaimed;
+the default (all four) is unchanged. Note the reference-level label (\code{refLabel})
+is drawn in the \code{"hr"} column, so omitting \code{"hr"} also hides it.}
 
 \item{ggtheme}{a ggplot2 theme (e.g. the result of \code{theme(...)} or a
 complete theme) applied to the forest plot. Because \code{ggforest()}

--- a/tests/testthat/test-ggforest-columns.R
+++ b/tests/testthat/test-ggforest-columns.R
@@ -1,0 +1,54 @@
+# ggforest(columns=): choose which statistic columns show, reflowing the rest.
+# The default (all four) is unchanged.
+
+library(survival)
+
+.flabels <- function(p) {
+  gt <- grid::grid.force(ggplot2::ggplotGrob(p)); L <- character()
+  w <- function(g) {
+    if (inherits(g, "gTree") && !is.null(g$children))
+      for (n in names(g$children)) w(g$children[[n]])
+    if (!is.null(g$label)) L <<- c(L, as.character(g$label))
+  }
+  w(gt); L[nzchar(L)]
+}
+
+.m <- function() coxph(Surv(time, status) ~ age + factor(ph.ecog) + sex, data = lung)
+
+test_that("the default columns argument reproduces the default output", {
+  m <- .m()
+  expect_setequal(.flabels(ggforest(m, data = lung)),
+                  .flabels(ggforest(m, data = lung, columns = c("N", "hr", "ci", "p"))))
+})
+
+test_that("dropping a column removes exactly its labels", {
+  m <- .m()
+  all  <- .flabels(ggforest(m, data = lung))
+  noN  <- .flabels(ggforest(m, data = lung, columns = c("hr", "ci", "p")))
+  noP  <- .flabels(ggforest(m, data = lung, columns = c("N", "hr", "ci")))
+  # N labels look like "(N=138)"
+  expect_true(any(grepl("^\\(N=", all)))
+  expect_false(any(grepl("^\\(N=", noN)))
+  # p/stars labels contain significance stars or "<0.001"
+  expect_true(any(grepl("\\*|<0.001", all)))
+  expect_false(any(grepl("\\*|<0.001", noP)))
+})
+
+test_that("minimal columns keep the HR/CI and the reference indicator", {
+  m <- .m()
+  labs <- .flabels(ggforest(m, data = lung, columns = c("hr", "ci")))
+  expect_false(any(grepl("^\\(N=", labs)))     # no N
+  expect_true("reference" %in% labs)           # ref label kept (lives in hr column)
+  expect_true(any(grepl("^\\(", labs)))        # CI strings like "(1.02 - 2.23)"
+})
+
+test_that("columns is case-insensitive and validated", {
+  m <- .m()
+  expect_error(ggforest(m, data = lung, columns = c("HR", "P")), NA)  # OK
+  expect_error(ggforest(m, data = lung, columns = c("hr", "xyz")),
+               "Unknown `columns`")
+  expect_error(ggforest(m, data = lung, columns = character(0)), NA)  # legal minimal
+  # NULL means the default (all four), not "none"
+  expect_setequal(.flabels(ggforest(m, data = lung, columns = NULL)),
+                  .flabels(ggforest(m, data = lung)))
+})


### PR DESCRIPTION
`ggforest()` gains a `columns` argument to choose which statistic columns are shown — any subset of `c("N", "hr", "ci", "p")` (the variable name, level and forest are always drawn).

```r
library(survival)
m <- coxph(Surv(time, status) ~ age + factor(ph.ecog) + sex, data = lung)
ggforest(m, columns = c("hr", "ci"))   # compact: forest + HR (CI), no N/p
```

![ggforest with a minimal column set](https://i.imgur.com/eoCiDIq.png)

A dropped column reflows the rest: a stacked partner (level under N, HR value over CI) re-centres via its `vjust`, and the p-value column's reserved right margin is only added when the p column is shown — so nothing is left off-centre or as an empty band, and the forest's axis breaks are unchanged (a point at HR=2 stays on the "2" gridline). Input is case-insensitive and validated (`NULL` means the default).

The default (all four columns) is **byte-identical** to before, verified across the documented examples, `ref.display = FALSE`, moved `cpositions`, `palette`, `global.stats = FALSE`, `var.labels`, interaction/`I()`/`strata()`, and separated models.
