### PR TITLE
Add new functions to the pkgdown reference index and README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -55,40 +55,70 @@ The main functions, in the package, are organized in different categories as fol
 - **arrange_ggsurvplots**(): Arranges multiple ggsurvplots on the same page.
     
 - **ggsurvevents**(): Plots the distribution of event's times.
-     
+
+- **ggsurvparametric**(): Overlays a parametric (survreg or flexsurv) survival fit on the Kaplan-Meier curves.
+
 - **surv_summary**(): Summary of a survival curve. Compared to the default summary() function, surv_summary() creates a data frame containing a nice summary from survfit results.
-   
+
 - **surv_cutpoint**(): Determines the optimal cutpoint for one or multiple continuous variables at once. Provides a value of a cutpoint that correspond to the most significant relation with survival.
-    
-- **pairwise_survdiff**(): Multiple comparisons of survival curves. Calculate pairwise comparisons between group levels with corrections for multiple testing. 
-        
-<br/> 
-             
+
+- **surv_median_followup**(): Computes the median follow-up time by the reverse Kaplan-Meier method.
+
+- **pairwise_survdiff**(): Multiple comparisons of survival curves. Calculate pairwise comparisons between group levels with corrections for multiple testing.
+
+- **weighted_logrank**(): Weighted (Fleming-Harrington) log-rank tests for arbitrary early/late emphasis.
+
+<br/>
+
+**Modern effect measures**
+<hr/><br/>
+
+- **ggrmst**() / **ggrmst_difference**(): Restricted mean survival time (RMST) -- shades the area to a horizon tau and annotates the between-arm difference with its confidence interval and p-value.
+
+- **gglandmark**(): Landmark analysis -- re-origins the survival curves at a landmark time to avoid immortal-time (guarantee-time) bias.
+
+- **ggmilestone**(): Milestone (fixed-time) survival at one or more timepoints, with the between-arm difference, confidence interval and p-value.
+
+<br/>
+
  **Diagnostics of Cox Model**
-<hr/><br/> 
-   
+<hr/><br/>
+
 - **ggcoxzph**(): Graphical test of proportional hazards. Displays a graph of the scaled Schoenfeld residuals, along with a smooth curve using ggplot2. Wrapper around plot.cox.zph().
-   
+
 - **ggcoxdiagnostics**(): Displays diagnostics graphs presenting goodness of Cox Proportional Hazards Model fit.
-     
+
 - **ggcoxfunctional**(): Displays graphs of continuous explanatory variable against martingale residuals of null cox proportional hazards model. It helps to properly choose the functional form of continuous variable in cox model.
-     
-<br/>           
-     
+
+- **ggcoxnph**(): Non-proportional-hazards diagnostic panel (cloglog, scaled Schoenfeld with a time-varying-coefficient smooth, hazard-ratio trend and RMST difference).
+
+<br/>
+
 **Summary of Cox Model**
-<hr/><br/> 
+<hr/><br/>
 
 - **ggforest**(): Draws forest plot for CoxPH model.
-   
+
+- **ggforest_models**(): Forest plot comparing one covariate's hazard ratio across several Cox models (crude vs. adjusted).
+
+- **ggforest_subgroup**(): Subgroup forest plot -- the treatment hazard ratio within each subgroup, with the interaction (effect-modification) p-value.
+
 - **ggadjustedcurves**(): Plots adjusted survival curves for coxph model.
-   
+
 <br/>
 
 **Competing Risks**
-<hr/><br/> 
+<hr/><br/>
 
 - **ggcompetingrisks**(): Plots cumulative incidence curves for competing risks.
-    
+
+<br/>
+
+**Clinical trial data**
+<hr/><br/>
+
+- **surv_adtte**(): Prepares a CDISC ADaM time-to-event (ADTTE) dataset for analysis, deriving the event indicator from the CNSR flag (avoiding the silent censoring-flag inversion).
+
 <br/>
    
 > Find out more at https://rpkgs.datanovia.com/survminer/, and check out the documentation and usage examples of each of the functions in survminer package. 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ categories as follow.
 
 -   **ggsurvevents**(): Plots the distribution of event’s times.
 
+-   **ggsurvparametric**(): Overlays a parametric (survreg or flexsurv)
+    survival fit on the Kaplan-Meier curves.
+
 -   **surv_summary**(): Summary of a survival curve. Compared to the
     default summary() function, surv_summary() creates a data frame
     containing a nice summary from survfit results.
@@ -57,9 +60,33 @@ categories as follow.
     cutpoint that correspond to the most significant relation with
     survival.
 
+-   **surv_median_followup**(): Computes the median follow-up time by
+    the reverse Kaplan-Meier method.
+
 -   **pairwise_survdiff**(): Multiple comparisons of survival curves.
     Calculate pairwise comparisons between group levels with corrections
     for multiple testing.
+
+-   **weighted_logrank**(): Weighted (Fleming-Harrington) log-rank tests
+    for arbitrary early/late emphasis.
+
+<br/>
+
+**Modern effect measures**
+<hr/>
+
+<br/>
+
+-   **ggrmst**() / **ggrmst_difference**(): Restricted mean survival
+    time (RMST) — shades the area to a horizon tau and annotates the
+    between-arm difference with its confidence interval and p-value.
+
+-   **gglandmark**(): Landmark analysis — re-origins the survival curves
+    at a landmark time to avoid immortal-time (guarantee-time) bias.
+
+-   **ggmilestone**(): Milestone (fixed-time) survival at one or more
+    timepoints, with the between-arm difference, confidence interval and
+    p-value.
 
 <br/>
 
@@ -80,6 +107,10 @@ categories as follow.
     hazards model. It helps to properly choose the functional form of
     continuous variable in cox model.
 
+-   **ggcoxnph**(): Non-proportional-hazards diagnostic panel (cloglog,
+    scaled Schoenfeld with a time-varying-coefficient smooth,
+    hazard-ratio trend and RMST difference).
+
 <br/>
 
 **Summary of Cox Model**
@@ -88,6 +119,13 @@ categories as follow.
 <br/>
 
 -   **ggforest**(): Draws forest plot for CoxPH model.
+
+-   **ggforest_models**(): Forest plot comparing one covariate’s hazard
+    ratio across several Cox models (crude vs. adjusted).
+
+-   **ggforest_subgroup**(): Subgroup forest plot — the treatment hazard
+    ratio within each subgroup, with the interaction (effect-modification)
+    p-value.
 
 -   **ggadjustedcurves**(): Plots adjusted survival curves for coxph
     model.
@@ -101,6 +139,17 @@ categories as follow.
 
 -   **ggcompetingrisks**(): Plots cumulative incidence curves for
     competing risks.
+
+<br/>
+
+**Clinical trial data**
+<hr/>
+
+<br/>
+
+-   **surv_adtte**(): Prepares a CDISC ADaM time-to-event (ADTTE)
+    dataset for analysis, deriving the event indicator from the CNSR
+    flag (avoiding the silent censoring-flag inversion).
 
 <br/>
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -14,52 +14,66 @@ copy:
 
 reference:
   - title: Fit survival curves
-    desc: Fit survival curves and compute p-values as well as median survival times.
+    desc: Fit survival curves and compute p-values, median survival and median follow-up.
     contents:
       - surv_group_by
       - surv_fit
+      - surv_summary
       - surv_median
+      - surv_median_followup
       - surv_pvalue
-  - title: Survival Curves
-    desc:  Summarize and visualize survival curves.
+      - weighted_logrank
+      - pairwise_survdiff
+      - surv_cutpoint
+  - title: Visualize survival curves
+    desc: Summarize and visualize Kaplan-Meier survival curves.
     contents:
       - ggsurvplot
+      - ggsurvplot_facet
+      - ggsurvplot_combine
+      - ggsurvplot_group_by
+      - ggsurvplot_add_all
+      - ggsurvplot_df
+      - ggsurvplot_list
       - ggflexsurvplot
+      - ggsurvparametric
       - arrange_ggsurvplots
       - ggsurvevents
-      - surv_summary
-      - surv_cutpoint
-      - pairwise_survdiff
-  - title: Diagnostics of Cox Model
+  - title: Modern methods
+    desc: RMST, landmark, milestone and competing-risks summaries reviewers now expect.
+    contents:
+      - ggrmst_difference
+      - gglandmark
+      - ggmilestone
+      - ggcompetingrisks
+  - title: Cox model summary and forest plots
+    contents:
+      - ggforest
+      - ggforest_models
+      - ggforest_subgroup
+      - ggadjustedcurves
+  - title: Diagnostics of Cox model
     contents:
       - ggcoxdiagnostics
       - ggcoxfunctional
       - ggcoxzph
-  - title: Summary of Cox Model
+      - ggcoxnph
+  - title: Clinical trial data
+    desc: Prepare CDISC ADaM time-to-event (ADTTE) data for analysis.
     contents:
-      - ggforest
-      - ggadjustedcurves
-  - title: Competing Risks
-    contents:
-      - ggcompetingrisks
-  - title: Helpers
+      - surv_adtte
+  - title: Tables, themes and helpers
     contents:
       - ggsurvtable
-      - ggsurvplot_df
-      - ggsurvplot_list
-      - ggsurvplot_group_by
-      - ggsurvplot_add_all
-      - ggsurvplot_combine
-      - ggsurvplot_facet
+      - customize_labels
+      - build_ggsurvplot
+      - add_ggsurvplot
+      - ggsurvplot_arguments
+      - theme_survminer
   - title: Data
     contents:
       - myeloma
       - BMT
-  - title: Others
-    contents:
-      - theme_survminer
-      - add_ggsurvplot
-      - ggsurvplot_arguments
       - BRCAOV.survInfo
 
 


### PR DESCRIPTION
The pkgdown reference index and the README function list predated the recent function additions, so several exported functions were invisible on the reference page and the README.

- Reference index (`_pkgdown.yml`) regrouped into clearer sections and now lists every exported function: `ggrmst()`/`ggrmst_difference()`, `gglandmark()`, `ggmilestone()`, `ggforest_models()`, `ggforest_subgroup()`, `ggcoxnph()`, `ggsurvparametric()`, `surv_adtte()`, `surv_median_followup()`, `weighted_logrank()`.
- README function list updated to match, with new "Modern effect measures" and "Clinical trial data" categories.

Docs-only; no package code touched.