### PR TITLE
Cross-reference ggforest_models() from the univariate-Cox forest recipe

### DIFF
--- a/vignettes/Customization_recipes.Rmd
+++ b/vignettes/Customization_recipes.Rmd
@@ -428,6 +428,11 @@ multi-level factor contributes one row per level. Swap in a multivariable
 `ggforest(coxph(Surv(time, status) ~ ., data = ...))` when you want one adjusted
 model instead.
 
+A related but different question — the hazard ratio of *one* covariate across
+*several* models (e.g. crude vs. adjusted, or as covariates are added) — is
+answered directly by `ggforest_models()`, which puts one model per row for a
+single shared term.
+
 # Smooth parametric (survreg / Weibull) survival curves
 
 A `survreg()` accelerated-failure-time fit predicts a *smooth* survival curve;


### PR DESCRIPTION
The "Forest plot of several univariate Cox models" recipe in `Customization_recipes.Rmd` and the new `ggforest_models()` solve adjacent but distinct questions:

- the recipe: one *univariate* model per covariate, one row per coefficient;
- `ggforest_models()`: one *shared* term across several models, one row per model (crude vs. adjusted, etc.).

Add a one-sentence pointer at the end of the recipe so readers land on the right tool. Docs-only; no package code touched.