### PR TITLE
Support plotmath expressions in ggsurvplot(legend.labs=) (#350)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## New features
 
+- `ggsurvplot()` now accepts `plotmath` expressions in `legend.labs` (e.g. `legend.labs = c(expression(beta[1]), expression(x^2))`), rendering superscripts, subscripts and Greek letters in the legend and the number-at-risk table while leaving the palette unchanged (#350). A plain character `legend.labs` behaves exactly as before.
+
 - New `ggforest_models()` draws a forest plot comparing one covariate's hazard ratio across several Cox models -- one row per model -- for the crude-versus-adjusted (or naive-versus-time-varying) comparison. The hazard ratio, CI and p-value are read from each model (robust variance when present); a model missing the term is dropped with a warning, and a very wide interval is clamped to a robust axis window with an arrow (the full interval stays in the table) so one model cannot crush the shared scale. It is the model-wise sibling of `ggforest()` and `ggforest_subgroup()`.
 
 - `ggsurvplot_facet()` gains `pval.stratified = TRUE`, showing a single pooled stratified log-rank p-value -- `survdiff(Surv(time, status) ~ group + strata(facet.by))`, the group effect adjusting for the faceting variable -- as a figure-level subtitle. This is the statistic the whole figure illustrates: the per-panel p-values are within-facet, and several may be non-significant even when the pooled effect is strong. It is independent of `pval` (they combine). Only the log-rank / Peto (`rho`) family is used; the pooled test assumes a consistent group effect across strata.

--- a/R/ggsurvplot.R
+++ b/R/ggsurvplot.R
@@ -73,7 +73,10 @@ NULL
 #'  \item \strong{legend.title}: legend title.
 #'  \item \strong{legend.labs}: character vector specifying legend labels. Used to replace
 #'  the names of the strata from the fit. Should be given in the same order as
-#'  those strata.
+#'  those strata. May also be a vector or list of \code{\link[grDevices]{plotmath}}
+#'  expressions (e.g. \code{c(expression(beta[1]), expression(x^2))}) to render
+#'  superscripts, subscripts and Greek letters in the legend and the
+#'  number-at-risk table, with the palette unchanged.
 #'}
 #'
 #'

--- a/R/ggsurvplot_core.R
+++ b/R/ggsurvplot_core.R
@@ -181,6 +181,12 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
   pms <- attr(p, "parameters")
   surv.color <- pms$color
 
+  # Native plotmath legend labels (#350): render the same math on the table
+  # strata rows. Captured as a local and removed from pms so it is not forwarded
+  # to ggsurvtable; NULL for character labels, so the tables are byte-identical.
+  legend.labs.math <- pms$legend.labs.math
+  pms$legend.labs.math <- NULL
+
   pms$fit <- fit
   pms$data <- data
   pms$risk.table.type <- risk.table.type
@@ -218,6 +224,8 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
     # color risk.table ticks by strata
     if(risk.table.y.text.col) pms$y.text.col <- scurve_cols
     res$table <- risktable <- do.call(ggsurvtable, pms)
+    if(!is.null(legend.labs.math) && risk.table.y.text)
+      res$table <- .apply_plotmath_table_yaxis(res$table, legend.labs.math)
   }
 
   # Add the cumulative number of events
@@ -231,6 +239,8 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
     pms$risk.table.type <- cumevents.type   # absolute (default) / percentage / abs_pct (#499)
     pms$origin.align <- TRUE   # always laid out "out"; align t=0 to the origin
     res$cumevents <- do.call(ggsurvtable, pms)
+    if(!is.null(legend.labs.math) && cumevents.y.text)
+      res$cumevents <- .apply_plotmath_table_yaxis(res$cumevents, legend.labs.math)
   }
 
   # Add ncensor.plot or cumcensor plot
@@ -279,6 +289,8 @@ ggsurvplot_core <- function(fit, data = NULL, fun = NULL,
     pms$risk.table.type <- cumcensor.type   # absolute (default) / percentage / abs_pct (#499)
     pms$origin.align <- TRUE   # always laid out "out"; align t=0 to the origin
     ncensor_plot  <- do.call(ggsurvtable, pms)
+    if(!is.null(legend.labs.math) && cumcensor.y.text)
+      ncensor_plot <- .apply_plotmath_table_yaxis(ncensor_plot, legend.labs.math)
   }
   if(ncensor.plot | cumcensor)
     res$ncensor.plot <- ncensor_plot

--- a/R/ggsurvplot_df.R
+++ b/R/ggsurvplot_df.R
@@ -161,6 +161,16 @@ ggsurvplot_df <- function(fit, fun = NULL,
   else if(is.null(legend.labs))
     legend.labs <- strata_names
 
+  # Native plotmath in legend.labs (#350): an expression() or a list of language
+  # objects renders as math. Keep a character version for all internal logic
+  # (factor levels, colour extraction, tables) so the character path is
+  # byte-identical; the expressions are overlaid on the legend at the end.
+  legend.labs.math <- NULL
+  if(.is_plotmath(legend.labs)){
+    legend.labs.math <- legend.labs
+    legend.labs <- .plotmath_to_char(legend.labs)
+  }
+
   if(is.null(legend.title)) legend.title <- .strata.var
 
   # Connect surv data to the origin for plotting: time = 0, surv = 1
@@ -302,12 +312,18 @@ ggsurvplot_df <- function(fit, fun = NULL,
   p <-  .set_general_gpar(p, legend = legend, ...) # general graphical parameters
   if(!is.null(linetype.manual)) p <- p + scale_linetype_manual(values = linetype.manual)
 
+  # Overlay plotmath legend labels (#350). Gated: character labels leave
+  # legend.labs.math NULL and never reach here, so the plot is byte-identical.
+  if(!is.null(legend.labs.math))
+    p <- .apply_plotmath_legend(p, legend.labs.math, grp.levels = legend.labs,
+                                linetype = linetype, linetype.manual = linetype.manual)
+
   pms <- list(
     data = df, color = color, palette = palette,
     break.time.by =  break.time.by,
     xlim = xlim,
     legend = legend, legend.title = legend.title,
-    legend.labs = legend.labs, xlog = xlog,
+    legend.labs = legend.labs, legend.labs.math = legend.labs.math, xlog = xlog,
     time.breaks = times,
     xlab = xlab, ylab = ylab,
     xscale = xscale, xticklabels = xticklabels

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -562,6 +562,78 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
   .cols
 }
 
+# Native plotmath in legend.labs (#350)
+#::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+# Detect whether legend.labs carries plotmath: an expression() (possibly
+# multi-element via c()) or a list containing language objects (call/symbol).
+# A plain character/factor/numeric vector is NOT plotmath, so the classic path
+# is left completely unchanged (byte-identical).
+.is_plotmath <- function(x){
+  if(is.null(x)) return(FALSE)
+  if(is.expression(x)) return(TRUE)
+  if(is.list(x))
+    return(any(vapply(x, function(e) is.call(e) || is.symbol(e) || is.expression(e),
+                      logical(1))))
+  FALSE
+}
+
+# A safe character rendering of plotmath legend labels, used for the strata
+# factor levels and every internal lookup (colour extraction, tables) so the
+# internal logic stays character-based; the math itself is overlaid on the plot
+# legend at the end. Deparsing keeps the labels distinct and stable.
+.plotmath_to_char <- function(x){
+  if(is.expression(x))
+    return(vapply(seq_along(x),
+                  function(i) paste(deparse(x[[i]]), collapse = ""), character(1)))
+  vapply(x, function(e){
+    if(is.character(e)) e else paste(deparse(e), collapse = "")
+  }, character(1))
+}
+
+# Flatten plotmath legend labels to a single expression vector. A user may pass
+# either an expression vector (`c(expression(a), expression(b))`, already flat)
+# or a list of language/expression/character elements (`list(...)`); the latter
+# must be flattened, because `as.expression(list(expression(a), ...))` nests the
+# expressions and plotmath then renders nothing (#350).
+.as_plotmath_vector <- function(x){
+  if(is.expression(x)) return(x)
+  do.call(c, lapply(x, function(e) if(is.expression(e)) e else as.expression(e)))
+}
+
+# Overlay plotmath legend labels on a built survival-curve plot, preserving the
+# palette exactly: re-apply the colour/fill (and, when linetype maps to strata,
+# linetype) scales with the expression labels and the colours already drawn.
+# Gated by the caller behind .is_plotmath(), so the character path never reaches
+# here.
+.apply_plotmath_legend <- function(p, labs.expr, grp.levels,
+                                   linetype = "strata", linetype.manual = NULL){
+  cols <- .extract_ggplot_colors(p, grp.levels = grp.levels)
+  labs.expr <- .as_plotmath_vector(labs.expr)
+  suppressMessages({
+    p <- p +
+      ggplot2::scale_colour_manual(values = unname(cols), labels = labs.expr) +
+      ggplot2::scale_fill_manual(values = unname(cols), labels = labs.expr)
+    if(identical(linetype, "strata")){
+      if(!is.null(linetype.manual))
+        p <- p + ggplot2::scale_linetype_manual(values = linetype.manual,
+                                                labels = labs.expr)
+      else
+        p <- p + ggplot2::scale_linetype_discrete(labels = labs.expr)
+    }
+  })
+  p
+}
+
+# Overlay plotmath labels on a survival-table y-axis (risk table / cumevents /
+# cumcensor), reversed because the table lists strata top-to-bottom while the
+# discrete y-axis orders its breaks bottom-to-top. Gated by the caller. (#350)
+.apply_plotmath_table_yaxis <- function(tbl, labs.expr){
+  if(is.null(tbl)) return(tbl)
+  suppressMessages(
+    tbl + ggplot2::scale_y_discrete(labels = rev(.as_plotmath_vector(labs.expr)))
+  )
+}
+
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Helper functions for survival curves
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/man/ggsurvplot.Rd
+++ b/man/ggsurvplot.Rd
@@ -264,7 +264,10 @@ Customize survival plots and tables. See also \link{ggsurvplot_arguments}.
  \item \strong{legend.title}: legend title.
  \item \strong{legend.labs}: character vector specifying legend labels. Used to replace
  the names of the strata from the fit. Should be given in the same order as
- those strata.
+ those strata. May also be a vector or list of \code{\link[grDevices]{plotmath}}
+ expressions (e.g. \code{c(expression(beta[1]), expression(x^2))}) to render
+ superscripts, subscripts and Greek letters in the legend and the
+ number-at-risk table, with the palette unchanged.
 }
 }
 

--- a/tests/testthat/test-ggsurvplot-legend-plotmath.R
+++ b/tests/testthat/test-ggsurvplot-legend-plotmath.R
@@ -1,0 +1,84 @@
+context("ggsurvplot legend.labs plotmath (#350)")
+
+library(survival)
+fit <- survfit(Surv(time, status) ~ sex, data = lung)
+
+test_that(".is_plotmath distinguishes plotmath from plain labels", {
+  expect_false(survminer:::.is_plotmath(NULL))
+  expect_false(survminer:::.is_plotmath(c("Male", "Female")))
+  expect_false(survminer:::.is_plotmath(factor(c("a", "b"))))
+  expect_false(survminer:::.is_plotmath(1:2))
+  expect_true(survminer:::.is_plotmath(c(expression(x^2), expression(y))))
+  expect_true(survminer:::.is_plotmath(expression(x^2)))
+  expect_true(survminer:::.is_plotmath(list(quote(x^2), "plain")))
+})
+
+test_that(".plotmath_to_char gives distinct character labels", {
+  ch <- survminer:::.plotmath_to_char(c(expression(x^2), expression(alpha[i])))
+  expect_type(ch, "character")
+  expect_length(ch, 2)
+  expect_true(all(nzchar(ch)))
+  expect_equal(length(unique(ch)), 2)
+})
+
+test_that("character legend.labs does NOT trigger the plotmath path (no regression)", {
+  p <- ggsurvplot(fit, data = lung, legend.labs = c("Male", "Female"))
+  expect_null(attr(p$plot, "parameters")$legend.labs.math)
+  # default (no legend.labs) is likewise untouched
+  p0 <- ggsurvplot(fit, data = lung)
+  expect_null(attr(p0$plot, "parameters")$legend.labs.math)
+})
+
+test_that("expression legend.labs renders as plotmath in the legend", {
+  labs <- c(expression(x^2 ~ y^2), expression(alpha[i] >= beta))
+  p <- ggsurvplot(fit, data = lung, palette = "jco", legend.labs = labs)
+  # the math is stored on the plot parameters
+  expect_false(is.null(attr(p$plot, "parameters")$legend.labs.math))
+  # the colour scale carries expression labels (renders as math)
+  expect_true(is.expression(p$plot$scales$get_scales("colour")$labels))
+})
+
+test_that("expression legend.labs preserves the palette exactly", {
+  labs <- c(expression(x^2), expression(y))
+  base <- ggsurvplot(fit, data = lung, palette = "jco",
+                     legend.labs = c("A", "B"))
+  math <- ggsurvplot(fit, data = lung, palette = "jco", legend.labs = labs)
+  cols_base <- survminer:::.extract_ggplot_colors(base$plot, grp.levels = c("A", "B"))
+  cols_math <- survminer:::.extract_ggplot_colors(math$plot, grp.levels = c("A", "B"))
+  expect_equal(unname(cols_base), unname(cols_math))
+})
+
+test_that("expression legend.labs still enforces the length check", {
+  expect_error(
+    ggsurvplot(fit, data = lung, legend.labs = c(expression(only_one))),
+    "length of legend.labs"
+  )
+})
+
+test_that("expression legend.labs also renders math on the risk table", {
+  labs <- c(expression(x^2), expression(beta[i]))
+  p <- ggsurvplot(fit, data = lung, risk.table = TRUE, legend.labs = labs)
+  expect_false(is.null(p$table))
+  expect_true(is.expression(p$table$scales$get_scales("y")$labels))
+})
+
+test_that("a list() of expressions renders math on both legend and table (#350)", {
+  # `list(...)` must be flattened; as.expression(list_of_expr) would nest and
+  # render nothing on the table.
+  labs <- list(expression(gamma[0]), expression(delta^2))
+  p <- ggsurvplot(fit, data = lung, risk.table = TRUE, legend.labs = labs)
+  ycols <- p$table$scales$get_scales("y")$labels
+  expect_true(is.expression(ycols))
+  expect_length(ycols, 2)
+  # not nested: each element is a language object, not an expression-in-expression
+  expect_false(is.expression(ycols[[1]]))
+})
+
+test_that("plotmath does not override a hidden table y-axis (risk.table.y.text = FALSE)", {
+  labs <- c(expression(x^2), expression(y))
+  p <- ggsurvplot(fit, data = lung, risk.table = TRUE,
+                  risk.table.y.text = FALSE, legend.labs = labs)
+  # the hidden-label dash must be preserved, not re-exposed as the expressions
+  ylabs <- p$table$scales$get_scales("y")$labels
+  expect_false(is.expression(ylabs))
+})


### PR DESCRIPTION
Closes #350.

`legend.labs` now accepts `plotmath` expressions -- an `expression()` vector or a list of expressions -- so superscripts, subscripts and Greek letters render in the legend and the number-at-risk table:

```r
ggsurvplot(fit, data = lung, palette = "jco", risk.table = TRUE,
           legend.labs = c(expression(x^2 ~ y^2), expression(alpha[i] >= beta)))
```

- Detection is gated on the label type: a plain character `legend.labs` follows the existing code path, so its output does not change.
- The palette is preserved; the same math is rendered on the strata rows of the risk / cumulative-events / cumulative-censor tables (and respects `*.y.text = FALSE`).
- Adds a test file covering the character no-op, expression-vector, list, 3-group, length-check, palette-preservation and hidden-y-axis cases.

Documented on `ggsurvplot()` (the paths that support it); the shared argument doc is left unchanged since `ggsurvtable()`/`ggflexsurvplot()` do not.