### PR TITLE
Group the pkgdown articles into Get started, Methods and Customization

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -77,6 +77,29 @@ reference:
       - BRCAOV.survInfo
 
 
+articles:
+  - title: Get started
+    navbar: Get started
+    contents:
+      - Get_started
+  - title: Methods
+    navbar: Methods
+    desc: The survival summaries a manuscript reports.
+    contents:
+      - Effect_measures
+      - Cox_forests_diagnostics
+      - Competing_risks
+      - Specifiying_weights_in_log-rank_comparisons
+  - title: Customization and examples
+    navbar: Customization
+    desc: Tune the look and compose on the objects survminer returns.
+    contents:
+      - Customization_recipes
+      - Playing_with_fonts_and_texts
+      - ggforest-show-interactions-hazard-ratio
+      - Informative_Survival_Plots
+
+
 navbar:
   title: "survminer"
   left:


### PR DESCRIPTION
The pkgdown articles index was in filename order. Add an `articles:` section grouping the vignettes so readers find their way:

- **Get started** — the onboarding tour.
- **Methods** — absolute effect measures, interrogating a Cox model, competing risks, weighted log-rank.
- **Customization and examples** — the recipes, fonts/text, ggforest interactions, and the older showcase.

Config-only; validated that every vignette is listed exactly once.