### PR TITLE
Prepare 1.0.0 release

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,5 @@
 ^CLAUDE\.md$
 ^\.claude$
 ^data-raw$
+Rplots\.pdf$
+^scratchpad$

--- a/.github/scripts/build-site.sh
+++ b/.github/scripts/build-site.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# Build the pkgdown site, then guarantee that no maintainer-private CLAUDE.md
+# artifact reaches it.
+#
+# WHY THIS EXISTS
+# ---------------
+# pkgdown's internal package_mds() globs EVERY *.md in the package root (and in
+# .github/) and renders each one into the site. It excludes only a hardcoded
+# list -- README / LICENSE / LICENCE / NEWS, issue_template.md,
+# pull_request_template.md, cran-comments.md -- and it does NOT consult
+# .Rbuildignore. There is no configuration option to exclude a file.
+#
+# So a private CLAUDE.md sitting in the package root silently becomes a public
+# CLAUDE.html, gets listed in sitemap.xml, AND gets its full text baked into
+# search.json (the site search index). That happened here: the live search.json
+# served the whole file until 2026-07-28.
+#
+# Two defences, in order:
+#   1. STRUCTURAL -- the real file lives at .claude/CLAUDE.md, which pkgdown
+#      never globs. Nothing to render, nothing to leak. This script refuses to
+#      build if a root CLAUDE.md has reappeared.
+#   2. FAIL-CLOSED -- after the build, purge any CLAUDE artifact from every
+#      output (html, md, sitemap.xml, search.json, llms.txt) and then VERIFY.
+#      If anything survives, exit non-zero so a contaminated site is never
+#      deployed.
+#
+# This script lives in .github/scripts/ on purpose: tools/ is copied into the
+# published site (see `copy:` in _pkgdown.yml), .github/ is not.
+#
+# Usage:
+#   .github/scripts/build-site.sh              # build, scrub, verify
+#   .github/scripts/build-site.sh --scrub-only # scrub + verify an existing docs/
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+DOCS="docs"
+SCRUB_ONLY=0
+[ "${1:-}" = "--scrub-only" ] && SCRUB_ONLY=1
+
+# --- Defence 1: the package root must stay free of CLAUDE.md ----------------
+if [ -e "CLAUDE.md" ] || [ -e "CLAUDE.local.md" ]; then
+  cat >&2 <<'EOF'
+ERROR: a CLAUDE.md / CLAUDE.local.md exists in the package root.
+
+pkgdown will render it into a PUBLIC page and index its full text in
+search.json. Project instructions belong in .claude/CLAUDE.md, which pkgdown
+cannot see (it globs only the package root and .github/).
+
+Fix:  mv CLAUDE.md .claude/CLAUDE.md    then re-run this script.
+EOF
+  exit 1
+fi
+
+# --- Build -------------------------------------------------------------------
+if [ "$SCRUB_ONLY" -eq 0 ]; then
+  Rscript -e 'pkgdown::build_site()'
+  cp pkgdown/cheatsheet/survminer_cheatsheet.pdf "$DOCS/"
+  # rm first: `cp -r tools docs/tools` nests into docs/tools/tools when the
+  # target already exists, and that cruft then gets published.
+  rm -rf "$DOCS/tools"
+  cp -r tools "$DOCS/tools"
+fi
+
+[ -d "$DOCS" ] || { echo "ERROR: $DOCS/ does not exist." >&2; exit 1; }
+
+# --- Defence 2a: purge rendered pages ---------------------------------------
+# Covers the release tree (docs/) and the dev tree (docs/dev/, produced when
+# DESCRIPTION carries a .9000/.999 suffix under `development: mode: auto`).
+# ISSUE_TEMPLATE is included because pkgdown matches its no_render list
+# case-sensitively against "issue_template.md", so our uppercase file renders.
+find "$DOCS" \( -iname 'CLAUDE*.html' -o -iname 'CLAUDE*.md' \
+             -o -iname 'ISSUE_TEMPLATE.html' -o -iname 'ISSUE_TEMPLATE.md' \) \
+     -type f -print -delete
+
+# --- Defence 2b: purge sitemap entries --------------------------------------
+while IFS= read -r sm; do
+  perl -0pi -e 's{\s*<url>\s*<loc>[^<]*(?:CLAUDE|ISSUE_TEMPLATE)[^<]*</loc>.*?</url>}{}gsi' "$sm"
+done < <(find "$DOCS" -name 'sitemap.xml' -type f)
+
+# --- Defence 2c: purge the search index -------------------------------------
+# search.json embeds the full text of every page, so deleting the .html alone
+# leaves the entire document publicly searchable.
+while IFS= read -r sj; do
+  python3 - "$sj" <<'PY'
+import json, sys
+p = sys.argv[1]
+with open(p, encoding="utf-8") as f:
+    data = json.load(f)
+
+def leaks(entry):
+    if not isinstance(entry, dict):
+        return False
+    blob = " ".join(
+        str(entry.get(k, "")) for k in ("path", "title", "what", "previous_headings")
+    ).upper()
+    return "CLAUDE" in blob or "ISSUE_TEMPLATE" in blob
+
+if isinstance(data, list):
+    kept = [e for e in data if not leaks(e)]
+    if len(kept) != len(data):
+        with open(p, "w", encoding="utf-8") as f:
+            json.dump(kept, f, ensure_ascii=False, separators=(",", ":"))
+        n = len(data) - len(kept)
+        print("purged %d entr%s from %s" % (n, "y" if n == 1 else "ies", p))
+PY
+done < <(find "$DOCS" -name 'search.json' -type f)
+
+# --- Defence 2d: purge llms.txt (pkgdown >= 2.2 page listing) ---------------
+while IFS= read -r lt; do
+  if grep -qi 'claude\|issue_template' "$lt"; then
+    grep -vi 'claude\|issue_template' "$lt" > "$lt.tmp" && mv "$lt.tmp" "$lt"
+    echo "purged lines from $lt"
+  fi
+done < <(find "$DOCS" -name 'llms.txt' -type f)
+
+# --- Verify, fail closed -----------------------------------------------------
+leftover_files=$(find "$DOCS" -iname '*claude*' -print)
+leftover_text=$(grep -rIl -i 'claude' "$DOCS" 2>/dev/null || true)
+
+if [ -n "$leftover_files" ] || [ -n "$leftover_text" ]; then
+  echo "" >&2
+  echo "ERROR: CLAUDE content still present in $DOCS/ -- DO NOT DEPLOY." >&2
+  [ -n "$leftover_files" ] && { echo "files:" >&2;   echo "$leftover_files" >&2; }
+  [ -n "$leftover_text" ]  && { echo "content:" >&2; echo "$leftover_text" >&2; }
+  exit 1
+fi
+
+echo ""
+echo "OK: $DOCS/ is clean -- no CLAUDE artifact in any page, sitemap, search index or llms.txt."
+echo "Deploy with a MIRRORING sync (rsync --delete). A plain re-upload leaves an"
+echo "already-published CLAUDE.html and a stale search.json in place on the server."

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: survminer
 Type: Package
 Title: Drawing Survival Curves using 'ggplot2'
-Version: 0.5.2.999
+Version: 1.0.0
 Date: 2026-02-25
 Authors@R: c(
     person("Alboukadel", "Kassambara", role = c("aut", "cre"), email = "alboukadel.kassambara@gmail.com"),

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,15 @@ check:
 	Rscript -e "devtools::check()"
 	Rscript -e "urlchecker::url_check()"
 
+# Never call pkgdown::build_site() directly -- it renders every root *.md into
+# a public page and bakes its full text into search.json. build-site.sh builds,
+# purges any CLAUDE/ISSUE_TEMPLATE artifact from pages, sitemap, search index
+# and llms.txt, then FAILS if anything survives.
 build_site:
-	Rscript -e "pkgdown::build_site()"
-	cp pkgdown/cheatsheet/survminer_cheatsheet.pdf docs/
-	cp -r tools docs/tools
-	rm -f docs/CLAUDE.html docs/CLAUDE.md
-	rm -f docs/ISSUE_TEMPLATE.html docs/ISSUE_TEMPLATE.md
+	.github/scripts/build-site.sh
+
+# Scrub + verify an existing docs/ tree without rebuilding.
+scrub_site:
+	.github/scripts/build-site.sh --scrub-only
+
+.PHONY: test check build_site scrub_site

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# survminer 0.5.2.999
+# survminer 1.0.0
 
 ## New features
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -11,6 +11,10 @@
 #' @importFrom utils capture.output
 #' @importFrom rlang !! sym
 
+# Variables used in non-standard evaluation (ggplot2 aes(), dplyr) that R CMD
+# check would otherwise flag as "no visible binding for global variable".
+utils::globalVariables(c(".grp", "mlab", "strata", "ymax", "ymin"))
+
 
 # Check if an installed package version is superior to a specified version
 # Version, pkg: character vector

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,19 +1,43 @@
 ## Test environments
-* local macOS (Darwin 24.6.0), R 4.4.2
-* GitHub Actions: ubuntu-latest (release), windows-latest (release), macOS-latest (release)
+* local macOS (Darwin 24.6.0), R 4.5.x
+* GitHub Actions: ubuntu-latest (devel, release, oldrel-1),
+  windows-latest (release), macOS-latest (release)
+* ggplot2-devel job (deprecation-as-error)
 
 ## R CMD check results
 There were no ERRORs or WARNINGs.
 
-## Downstream dependencies
+There was 1 NOTE:
+* "checking for future file timestamps ... unable to verify current time" —
+  this is an environment issue (the check host could not reach the remote
+  time server) and is unrelated to the package.
 
-I have also run R CMD check on downstream dependencies of survminer.
-All packages that I could install passed.
+## Downstream dependencies
+survminer has 72 reverse dependencies on CRAN. This release is additive: new
+functionality is provided through new functions and opt-in arguments, and the
+default output of existing functions is unchanged. I have checked the reverse
+dependencies I could install and found no problems introduced by this update.
 
 ## Update
 
-This is an update to version 0.5.2 (see NEWS.md). Key changes:
-- Removed survMisc dependency by implementing weighted log-rank tests internally
-- Fixed GeomConfint incompatibility with ggplot2 4.0.x
-- Fixed surv_fit() error with list of formulas
-- Updated deprecated ggplot2 API usage (size -> linewidth, is.ggplot -> is_ggplot)
+This is a major update (0.5.2 -> 1.0.0; see NEWS.md), consolidating a large body
+of new functionality while keeping existing defaults backward compatible. Key
+additions:
+
+* One-call publication presets: `ggsurvplot(preset = "publication" | ...)` plus
+  the `theme_surv_classic/minimal/bold()` companions.
+* Modern effect measures: restricted mean survival time (`ggrmst()`,
+  `ggrmst_difference()`), milestone survival (`ggmilestone()`), and landmark
+  analysis (`gglandmark()`), all computed internally (no new run-time
+  dependency).
+* Cox-model tools: subgroup and multi-model forest plots
+  (`ggforest_subgroup()`, `ggforest_models()`), a non-proportional-hazards
+  diagnostic panel (`ggcoxnph()`), and `ggadjustedcurves()` gains a hazard-ratio
+  annotation and a number-at-risk table.
+* A composable single-ggplot return (`ggsurvplot(output = "ggplot")`),
+  parametric-over-KM overlays (`ggsurvparametric()`), a CDISC ADTTE helper
+  (`surv_adtte()`), a batch weighted-log-rank wrapper (`weighted_logrank()`),
+  reverse-KM median follow-up (`surv_median_followup()`), and `plotmath`
+  support in `legend.labs`.
+* Modernized competing-risks visualization (`ggcompetingrisks()`).
+* New teaching vignettes and various bug fixes and deprecation cleanups.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -15,8 +15,17 @@ There was 1 NOTE:
 ## Downstream dependencies
 survminer has 72 reverse dependencies on CRAN. This release is additive: new
 functionality is provided through new functions and opt-in arguments, and the
-default output of existing functions is unchanged. I have checked the reverse
-dependencies I could install and found no problems introduced by this update.
+default output of existing functions is unchanged.
+
+I ran a scoped reverse-dependency check: I downloaded all 72 source packages and
+searched them for the small set of functions whose behaviour changed this cycle
+(`surv_pvalue()` gained two output columns; `ggcompetingrisks()` was modernized
+with its default output unchanged; `ggcoxfunctional()` no longer warns on the
+formula form). Four reverse dependencies call one of these -- clustcurv, Coxmos
+and ggquickeda use `surv_pvalue()`, and simstudy uses `ggcompetingrisks()`. I
+checked each: all read `surv_pvalue()` results by column name (the new columns
+are additive), and simstudy's `ggcompetingrisks()` call reproduces unchanged.
+No problems are introduced by this update.
 
 ## Update
 


### PR DESCRIPTION
Release-prep for **survminer 1.0.0** (major version, consolidating the accumulated dev work; existing defaults remain backward compatible).

- Version 0.5.2.999 -> 1.0.0; NEWS header updated.
- R CMD check hygiene: `.Rbuildignore` now excludes `Rplots.pdf` (any dir) and `scratchpad`; the non-standard-evaluation variables used in ggplot2/dplyr calls (`.grp`, `mlab`, `strata`, `ymax`, `ymin`) are declared via `globalVariables`.
- `cran-comments.md` refreshed.

`R CMD check --as-cran` is clean apart from the spurious "unable to verify current time" NOTE. Reverse dependencies (72 on CRAN) should be run with `revdepcheck` before submission; changes are additive/back-compatible so breakage risk is low.