### PR TITLE
Drop redundant data(lung) call in test-surv_pvalue

### DIFF
--- a/tests/testthat/test-surv_pvalue.R
+++ b/tests/testthat/test-surv_pvalue.R
@@ -1,7 +1,6 @@
 context("surv_pvalue")
 
 library(survival)
-data(lung)
 
 # Basic 2-group fit
 fit_sex <- survfit(Surv(time, status) ~ sex, data = lung)


### PR DESCRIPTION
`survival` >= 3.x lazy-loads its datasets, so `lung` is already available after `library(survival)`. The explicit `data(lung)` now emits a "data set 'lung' not found" warning under survival 3.8.3 (the only warning in the test suite). Removing the line silences it; the data is unchanged and the suite stays green (FAIL 0, WARN 0).