### PR TITLE
Take the effect-measure groups from the fit's own strata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,14 +22,27 @@
   (guarantee-time) bias when groups are defined by a post-baseline status. A subject
   whose event falls exactly on `L` is excluded so the re-origined curve correctly
   starts at S = 1, and any requested log-rank p-value or risk table is computed on
-  the landmark cohort.
+  the landmark cohort. The landmark fit keeps the grouping term as written, so a
+  transformed right-hand side such as `~ (age > 60)` gives its two strata, and the
+  re-origined time and status are stored in columns that cannot collide with a
+  column of the same name in your data.
 
 - New `ggmilestone()` annotates milestone (fixed-time) survival: `S(t)` at one or
   more clinical timepoints with its confidence interval and, for a two-arm
   comparison, the between-arm difference with confidence interval and p-value
   (three or more arms via `ref.group`). A milestone beyond an arm's follow-up is
   returned as `NA` with a warning rather than silently dropped, and the full
-  milestone table is attached as `attr(x$plot, "milestone.table")`.
+  milestone table is attached as `attr(x$plot, "milestone.table")`. For two arms the
+  difference is the second arm minus the first, matching `ggrmst_difference()`, and
+  every difference row is labelled with its contrast. Arms are read from the fit's
+  own strata, so the labels and their order match `names(fit$strata)` and the plotted
+  curves.
+
+- `ggrmst()`, `ggrmst_difference()`, `ggmilestone()`, `gglandmark()` and
+  `surv_median_followup()` refuse a weighted `survfit()` with a clear message. These
+  summaries read the risk and event counts off the curve, and the confidence-interval
+  convention for weighted data (case weights vs sampling weights) is not determined by
+  the fit, so an interval reported for one could not be relied on.
 
 - New `surv_adtte()` prepares a CDISC ADaM time-to-event dataset (ADTTE) for
   analysis. ADTTE codes the censoring flag `CNSR` as 0 = event and >= 1 = censored
@@ -107,7 +120,8 @@
   reverse Kaplan-Meier method (Schemper & Smith, 1996) -- the roles of the event and
   censoring indicators are swapped and the median of the resulting curve is reported,
   per group. This is the follow-up counterpart of `surv_median()` (median survival),
-  a number routinely reported in clinical publications.
+  a number routinely reported in clinical publications. The confidence level is set
+  by `conf.level`, defaulting to the level the fit was built with.
 - New `ggrmst()` and `ggrmst_difference()` for restricted mean survival time (RMST) --
   the area under the Kaplan-Meier curve up to a truncation time `tau`, an absolute
   measure (in time units) that stays interpretable under non-proportional hazards.
@@ -117,9 +131,14 @@
   interval and p-value;
   for three or more groups the area under each curve is shaded, per panel.
   `ggrmst_difference()` returns a tidy table of per-group RMST (with SE and CI) and the
-  RMST difference. The estimate is computed internally from the Kaplan-Meier curve (no
-  new run-time dependency; matches `survRM2::rmst2()`), and `tau` defaults to the
-  largest time at which every group's curve is defined. See Royston & Parmar (2013).
+  RMST difference. The estimate is computed internally from the Kaplan-Meier curve and
+  matches `survRM2::rmst2()`; `tau` defaults to the largest time at which every group's
+  curve is defined. See Royston & Parmar (2013).
+  The confidence level is set by `conf.level`, as in `ggmilestone()`; `ggrmst()`
+  additionally takes `conf.int` with its package-wide meaning, drawing the
+  confidence band around the curves. Groups are read from the fit's own strata, so
+  the labels and their order match `names(fit$strata)` and the plotted curves, and a
+  transformed right-hand side such as `~ (age > 60)` is honoured as written.
 - `ggsurvplot()` gains an `output` argument. The default `output = "classic"` returns
   the usual compound `ggsurvplot` object (unchanged). `output = "ggplot"` instead
   returns a single survival-curve `ggplot` -- one object that composes normally with

--- a/R/gglandmark.R
+++ b/R/gglandmark.R
@@ -37,6 +37,17 @@ NULL
 #' grouping variable reflects a status attained up to \code{L}; for a fixed baseline
 #' covariate there is no immortal time to remove.
 #'
+#' Groups are taken from the fit's own strata, so the labels and their order match
+#' \code{names(fit$strata)}, and a transformed right-hand side such as
+#' \code{~ (age > 60)} is honoured as written (an ungrouped \code{~ 1} fit has no
+#' strata and is treated as a single group). Note that the landmark curves are a
+#' \emph{refit} on the landmark cohort, so a data-dependent grouping term such as
+#' \code{cut(age, 3)} recomputes its breaks on the survivors; bin such a variable
+#' before fitting if the strata must match the original figure exactly.
+#' A weighted \code{survfit()} is
+#' refused, since the landmark cohort would have to be re-fitted and the
+#' confidence-interval convention for weighted data is ambiguous.
+#'
 #' @param fit a survfit object (\code{survival::survfit()} or survminer's
 #'   \code{\link{surv_fit}()}).
 #' @param data the data frame used to fit the curves. Strongly recommended: it is
@@ -45,7 +56,10 @@ NULL
 #' @param landmark.time the landmark time \code{L} (in the data's time units) at
 #'   which the clock is reset. Required.
 #' @param conf.int logical; draw the confidence-interval band of the re-origined
-#'   curves. Default \code{FALSE} (matching \code{\link{ggsurvplot}()}).
+#'   curves. Default \code{FALSE} (matching \code{\link{ggsurvplot}()}). Because the
+#'   curves are re-fitted on the landmark cohort, the band is drawn at
+#'   \code{survfit()}'s default 95\% level rather than the level \code{fit} was
+#'   built with.
 #' @param xlab x-axis label. Default \code{"Time since landmark"} to make the
 #'   re-origining explicit.
 #' @param ... other arguments passed to \code{\link{ggsurvplot}()} (e.g.
@@ -87,6 +101,11 @@ gglandmark <- function(fit, data = NULL, landmark.time, conf.int = FALSE,
   if (missing(landmark.time) || !is.numeric(landmark.time) ||
       length(landmark.time) != 1L || is.na(landmark.time) || landmark.time < 0)
     stop("`landmark.time` must be a single non-negative number.", call. = FALSE)
+  # conf.int is the band flag here, as in every sibling; reject the numeric
+  # spelling rather than let a confidence level read as TRUE.
+  if (!is.logical(conf.int) || length(conf.int) != 1L || is.na(conf.int))
+    stop("`conf.int` must be TRUE or FALSE (it draws the confidence band around ",
+         "the curves), at the confidence level `fit` was built with.", call. = FALSE)
   L <- landmark.time
 
   ext <- .km_reorigin_extract(fit, data)
@@ -111,11 +130,16 @@ gglandmark <- function(fit, data = NULL, landmark.time, conf.int = FALSE,
          call. = FALSE)
 
   d.lm <- data[keep, , drop = FALSE]
-  d.lm[[".landmark_time"]]   <- time[keep] - L
-  d.lm[[".landmark_status"]] <- status[keep]
+  # Re-origined time/status go in columns that cannot clash with a user column of
+  # the same name (backticked in the formula so any generated name stays valid),
+  # mirroring surv_median_followup().
+  uniq <- function(base) { nm <- base; while (nm %in% names(d.lm)) nm <- paste0(nm, "_"); nm }
+  tcol <- uniq(".landmark_time"); scol <- uniq(".landmark_status")
+  d.lm[[tcol]] <- time[keep] - L
+  d.lm[[scol]] <- status[keep]
 
-  form <- stats::reformulate(if (length(ext$rhs)) ext$rhs else "1",
-                             response = "survival::Surv(.landmark_time, .landmark_status)")
+  form <- stats::as.formula(sprintf("survival::Surv(`%s`, `%s`) ~ %s",
+                                    tcol, scol, ext$rhs))
   fit.lm <- surv_fit(form, data = d.lm)
 
   n.risk <- sum(keep)
@@ -150,9 +174,10 @@ gglandmark <- function(fit, data = NULL, landmark.time, conf.int = FALSE,
 # ---- shared internal: raw (time, status, grouping) from a survfit + data -------
 # Mirrors ggrmst's extractor: right-censored Surv only, grouping from the formula
 # RHS, missing rows dropped. Reused by gglandmark() and ggmilestone().
-.km_reorigin_extract <- function(fit, data) {
+.km_reorigin_extract <- function(fit, data, fn = "gglandmark") {
   if (!.is_survfit(fit))
     stop("`fit` must be a survfit object.", call. = FALSE)
+  .stop_if_weighted(fit, fn)
   data <- as.data.frame(.get_data(fit, data))
   f <- stats::formula(fit)
   resp <- eval(f[[2]], envir = data)
@@ -161,12 +186,21 @@ gglandmark <- function(fit, data = NULL, landmark.time, conf.int = FALSE,
     stop("Only right-censored `Surv(time, status)` data are supported.",
          call. = FALSE)
   time <- as.numeric(resp[, 1]); status <- as.numeric(resp[, 2])
-  rhs <- all.vars(f[[3]])
-  if (length(rhs) == 1L && rhs == "1") rhs <- character(0)
-  if (length(rhs))
-    group <- interaction(data[rhs], sep = ", ", drop = TRUE)
-  else
-    group <- factor(rep("All", length(time)))
+  # The right-hand side verbatim (not all.vars(), and not the term labels): a
+  # transformed term such as `~ (age > 60)` must be re-fitted exactly as written.
+  # Term labels drop the parentheses, and reformulate() would paste them with `+`,
+  # so `~ sexf + (age > 60)` would re-parse as `~ (sexf + age) > 60`.
+  # collapse in case deparse returns several lines for a very wide right-hand side
+  rhs <- paste(deparse(f[[3]], width.cutoff = 500L), collapse = "")
+  # Grouping from the fit's own strata convention -- see .strata_group_from_formula().
+  group <- .strata_group_from_formula(f, data)
+  # survfit() stores no strata when the formula collapses to a single group (e.g.
+  # a factor with one used level); the package calls that "All" everywhere else.
+  # Rename the LEVELS only -- replacing the vector would overwrite the NAs that
+  # reproduce survfit()'s na.omit, and the estimates would then be computed on
+  # rows the fit excluded.
+  if (is.null(fit$strata) && nlevels(group) > 0L)
+    levels(group) <- rep("All", nlevels(group))
   ok <- stats::complete.cases(time, status) & !is.na(group)
   list(time = time[ok], status = status[ok], group = droplevels(group[ok]),
        data = data[ok, , drop = FALSE], rhs = rhs, formula = f)

--- a/R/ggmilestone.R
+++ b/R/ggmilestone.R
@@ -14,8 +14,8 @@ NULL
 #' For each arm and milestone the estimate is the Kaplan-Meier \eqn{S(t)} with its
 #' Greenwood standard error and confidence interval (\code{summary.survfit}; the
 #' interval uses the same \code{conf.type} as \code{fit}). The between-arm difference
-#' is on the risk-difference (identity) scale, \eqn{S_A(t) - S_B(t)}, with
-#' \eqn{se = \sqrt{se_A^2 + se_B^2}} (arms independent), a normal confidence interval
+#' is on the risk-difference (identity) scale -- the second arm minus the first --
+#' with \eqn{se = \sqrt{se_A^2 + se_B^2}} (arms independent), a normal confidence interval
 #' and Wald p-value -- the quantity clinical reports quote. Note (Klein et al., 2007)
 #' that this naive identity-scale inference can have inflated type-I error and poor
 #' coverage when \eqn{S} is close to 0 or 1 or the sample is small; interpret such
@@ -31,18 +31,31 @@ NULL
 #' (otherwise only the per-arm milestone table is produced). For a single arm only
 #' the per-arm milestone survival is shown.
 #'
+#' Arms are taken from the fit's own strata, so the labels and their order match
+#' \code{names(fit$strata)} and the curves drawn by \code{\link{ggsurvplot}()}, and a
+#' transformed right-hand side such as \code{~ (age > 60)} is honoured as written.
+#' (An ungrouped \code{~ 1} fit has no strata and is reported as a single
+#' \code{"All"} arm.) For two arms the difference is the \emph{second} arm minus the first (the first
+#' level is the reference), matching \code{\link{ggrmst_difference}()}; the row is
+#' always labelled with the contrast, so the direction is never left to the reader.
+#' A weighted \code{survfit()} is refused: the confidence-interval convention for
+#' weighted data is ambiguous, so reporting an interval for it would overstate what
+#' the estimate supports.
+#'
 #' @param fit a survfit object (\code{survival::survfit()} or survminer's
 #'   \code{\link{surv_fit}()}).
 #' @param data the data frame used to fit the curves (see \code{\link{ggsurvplot}}).
 #' @param milestone.times numeric vector of the fixed times at which to read
 #'   survival (in the data's time units). Required.
 #' @param conf.int logical; draw the confidence-interval band of the Kaplan-Meier
-#'   curves. Default \code{FALSE} (matching \code{\link{ggsurvplot}()}). The milestone
-#'   confidence level is set by \code{conf.level}.
+#'   curves. Default \code{FALSE} (matching \code{\link{ggsurvplot}()}). The band is
+#'   drawn at the confidence level \code{fit} was built with; \code{conf.level} sets
+#'   the level of the milestone estimates and their difference, not of the band.
 #' @param conf.level confidence level for the milestone survival intervals and the
 #'   between-arm difference. Default 0.95.
 #' @param ref.group for three or more arms, the reference arm the milestone
-#'   differences are taken against (an arm label). Default \code{NULL} reports only
+#'   differences are taken against, given in the fit's own label form (e.g.
+#'   \code{"sex=1"}; the error message lists the valid values). Default \code{NULL} reports only
 #'   the per-arm milestone survival. Ignored for one or two arms.
 #' @param label.milestones logical or \code{NULL}; draw the per-arm \eqn{S(t)}
 #'   value labels on the curves. Default \code{NULL} labels them only when the plot
@@ -57,7 +70,10 @@ NULL
 #'   each milestone, the per-arm \eqn{S(t)} marked, and the milestone survival (and
 #'   between-arm difference) reported in the caption. The full milestone table --
 #'   per-arm \eqn{S(t)}, CI, and any between-arm differences with CI and p-value --
-#'   is attached as \code{attr(x$plot, "milestone.table")}.
+#'   is attached as \code{attr(x$plot, "milestone.table")}. Its \code{group} column
+#'   carries the fit's own strata label -- \code{"All"} for an ungrouped fit, as in
+#'   \code{\link{surv_median}()} -- which is what the caption shows unless
+#'   \code{legend.labs} renames the arms on the plot.
 #'
 #' @references
 #' Klein JP, Logan B, Harhoff M, Andersen PK (2007). Analyzing survival curves at a
@@ -86,16 +102,19 @@ ggmilestone <- function(fit, data = NULL, milestone.times, conf.int = FALSE,
   if (missing(milestone.times) || !is.numeric(milestone.times) ||
       !length(milestone.times) || anyNA(milestone.times) || any(milestone.times <= 0))
     stop("`milestone.times` must be a vector of positive numbers.", call. = FALSE)
-  if (!is.numeric(conf.level) || length(conf.level) != 1L ||
+  if (!is.numeric(conf.level) || length(conf.level) != 1L || is.na(conf.level) ||
       conf.level <= 0 || conf.level >= 1)
     stop("`conf.level` must be a single number in (0, 1).", call. = FALSE)
+  # conf.int is the band flag; catch the stale numeric spelling rather than let it
+  # read as TRUE while the milestone interval silently stays at conf.level.
+  if (!is.logical(conf.int) || length(conf.int) != 1L || is.na(conf.int))
+    stop("`conf.int` must be TRUE or FALSE (it draws the confidence band around ",
+         "the curves). Use `conf.level` to set the confidence level of the ",
+         "milestone interval.", call. = FALSE)
   milestone.times <- sort(unique(milestone.times))
 
-  ext <- .km_reorigin_extract(fit, data)
+  ext <- .km_reorigin_extract(fit, data, fn = "ggmilestone")
   glevels <- levels(ext$group)
-  if (any(!nzchar(glevels)))
-    stop("An arm/group label is an empty string; give each group a non-empty ",
-         "label before calling ggmilestone().", call. = FALSE)
   z <- stats::qnorm(1 - (1 - conf.level) / 2)
   ct <- if (!is.null(fit$conf.type)) fit$conf.type else "log"
 
@@ -115,8 +134,11 @@ ggmilestone <- function(fit, data = NULL, milestone.times, conf.int = FALSE,
                            row.names = NULL, stringsAsFactors = FALSE)
       if (t <= tmax) {
         sm <- summary(fa, times = t, extend = FALSE)
-        return(data.frame(group = g, time = t, surv = sm$surv, se = sm$std.err,
-                          lower = sm$lower, upper = sm$upper,
+        # A fit stored with conf.type = "none" has no $lower/$upper at all; report
+        # NA limits rather than failing to build the row.
+        or_na <- function(v) if (is.null(v) || !length(v)) NA_real_ else as.numeric(v)
+        return(data.frame(group = g, time = t, surv = sm$surv, se = or_na(sm$std.err),
+                          lower = or_na(sm$lower), upper = or_na(sm$upper),
                           row.names = NULL, stringsAsFactors = FALSE))
       }
       if (isTRUE(s.end == 0)) {   # curve has reached 0: S(t) = 0 for all later t
@@ -141,7 +163,10 @@ ggmilestone <- function(fit, data = NULL, milestone.times, conf.int = FALSE,
   # ---- between-arm differences (k = 2 both; k >= 3 vs ref.group) ---------------
   diffs <- NULL
   if (length(glevels) == 2L) {
-    diffs <- list(c(glevels[1], glevels[2]))
+    # Second arm minus the first (the first level is the reference), matching
+    # ggrmst_difference() and survRM2's arm1 - arm0 convention. The row is always
+    # labelled with the contrast, so the direction is never left to the reader.
+    diffs <- list(c(glevels[2], glevels[1]))
   } else if (length(glevels) >= 3L && !is.null(ref.group)) {
     if (!ref.group %in% glevels)
       stop("`ref.group` must be one of the arm labels: ",
@@ -172,6 +197,7 @@ ggmilestone <- function(fit, data = NULL, milestone.times, conf.int = FALSE,
     tab$p.value <- NA_real_
   }
   milestone.table <- if (is.null(diff.tab)) tab else rbind(tab, diff.tab)
+  rownames(milestone.table) <- NULL
 
   # ---- base Kaplan-Meier plot --------------------------------------------------
   dots <- list(...)

--- a/R/ggrmst.R
+++ b/R/ggrmst.R
@@ -36,6 +36,16 @@ NULL
 #' observation is censored limits \code{tau} to that time. A \code{tau} beyond that
 #' admissible range is an error.
 #'
+#' Groups are taken from the fit's own strata, so the labels and their order match
+#' \code{names(fit$strata)} and the curves drawn by \code{\link{ggsurvplot}()}, and a
+#' transformed right-hand side such as \code{~ (age > 60)} is honoured as written.
+#' (An ungrouped \code{~ 1} fit has no strata and is reported as a single
+#' \code{"All"} group. The grouping is rebuilt from \code{data}, so a fit created
+#' with \code{survfit(..., subset =)} should be passed the same subset of rows.)
+#' A weighted \code{survfit()} is refused: the confidence-interval convention for
+#' weighted data is ambiguous, so reporting an interval for it would overstate what
+#' the estimate supports.
+#'
 #' @param fit a survfit object (\code{survival::survfit()} or survminer's
 #'   \code{\link{surv_fit}()}).
 #' @param data the data frame used to fit the survival curves. If not supplied it
@@ -43,9 +53,17 @@ NULL
 #' @param tau numeric truncation time. Default \code{NULL} uses the largest time at
 #'   which all groups' curves are defined (see Details). An out-of-range value is an
 #'   error.
-#' @param conf.int the confidence level for the intervals. Default 0.95.
+#' @param conf.level the confidence level for the RMST intervals, a single number in
+#'   (0, 1). Default 0.95. (\code{ggrmst_difference()} returns a table, so this is
+#'   its only confidence argument.)
+#' @param conf.int logical; draw the confidence band around the survival curves,
+#'   as in \code{\link{ggmilestone}()} and \code{\link{gglandmark}()}. Default
+#'   \code{FALSE}. \code{ggrmst()} only. The band is drawn at the confidence level
+#'   \code{fit} was built with; \code{conf.level} sets the level of the RMST
+#'   interval, not of the band.
 #' @param ref.group for three or more groups, the reference group the RMST
-#'   differences are taken against (a group label). Default \code{NULL} reports only
+#'   differences are taken against, given in the fit's own label form (e.g.
+#'   \code{"sex=1"}; the error message lists the valid values). Default \code{NULL} reports only
 #'   the per-group RMST (no differences). Ignored for one or two groups.
 #' @param palette,ggtheme,... passed to \code{\link{ggsurvplot}()} for the underlying
 #'   curves.
@@ -66,11 +84,14 @@ NULL
 #'
 #' @describeIn ggrmst_difference a tidy table of per-group RMST and the difference.
 #' @export
-ggrmst_difference <- function(fit, data = NULL, tau = NULL, conf.int = 0.95,
+ggrmst_difference <- function(fit, data = NULL, tau = NULL, conf.level = 0.95,
                               ref.group = NULL) {
-  ext <- .rmst_extract(fit, data)
+  if (!is.numeric(conf.level) || length(conf.level) != 1L || is.na(conf.level) ||
+      conf.level <= 0 || conf.level >= 1)
+    stop("`conf.level` must be a single number in (0, 1).", call. = FALSE)
+  ext <- .rmst_extract(fit, data, fn = "ggrmst_difference")
   tau <- .rmst_resolve_tau(ext$time, ext$status, ext$group, tau)
-  alpha <- 1 - conf.int
+  alpha <- 1 - conf.level
   glevels <- levels(ext$group)
 
   per <- lapply(glevels, function(g) {
@@ -121,16 +142,31 @@ ggrmst_difference <- function(fit, data = NULL, tau = NULL, conf.int = 0.95,
 
 #' @describeIn ggrmst_difference the shaded Kaplan-Meier RMST plot.
 #' @export
-ggrmst <- function(fit, data = NULL, tau = NULL, conf.int = 0.95,
-                   palette = NULL, ggtheme = theme_survminer(), ...) {
+ggrmst <- function(fit, data = NULL, tau = NULL, conf.level = 0.95,
+                   palette = NULL, ggtheme = theme_survminer(), ...,
+                   conf.int = FALSE) {
+  # conf.int is the band flag, as everywhere else in survminer. Catch the stale
+  # numeric spelling rather than let ggsurvplot() read 0.9 as "TRUE" while the
+  # RMST interval silently stays at conf.level.
+  if (!is.logical(conf.int) || length(conf.int) != 1L || is.na(conf.int))
+    stop("`conf.int` must be TRUE or FALSE (it draws the confidence band around ",
+         "the curves). Use `conf.level` to set the confidence level of the RMST ",
+         "interval.", call. = FALSE)
   ext <- .rmst_extract(fit, data)
   tau <- .rmst_resolve_tau(ext$time, ext$status, ext$group, tau)
   glevels <- levels(ext$group)
-  tab <- ggrmst_difference(fit, data = ext$data, tau = tau, conf.int = conf.int)
+  tab <- ggrmst_difference(fit, data = ext$data, tau = tau, conf.level = conf.level)
 
   # Bare, composable survival-curve ggplot (output = "ggplot"). No table -- RMST is a single plot.
   p <- ggsurvplot(fit, data = ext$data, palette = palette, ggtheme = ggtheme,
-                  output = "ggplot", ...)
+                  output = "ggplot", conf.int = conf.int, ...)
+
+  # The plot's own strata levels, in the same order as glevels (ggsurvplot may
+  # rename them via legend.labs). Used for every label we draw, so the annotation
+  # never names an arm the legend does not show.
+  plot.strata <- levels(p$data$strata)
+  remap <- if (length(plot.strata) == length(glevels))
+    stats::setNames(plot.strata, glevels) else stats::setNames(glevels, glevels)
 
   time <- surv <- NULL
   if (length(glevels) == 2L) {
@@ -141,21 +177,22 @@ ggrmst <- function(fit, data = NULL, tau = NULL, conf.int = 0.95,
       ggplot2::geom_ribbon(data = band,
                            ggplot2::aes(x = time, ymin = ymin, ymax = ymax),
                            inherit.aes = FALSE, fill = "grey50", alpha = 0.3)
-    dr <- tab[grepl(" - ", tab$group), ]
-    lab <- sprintf("Delta RMST = %.1f  (%.0f%% CI %.1f to %.1f)\np = %s",
-                   dr$rmst, conf.int * 100, dr$lower, dr$upper,
+    # The difference rows are the ones appended after the per-group block; select
+    # them by position, never by matching " - " in the label, since a group label
+    # may itself contain " - ".
+    dr <- tab[nrow(tab), , drop = FALSE]
+    contrast <- paste(remap[[glevels[2]]], "-", remap[[glevels[1]]])
+    lab <- sprintf("Delta RMST (%s) = %.1f  (%.0f%% CI %.1f to %.1f)\np = %s",
+                   contrast, dr$rmst, conf.level * 100, dr$lower, dr$upper,
                    format.pval(dr$p.value, digits = 2, eps = 1e-4))
     p <- p + ggplot2::labs(subtitle = lab)
   } else {
     # One or 3+ groups: shade the area under each curve up to tau (faceted for 3+).
     # Relabel the area's group to the plot's own strata levels (same order) so a
-    # facet by strata matches the curves (ggsurvplot may rename via legend.labs).
+    # facet by strata matches the curves.
     areas <- .rmst_under_band(ext, tau)
-    plot.strata <- levels(p$data$strata)
-    if (length(plot.strata) == length(glevels)) {
-      remap <- stats::setNames(plot.strata, glevels)
+    if (length(plot.strata) == length(glevels))
       areas$strata <- factor(remap[areas$strata], levels = plot.strata)
-    }
     p <- p +
       ggplot2::geom_ribbon(data = areas,
                            ggplot2::aes(x = time, ymin = 0, ymax = surv,
@@ -183,7 +220,11 @@ ggrmst <- function(fit, data = NULL, tau = NULL, conf.int = 0.95,
   keep <- tt <= tau
   tt <- tt[keep]; Y <- Y[keep]; d <- d[keep]; S <- S[keep]
   gt <- c(0, tt, tau)
-  gS <- c(1, S, S[length(S)])         # step value on each left segment; flat to tau
+  # Step value on each left segment; flat to tau. When no observation falls at or
+  # before tau, S is empty and S[length(S)] is numeric(0) -- which would collapse gS
+  # to length 1 and make the sum below 0 instead of tau. The curve is identically 1
+  # on [0, tau] in that case, so the flat-forward value is 1.
+  gS <- c(1, S, if (length(S)) S[length(S)] else 1)
   w  <- diff(gt)
   Sv <- gS[-length(gS)]
   rmst <- sum(Sv * w)
@@ -220,9 +261,10 @@ ggrmst <- function(fit, data = NULL, tau = NULL, conf.int = 0.95,
 }
 
 # Extract raw time, status and the grouping (combined strata) from fit + data.
-.rmst_extract <- function(fit, data) {
+.rmst_extract <- function(fit, data, fn = "ggrmst") {
   if (!.is_survfit(fit))
     stop("`fit` must be a survfit object.", call. = FALSE)
+  .stop_if_weighted(fit, fn)
   data <- as.data.frame(.get_data(fit, data))
   f <- stats::formula(fit)
   resp <- eval(f[[2]], envir = data)
@@ -231,14 +273,21 @@ ggrmst <- function(fit, data = NULL, tau = NULL, conf.int = 0.95,
   # a meaningless RMST from the collapsed status codes; left-censored likewise.
   if (!survival::is.Surv(resp) || ncol(resp) != 2L ||
       !identical(attr(resp, "type"), "right"))
-    stop("ggrmst() supports right-censored `Surv(time, status)` data only.",
+    stop(fn, "() supports right-censored `Surv(time, status)` data only.",
          call. = FALSE)
   time <- as.numeric(resp[, 1]); status <- as.numeric(resp[, 2])
-  rhs <- all.vars(f[[3]])
-  if (length(rhs) == 0L || identical(rhs, "1"))
-    group <- factor(rep("All", length(time)))
-  else
-    group <- interaction(data[rhs], sep = ", ", drop = TRUE)
+  # Grouping straight from the fit's own strata convention: the levels reproduce
+  # names(fit$strata) in survfit's order, so the label remap onto the plotted
+  # curves is correct by construction and a transformed right-hand side such as
+  # `~ (age > 60)` groups into its two strata rather than one per distinct value.
+  group <- .strata_group_from_formula(f, data)
+  # survfit() stores no strata when the formula collapses to a single group (e.g.
+  # a factor with one used level); the package calls that "All" everywhere else.
+  # Rename the LEVELS only -- replacing the vector would overwrite the NAs that
+  # reproduce survfit()'s na.omit, and the estimates would then be computed on
+  # rows the fit excluded.
+  if (is.null(fit$strata) && nlevels(group) > 0L)
+    levels(group) <- rep("All", nlevels(group))
   ok <- stats::complete.cases(time, status) & !is.na(group)
   list(time = time[ok], status = status[ok], group = droplevels(group[ok]),
        data = data)

--- a/R/surv_median_followup.R
+++ b/R/surv_median_followup.R
@@ -31,9 +31,12 @@ NULL
 #'   status)} data.
 #' @param data the data frame used to fit the survival curves. If not supplied
 #'   it is extracted from \code{fit}.
-#' @param conf.int the confidence level for the limits. Default \code{NULL} uses
-#'   the confidence level the \code{fit} was built with (95\% by default). The
-#'   fit's confidence-interval type (\code{conf.type}) is honoured as well.
+#' @param conf.level the confidence level for the limits, a single number in
+#'   (0, 1). Default \code{NULL} uses the confidence level the \code{fit} was built
+#'   with (95\% by default). The fit's confidence-interval type (\code{conf.type})
+#'   is honoured as well. Named \code{conf.level} rather than \code{conf.int} so
+#'   that, as everywhere else in survminer, \code{conf.int} means "draw the band"
+#'   and \code{conf.level} means "at what level".
 #' @return A data frame with one row per group and the columns: \itemize{ \item
 #'   strata: group name (\code{"All"} for an ungrouped fit) \item median: median
 #'   follow-up time \item lower: lower confidence limit \item upper: upper
@@ -55,10 +58,16 @@ NULL
 #' fit.null <- surv_fit(Surv(time, status) ~ 1, data = lung)
 #' surv_median_followup(fit.null)
 #' @export
-surv_median_followup <- function(fit, data = NULL, conf.int = NULL) {
+surv_median_followup <- function(fit, data = NULL, conf.level = NULL) {
+
+  if (!is.null(conf.level) &&
+      (!is.numeric(conf.level) || length(conf.level) != 1L || is.na(conf.level) ||
+       conf.level <= 0 || conf.level >= 1))
+    stop("`conf.level` must be a single number in (0, 1).", call. = FALSE)
 
   if (!.is_survfit(fit))
     stop("`fit` must be a survfit object.", call. = FALSE)
+  .stop_if_weighted(fit, "surv_median_followup")
 
   # Extract the data from the fit when not supplied. Quiet by default (complain =
   # FALSE) so a fit-only call matches surv_median()'s silence; .get_data() still
@@ -77,7 +86,7 @@ surv_median_followup <- function(fit, data = NULL, conf.int = NULL) {
   # Confidence limits: honour the original fit's confidence level (unless
   # overridden) and its interval type, so the reported limits are consistent with
   # how the fit was built (e.g. conf.type = "none" -> NA limits).
-  cl <- if (!is.null(conf.int)) conf.int
+  cl <- if (!is.null(conf.level)) conf.level
         else if (!is.null(fit$conf.int)) fit$conf.int
         else 0.95
   ct <- if (!is.null(fit$conf.type)) fit$conf.type else "log"

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -336,6 +336,59 @@ GeomConfint_old <- ggplot2::ggproto('GeomConfint_old', ggplot2::GeomRibbon,
   tl
 }
 
+# Per-subject grouping factor whose LEVELS reproduce names(fit$strata) exactly, in
+# survfit's own order.
+#
+# The effect-measure functions (ggrmst/ggmilestone/gglandmark) used to rebuild the
+# grouping with interaction(data[all.vars(rhs)]), which is wrong twice over:
+#   * interaction() varies the FIRST factor fastest while survfit varies the LAST
+#     fastest, so for a multi-variable right-hand side the levels came out in a
+#     different ORDER than the plotted strata -- and the positional label remap
+#     then attached each arm's statistics to the wrong curve;
+#   * all.vars() discards the expression, so `~ (age > 60)` grouped by `age` and
+#     produced one "group" per distinct age instead of two.
+# Building the factor the way survfit does (survival::strata() over the model
+# frame's term columns) makes the labels and the ordering agree by construction.
+.strata_group_from_formula <- function(f, data){
+  tt <- stats::terms(f)
+  tl <- attr(tt, "term.labels")
+  # survfit() strips a cluster() term before grouping, so it is not a stratum.
+  # Matched on the term label because survfit() keeps whichever spelling the user
+  # wrote, including the namespace-qualified survival::cluster().
+  tl <- tl[!grepl("^(survival::)?cluster\\(", tl)]
+  if(length(tl) == 0)
+    return(factor(rep("All", nrow(data))))
+  # delete.response(): the model frame must not re-evaluate the Surv() response.
+  # model.frame() evaluates it in the formula's own environment, which for a fit
+  # saved and reloaded (or built before survival was detached) can no longer
+  # resolve Surv -- the grouping does not need the response anyway.
+  mf <- stats::model.frame(stats::delete.response(tt), data = data,
+                           na.action = stats::na.pass)
+  # Pass the term columns as a single data frame, exactly as survfit.formula()
+  # does (strata(mf[ll])). Splatting them as named arguments instead would let a
+  # grouping variable called `sep`, `shortlabel` or `na.group` collide with
+  # strata()'s own formals and error.
+  droplevels(survival::strata(mf[tl]))
+}
+
+# Refuse a weighted survfit in the effect-measure functions.
+#
+# These estimators read the risk/event counts off the curve, so a weighted fit
+# would silently mix a weighted point estimate with a variance whose convention
+# (case weights vs sampling/IPTW weights) is not determined by the fit object.
+# Rather than annotate a number we cannot stand behind, we refuse; supporting
+# weights is a purely additive change whenever the convention is settled.
+.stop_if_weighted <- function(fit, fn){
+  if(!is.null(fit$call$weights))
+    stop(fn, "() does not support a weighted survfit(): the confidence interval ",
+         "convention for weighted data (case weights vs sampling/IPTW weights) is ",
+         "ambiguous, and reporting an unweighted estimate next to a weighted curve ",
+         "would be misleading. ggsurvplot() still draws the weighted curves; refit ",
+         "without `weights` to use ", fn, "().",
+         call. = FALSE)
+  invisible(NULL)
+}
+
 # Escape regex metacharacters so a (possibly non-syntactic) variable name can be
 # used literally inside a pattern.
 .escape_regex <- function(x){

--- a/man/gglandmark.Rd
+++ b/man/gglandmark.Rd
@@ -25,7 +25,10 @@ for a fit created in the global environment (see \code{\link{ggsurvplot}}).}
 which the clock is reset. Required.}
 
 \item{conf.int}{logical; draw the confidence-interval band of the re-origined
-curves. Default \code{FALSE} (matching \code{\link{ggsurvplot}()}).}
+curves. Default \code{FALSE} (matching \code{\link{ggsurvplot}()}). Because the
+curves are re-fitted on the landmark cohort, the band is drawn at
+\code{survfit()}'s default 95\% level rather than the level \code{fit} was
+built with.}
 
 \item{xlab}{x-axis label. Default \code{"Time since landmark"} to make the
 re-origining explicit.}
@@ -75,6 +78,17 @@ choice of \code{L}; reporting a sensitivity analysis over several landmarks is
 good practice (Dafni, 2011). The immortal-time-bias correction applies when the
 grouping variable reflects a status attained up to \code{L}; for a fixed baseline
 covariate there is no immortal time to remove.
+
+Groups are taken from the fit's own strata, so the labels and their order match
+\code{names(fit$strata)}, and a transformed right-hand side such as
+\code{~ (age > 60)} is honoured as written (an ungrouped \code{~ 1} fit has no
+strata and is treated as a single group). Note that the landmark curves are a
+\emph{refit} on the landmark cohort, so a data-dependent grouping term such as
+\code{cut(age, 3)} recomputes its breaks on the survivors; bin such a variable
+before fitting if the strata must match the original figure exactly.
+A weighted \code{survfit()} is
+refused, since the landmark cohort would have to be re-fitted and the
+confidence-interval convention for weighted data is ambiguous.
 }
 \examples{
 library(survival)

--- a/man/ggmilestone.Rd
+++ b/man/ggmilestone.Rd
@@ -25,14 +25,16 @@ ggmilestone(
 survival (in the data's time units). Required.}
 
 \item{conf.int}{logical; draw the confidence-interval band of the Kaplan-Meier
-curves. Default \code{FALSE} (matching \code{\link{ggsurvplot}()}). The milestone
-confidence level is set by \code{conf.level}.}
+curves. Default \code{FALSE} (matching \code{\link{ggsurvplot}()}). The band is
+drawn at the confidence level \code{fit} was built with; \code{conf.level} sets
+the level of the milestone estimates and their difference, not of the band.}
 
 \item{conf.level}{confidence level for the milestone survival intervals and the
 between-arm difference. Default 0.95.}
 
 \item{ref.group}{for three or more arms, the reference arm the milestone
-differences are taken against (an arm label). Default \code{NULL} reports only
+differences are taken against, given in the fit's own label form (e.g.
+\code{"sex=1"}; the error message lists the valid values). Default \code{NULL} reports only
 the per-arm milestone survival. Ignored for one or two arms.}
 
 \item{label.milestones}{logical or \code{NULL}; draw the per-arm \eqn{S(t)}
@@ -50,7 +52,10 @@ a \code{ggsurvplot} object: the Kaplan-Meier curves with a dashed line at
   each milestone, the per-arm \eqn{S(t)} marked, and the milestone survival (and
   between-arm difference) reported in the caption. The full milestone table --
   per-arm \eqn{S(t)}, CI, and any between-arm differences with CI and p-value --
-  is attached as \code{attr(x$plot, "milestone.table")}.
+  is attached as \code{attr(x$plot, "milestone.table")}. Its \code{group} column
+  carries the fit's own strata label -- \code{"All"} for an ungrouped fit, as in
+  \code{\link{surv_median}()} -- which is what the caption shows unless
+  \code{legend.labs} renames the arms on the plot.
 }
 \description{
 Annotates Kaplan-Meier curves with \strong{milestone survival}: the survival
@@ -64,8 +69,8 @@ when a single hazard ratio is not enough (e.g. under non-proportional hazards).
 For each arm and milestone the estimate is the Kaplan-Meier \eqn{S(t)} with its
 Greenwood standard error and confidence interval (\code{summary.survfit}; the
 interval uses the same \code{conf.type} as \code{fit}). The between-arm difference
-is on the risk-difference (identity) scale, \eqn{S_A(t) - S_B(t)}, with
-\eqn{se = \sqrt{se_A^2 + se_B^2}} (arms independent), a normal confidence interval
+is on the risk-difference (identity) scale -- the second arm minus the first --
+with \eqn{se = \sqrt{se_A^2 + se_B^2}} (arms independent), a normal confidence interval
 and Wald p-value -- the quantity clinical reports quote. Note (Klein et al., 2007)
 that this naive identity-scale inference can have inflated type-I error and poor
 coverage when \eqn{S} is close to 0 or 1 or the sample is small; interpret such
@@ -80,6 +85,17 @@ The between-arm difference is defined only for two arms; for three or more arms,
 set \code{ref.group} to report each other arm's difference against a reference
 (otherwise only the per-arm milestone table is produced). For a single arm only
 the per-arm milestone survival is shown.
+
+Arms are taken from the fit's own strata, so the labels and their order match
+\code{names(fit$strata)} and the curves drawn by \code{\link{ggsurvplot}()}, and a
+transformed right-hand side such as \code{~ (age > 60)} is honoured as written.
+(An ungrouped \code{~ 1} fit has no strata and is reported as a single
+\code{"All"} arm.) For two arms the difference is the \emph{second} arm minus the first (the first
+level is the reference), matching \code{\link{ggrmst_difference}()}; the row is
+always labelled with the contrast, so the direction is never left to the reader.
+A weighted \code{survfit()} is refused: the confidence-interval convention for
+weighted data is ambiguous, so reporting an interval for it would overstate what
+the estimate supports.
 }
 \examples{
 library(survival)

--- a/man/ggrmst_difference.Rd
+++ b/man/ggrmst_difference.Rd
@@ -9,7 +9,7 @@ ggrmst_difference(
   fit,
   data = NULL,
   tau = NULL,
-  conf.int = 0.95,
+  conf.level = 0.95,
   ref.group = NULL
 )
 
@@ -17,10 +17,11 @@ ggrmst(
   fit,
   data = NULL,
   tau = NULL,
-  conf.int = 0.95,
+  conf.level = 0.95,
   palette = NULL,
   ggtheme = theme_survminer(),
-  ...
+  ...,
+  conf.int = FALSE
 )
 }
 \arguments{
@@ -34,14 +35,23 @@ is extracted from \code{fit}.}
 which all groups' curves are defined (see Details). An out-of-range value is an
 error.}
 
-\item{conf.int}{the confidence level for the intervals. Default 0.95.}
+\item{conf.level}{the confidence level for the RMST intervals, a single number in
+(0, 1). Default 0.95. (\code{ggrmst_difference()} returns a table, so this is
+its only confidence argument.)}
 
 \item{ref.group}{for three or more groups, the reference group the RMST
-differences are taken against (a group label). Default \code{NULL} reports only
+differences are taken against, given in the fit's own label form (e.g.
+\code{"sex=1"}; the error message lists the valid values). Default \code{NULL} reports only
 the per-group RMST (no differences). Ignored for one or two groups.}
 
 \item{palette, ggtheme, ...}{passed to \code{\link{ggsurvplot}()} for the underlying
 curves.}
+
+\item{conf.int}{logical; draw the confidence band around the survival curves,
+as in \code{\link{ggmilestone}()} and \code{\link{gglandmark}()}. Default
+\code{FALSE}. \code{ggrmst()} only. The band is drawn at the confidence level
+\code{fit} was built with; \code{conf.level} sets the level of the RMST
+interval, not of the band.}
 }
 \value{
 \code{ggrmst_difference()} returns a data.frame with one row per group
@@ -83,6 +93,16 @@ estimate is still defined: a group whose last observation is an event places no
 upper limit (its curve is defined to be 0 afterwards), while a group whose last
 observation is censored limits \code{tau} to that time. A \code{tau} beyond that
 admissible range is an error.
+
+Groups are taken from the fit's own strata, so the labels and their order match
+\code{names(fit$strata)} and the curves drawn by \code{\link{ggsurvplot}()}, and a
+transformed right-hand side such as \code{~ (age > 60)} is honoured as written.
+(An ungrouped \code{~ 1} fit has no strata and is reported as a single
+\code{"All"} group. The grouping is rebuilt from \code{data}, so a fit created
+with \code{survfit(..., subset =)} should be passed the same subset of rows.)
+A weighted \code{survfit()} is refused: the confidence-interval convention for
+weighted data is ambiguous, so reporting an interval for it would overstate what
+the estimate supports.
 }
 \section{Functions}{
 \itemize{

--- a/man/surv_median_followup.Rd
+++ b/man/surv_median_followup.Rd
@@ -4,7 +4,7 @@
 \alias{surv_median_followup}
 \title{Median Follow-Up Time (Reverse Kaplan-Meier)}
 \usage{
-surv_median_followup(fit, data = NULL, conf.int = NULL)
+surv_median_followup(fit, data = NULL, conf.level = NULL)
 }
 \arguments{
 \item{fit}{a survfit object (\code{survival::survfit()} or survminer's
@@ -14,9 +14,12 @@ status)} data.}
 \item{data}{the data frame used to fit the survival curves. If not supplied
 it is extracted from \code{fit}.}
 
-\item{conf.int}{the confidence level for the limits. Default \code{NULL} uses
-the confidence level the \code{fit} was built with (95\% by default). The
-fit's confidence-interval type (\code{conf.type}) is honoured as well.}
+\item{conf.level}{the confidence level for the limits, a single number in
+(0, 1). Default \code{NULL} uses the confidence level the \code{fit} was built
+with (95\% by default). The fit's confidence-interval type (\code{conf.type})
+is honoured as well. Named \code{conf.level} rather than \code{conf.int} so
+that, as everywhere else in survminer, \code{conf.int} means "draw the band"
+and \code{conf.level} means "at what level".}
 }
 \value{
 A data frame with one row per group and the columns: \itemize{ \item

--- a/tests/testthat/test-ggrmst.R
+++ b/tests/testthat/test-ggrmst.R
@@ -16,8 +16,8 @@ test_that("ggrmst_difference matches survRM2::rmst2() (numeric parity)", {
   # default tau
   expect_equal(tab$tau[1], ref$tau, tolerance = 1e-6)
   # per-arm RMST + SE
-  r_obs <- tab[tab$group == "Obs", ]
-  r_trt <- tab[tab$group == "Lev+5FU", ]
+  r_obs <- tab[tab$group == "rx=Obs", ]
+  r_trt <- tab[tab$group == "rx=Lev+5FU", ]
   expect_equal(r_obs$rmst, ref$RMST.arm0$rmst[[1]], tolerance = 1e-4)
   expect_equal(r_obs$se,   ref$RMST.arm0$rmst[[2]], tolerance = 1e-4)
   expect_equal(r_trt$rmst, ref$RMST.arm1$rmst[[1]], tolerance = 1e-4)
@@ -36,7 +36,7 @@ test_that("ggrmst_difference structure and columns", {
   expect_true(all(c("group", "rmst", "se", "lower", "upper", "tau", "p.value") %in% names(tab)))
   expect_equal(nrow(tab), 3L)                 # 2 groups + 1 difference row
   expect_true(any(grepl(" - ", tab$group)))
-  expect_true(is.na(tab$p.value[tab$group == "1"]))   # per-group rows have no p
+  expect_true(is.na(tab$p.value[tab$group == "sex=1"]))   # per-group rows have no p
 })
 
 test_that("tau default is the admissible max; out-of-range tau errors", {
@@ -71,7 +71,7 @@ test_that("ggrmst() facets per arm for 3+ groups (no invented pairwise differenc
   expect_equal(nrow(tab), 3L)               # 3 groups, no difference rows by default
   expect_false(any(grepl(" - ", tab$group)))
   # with a reference group, differences vs the reference appear
-  tab2 <- ggrmst_difference(fit, data = d, ref.group = "0")
+  tab2 <- ggrmst_difference(fit, data = d, ref.group = "ph.ecog=0")
   expect_equal(sum(grepl(" - ", tab2$group)), 2L)
 })
 
@@ -105,4 +105,178 @@ test_that("a single-group fit gives an overall RMST", {
   expect_true(is.finite(tab$rmst))
   p <- ggrmst(fit, data = lung)
   expect_s3_class(p, "ggplot")
+})
+
+# ---- regression: arm with no observation at or before tau ---------------------
+
+test_that("RMST is tau, not 0, for an arm with no observation before tau", {
+  # arm B's earliest observation (7) is after tau = 6.5, so its curve is
+  # identically 1 on [0, tau] and its RMST is exactly tau. Reading it as 0 also
+  # inverted the sign of the reported difference.
+  d <- data.frame(time   = c(6, 10, 14, 20,  7, 11, 15, 22),
+                  status = c(1,  1,  1,  0,  1,  1,  1,  0),
+                  arm    = rep(c("A", "B"), each = 4))
+  fit <- survival::survfit(survival::Surv(time, status) ~ arm, data = d)
+  tab <- ggrmst_difference(fit, data = d, tau = 6.5)
+
+  expect_equal(tab$rmst[tab$group == "arm=B"], 6.5)
+  expect_equal(tab$se[tab$group == "arm=B"], 0)
+  dr <- tab[grepl(" - ", tab$group), ]
+  expect_equal(dr$rmst, 6.5 - tab$rmst[tab$group == "arm=A"])
+  expect_gt(dr$rmst, 0)                       # B is better than A here
+})
+
+test_that("groups come from the fit's strata: order, labels and expressions", {
+  d <- survival::lung[!is.na(survival::lung$ph.ecog) &
+                        survival::lung$ph.ecog %in% c(0, 1), ]
+  d$e <- factor(d$ph.ecog)
+  d$s <- factor(d$sex, labels = c("M", "F"))
+  fit <- survival::survfit(survival::Surv(time, status) ~ s + e, data = d)
+  tab <- ggrmst_difference(fit, data = d)
+  # labels AND order must match survfit's own strata, else the plot remap
+  # attaches each arm's statistics to the wrong curve
+  expect_equal(tab$group, unname(names(fit$strata)))
+
+  # a transformed right-hand side is one group per stratum, not per distinct value
+  f2 <- survival::survfit(survival::Surv(time, status) ~ (age > 60),
+                          data = survival::lung)
+  t2 <- ggrmst_difference(f2, data = survival::lung)
+  expect_equal(t2$group[1:2], unname(names(f2$strata)))
+  expect_equal(nrow(t2), 3L)                  # 2 groups + 1 difference row
+})
+
+test_that("a weighted survfit is refused rather than silently ignored", {
+  d <- survival::lung
+  d$w <- rep(c(1, 6), length.out = nrow(d))
+  fw <- survival::survfit(survival::Surv(time, status) ~ sex, data = d, weights = w)
+  expect_error(ggrmst_difference(fw, data = d), "does not support a weighted")
+  expect_error(ggrmst(fw, data = d), "does not support a weighted")
+})
+
+test_that("conf.level is validated and is the confidence level, not a flag", {
+  fit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung)
+  expect_error(ggrmst_difference(fit, data = survival::lung, conf.level = TRUE),
+               "single number in \\(0, 1\\)")
+  expect_error(ggrmst_difference(fit, data = survival::lung, conf.level = 42),
+               "single number in \\(0, 1\\)")
+  # a missing level must give the clear message, not R's "missing value where
+  # TRUE/FALSE needed" from the comparison below it
+  expect_error(ggrmst_difference(fit, data = survival::lung,
+                                 conf.level = NA_real_),
+               "single number in \\(0, 1\\)")
+  # a narrower level gives a strictly narrower interval
+  w95 <- ggrmst_difference(fit, data = survival::lung, conf.level = 0.95)
+  w80 <- ggrmst_difference(fit, data = survival::lung, conf.level = 0.80)
+  expect_true(all(w80$upper - w80$lower < w95$upper - w95$lower))
+  # conf.int is NOT captured here: it reaches ggsurvplot() and draws the KM band.
+  # ggrmst() always draws its own RMST ribbon, so counting GeomRibbon proves
+  # nothing -- the band is a GeomConfint layer that is absent without conf.int.
+  has_band <- function(p) any(vapply(p$layers,
+                    function(l) inherits(l$geom, "GeomConfint"), logical(1)))
+  expect_false(has_band(ggrmst(fit, data = survival::lung)))
+  expect_true(has_band(ggrmst(fit, data = survival::lung, conf.int = TRUE)))
+})
+
+test_that("the ggrmst() subtitle names the contrast and honours legend.labs", {
+  fit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung)
+  # the annotation must name the arms the legend actually shows
+  p <- ggrmst(fit, data = survival::lung, legend.labs = c("Male", "Female"))
+  expect_match(p$labels$subtitle, "Delta RMST (Female - Male)", fixed = TRUE)
+
+  # a group label containing " - " must not be mistaken for a difference row:
+  # the contrast is selected by position, never by parsing the label
+  d <- survival::lung
+  d$g <- factor(ifelse(d$sex == 1, "pre - post", "ctrl"))
+  f2 <- survival::survfit(survival::Surv(time, status) ~ g, data = d)
+  tab <- ggrmst_difference(f2, data = d)
+  p2 <- ggrmst(f2, data = d)
+  # the number in the subtitle is the difference row, not a per-arm RMST
+  expect_match(p2$labels$subtitle,
+               sprintf("= %.1f ", tab$rmst[nrow(tab)]), fixed = TRUE)
+})
+
+test_that("the strata helper survives cluster terms, hostile names and a bare formula env", {
+  d <- survival::lung
+  d$sexf <- factor(d$sex, labels = c("M", "F"))
+  d$id   <- seq_len(nrow(d))
+
+  # a cluster() term is not a stratum -- survfit drops it, so we must too,
+  # otherwise every subject becomes its own "group"
+  fc <- survival::survfit(survival::Surv(time, status) ~ sexf + cluster(id), data = d)
+  expect_equal(ggrmst_difference(fc, data = d)$group[1:2],
+               unname(names(fc$strata)))
+  expect_equal(nrow(ggrmst_difference(fc, data = d)), 3L)   # 2 groups + difference
+
+  # a grouping variable whose name collides with survival::strata()'s own
+  # formals must not be passed to it as a named argument
+  for (nm in c("sep", "shortlabel", "na.group")) {
+    dd <- d; dd[[nm]] <- dd$sexf
+    f <- eval(bquote(survival::survfit(
+      survival::Surv(time, status) ~ .(as.name(nm)), data = dd)))
+    expect_equal(ggrmst_difference(f, data = dd)$group[1:2],
+                 unname(names(f$strata)),
+                 info = paste("grouping variable named", nm))
+  }
+
+  # the grouping must not re-evaluate the Surv() response. Unqualified Surv() in
+  # an environment that cannot resolve it is exactly the saved-and-reloaded fit:
+  # the right-hand side is still perfectly usable.
+  f2 <- survival::survfit(survival::Surv(time, status) ~ sexf, data = d)
+  bare <- stats::as.formula("Surv(time, status) ~ sexf",
+                            env = new.env(parent = baseenv()))
+  expect_error(stats::model.frame(stats::terms(bare), data = d), "Surv")  # the trap
+  expect_equal(levels(survminer:::.strata_group_from_formula(bare, d)),
+               unname(names(f2$strata)))
+})
+
+test_that("ggrmst() rejects a numeric conf.int instead of silently banding", {
+  fit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung)
+  # the stale spelling from before the rename must not be read as TRUE
+  expect_error(ggrmst(fit, data = survival::lung, conf.int = 0.9),
+               "must be TRUE or FALSE")
+  expect_error(ggrmst(fit, data = survival::lung, conf.int = NA), "TRUE or FALSE")
+})
+
+test_that("a collapsed grouping variable with NAs keeps the fit's cohort", {
+  # fit$strata is NULL here, so the group is relabelled "All" -- but the NAs must
+  # survive, since they are what reproduces survfit()'s na.omit. Overwriting the
+  # whole vector would compute every statistic on rows the fit excluded.
+  d <- survival::lung
+  d$g <- factor(ifelse(d$age > 65, "hi", NA))
+  fit <- survival::survfit(survival::Surv(time, status) ~ g, data = d)
+  expect_null(fit$strata)
+  expect_lt(fit$n, nrow(d))                      # the fit dropped the NA rows
+
+  tab <- ggrmst_difference(fit, data = d, tau = 500)
+  expect_equal(tab$group, "All")
+  # the estimate must be the one the plotted curve carries
+  ref <- survminer:::.rmst_one_arm(
+    d$time[!is.na(d$g)], d$status[!is.na(d$g)], tau = 500, alpha = 0.05)
+  expect_equal(tab$rmst, unname(ref[["rmst"]]))
+  expect_equal(tab$se,   unname(ref[["se"]]))
+
+  ms <- attr(ggmilestone(fit, data = d, milestone.times = 365)$plot,
+             "milestone.table")
+  expect_equal(ms$surv, unname(summary(fit, times = 365)$surv))
+
+  lm <- attr(suppressMessages(gglandmark(fit, data = d, landmark.time = 200))$plot,
+             "landmark")
+  # read the event indicator off the Surv response, as gglandmark() does: lung
+  # codes status as 1 = censored / 2 = event, so a literal `status == 1` here
+  # would mean "censored" and pass only by accident
+  keep <- !is.na(d$g)
+  resp <- survival::Surv(d$time[keep], d$status[keep])
+  tt <- as.numeric(resp[, 1]); ss <- as.numeric(resp[, 2])
+  expect_equal(lm$n.at.risk, sum(tt >= 200) - sum(tt == 200 & ss == 1))
+})
+
+test_that("the Surv-type error names the function the user called", {
+  # a counting-process (start, stop] response is not right-censored Surv(time,
+  # status); the message must name the entry point, not always ggrmst()
+  d <- data.frame(t1 = c(0, 1, 0, 2, 0, 3), t2 = c(2, 3, 4, 5, 6, 7),
+                  st = c(1, 0, 1, 0, 1, 1), g = factor(rep(c("a", "b"), 3)))
+  f <- survival::survfit(survival::Surv(t1, t2, st) ~ g, data = d)
+  expect_error(ggrmst_difference(f, data = d),
+               "ggrmst_difference\\(\\) supports right-censored")
+  expect_error(ggrmst(f, data = d), "ggrmst\\(\\) supports right-censored")
 })

--- a/tests/testthat/test-landmark-milestone.R
+++ b/tests/testthat/test-landmark-milestone.R
@@ -76,9 +76,9 @@ test_that("ggmilestone tabulates per-arm S(t) and the between-arm difference", {
   # difference row = S_A - S_B with additive Greenwood variance
   dr <- tab[grepl(" - ", tab$group) & tab$time == 365, ]
   expect_equal(nrow(dr), 1L)
-  a <- tab[tab$group == "1" & tab$time == 365, ]
-  b <- tab[tab$group == "2" & tab$time == 365, ]
-  expect_equal(dr$surv, a$surv - b$surv)
+  a <- tab[tab$group == "sex=1" & tab$time == 365, ]
+  b <- tab[tab$group == "sex=2" & tab$time == 365, ]
+  expect_equal(dr$surv, b$surv - a$surv)
   expect_equal(dr$se, sqrt(a$se^2 + b$se^2))
   expect_true(dr$p.value > 0 && dr$p.value < 1)
 })
@@ -108,8 +108,8 @@ test_that("ggmilestone needs ref.group for 3+ arms and validates it", {
   p <- ggmilestone(f3, data = d, milestone.times = 365)
   expect_false(any(grepl(" - ", attr(p$plot, "milestone.table")$group)))
   # ref.group -> difference vs the reference
-  pr <- ggmilestone(f3, data = d, milestone.times = 365, ref.group = "0")
-  expect_true(any(grepl(" - 0$", attr(pr$plot, "milestone.table")$group)))
+  pr <- ggmilestone(f3, data = d, milestone.times = 365, ref.group = "g=0")
+  expect_true(any(grepl(" - g=0$", attr(pr$plot, "milestone.table")$group)))
   expect_error(ggmilestone(f3, data = d, milestone.times = 365, ref.group = "z"),
                "ref.group")
 })
@@ -168,15 +168,22 @@ test_that("ggmilestone reports 0 beyond follow-up when the curve has reached 0",
   p <- suppressWarnings(ggmilestone(fit, data = d, milestone.times = 20))
   tab <- attr(p$plot, "milestone.table")
   # allevent's curve reaches 0 -> S(20) = 0 (estimable); censlast -> NA
-  expect_equal(tab$surv[tab$group == "allevent" & tab$time == 20], 0)
-  expect_true(is.na(tab$surv[tab$group == "censlast" & tab$time == 20]))
+  expect_equal(tab$surv[tab$group == "g=allevent" & tab$time == 20], 0)
+  expect_true(is.na(tab$surv[tab$group == "g=censlast" & tab$time == 20]))
 })
 
-test_that("ggmilestone rejects an empty-string arm label", {
+test_that("an empty factor level is labelled like survfit, not refused", {
   d <- survival::lung
   d$arm <- factor(ifelse(seq_len(nrow(d)) <= 100, "", "X"))
   fit <- survival::survfit(survival::Surv(time, status) ~ arm, data = d)
-  expect_error(ggmilestone(fit, data = d, milestone.times = 100), "empty string")
+  p <- ggmilestone(fit, data = d, milestone.times = 100)
+  tab <- attr(p$plot, "milestone.table")
+  # the composed label carries the variable name, so it is never itself empty
+  expect_equal(sort(unique(tab$group[!grepl(" - ", tab$group)])),
+               sort(unname(names(fit$strata))))
+  s <- summary(fit, times = 100)
+  expect_equal(tab$surv[tab$group == "arm="][1],  s$surv[1])
+  expect_equal(tab$surv[tab$group == "arm=X"][1], s$surv[2])
 })
 
 test_that("gglandmark re-origined curve equals an independent manual survfit", {
@@ -198,12 +205,12 @@ test_that("ggmilestone difference equals the independent Greenwood formula", {
   fit <- .fit2()
   tab <- attr(ggmilestone(fit, data = survival::lung,
                           milestone.times = 365)$plot, "milestone.table")
-  a <- tab[tab$group == "1" & tab$time == 365, ]
-  b <- tab[tab$group == "2" & tab$time == 365, ]
+  a <- tab[tab$group == "sex=1" & tab$time == 365, ]
+  b <- tab[tab$group == "sex=2" & tab$time == 365, ]
   dr <- tab[grepl(" - ", tab$group), ]
   # independent recomputation from survival::summary.survfit
   s <- summary(fit, times = 365)
-  d.ref  <- s$surv[1] - s$surv[2]
+  d.ref  <- s$surv[2] - s$surv[1]
   se.ref <- sqrt(s$std.err[1]^2 + s$std.err[2]^2)
   p.ref  <- 2 * stats::pnorm(-abs(d.ref / se.ref))
   expect_equal(dr$surv, d.ref)
@@ -219,4 +226,154 @@ test_that("both functions return a printable ggsurvplot", {
   expect_s3_class(p2, "ggsurvplot")
   expect_s3_class(p1$plot, "ggplot")
   expect_s3_class(p2$plot, "ggplot")
+})
+
+# ---- regression: strata-sourced grouping, weights, conf.type, name clashes ----
+
+test_that("ggmilestone arm labels and values line up with the plotted strata", {
+  d <- survival::lung[!is.na(survival::lung$ph.ecog) &
+                        survival::lung$ph.ecog %in% c(0, 1), ]
+  d$e <- factor(d$ph.ecog)
+  d$s <- factor(d$sex, labels = c("M", "F"))
+  fit <- survival::survfit(survival::Surv(time, status) ~ s + e, data = d)
+  tab <- attr(ggmilestone(fit, data = d, milestone.times = 365)$plot,
+              "milestone.table")
+  per <- tab[!grepl(" - ", tab$group), ]
+  # order AND value must agree with survfit; a positional remap that disagrees
+  # attaches one arm's survival to another arm's label
+  expect_equal(per$group, unname(names(fit$strata)))
+  expect_equal(per$surv, unname(summary(fit, times = 365)$surv))
+})
+
+test_that("a transformed right-hand side groups into its strata", {
+  f <- survival::survfit(survival::Surv(time, status) ~ (age > 60),
+                         data = survival::lung)
+  tab <- attr(ggmilestone(f, data = survival::lung, milestone.times = 365)$plot,
+              "milestone.table")
+  expect_equal(sort(unique(tab$group[!grepl(" - ", tab$group)])),
+               sort(unname(names(f$strata))))
+})
+
+test_that("weighted fits are refused by ggmilestone() and gglandmark()", {
+  d <- survival::lung
+  d$w <- rep(c(1, 6), length.out = nrow(d))
+  fw <- survival::survfit(survival::Surv(time, status) ~ sex, data = d, weights = w)
+  expect_error(ggmilestone(fw, data = d, milestone.times = 365),
+               "does not support a weighted")
+  expect_error(gglandmark(fw, data = d, landmark.time = 200),
+               "does not support a weighted")
+})
+
+test_that("ggmilestone survives a fit stored with conf.type = 'none'", {
+  f <- survival::survfit(survival::Surv(time, status) ~ sex,
+                         data = survival::lung, conf.type = "none")
+  tab <- attr(ggmilestone(f, data = survival::lung, milestone.times = 365)$plot,
+              "milestone.table")
+  per <- tab[!grepl(" - ", tab$group), ]
+  expect_equal(per$surv, unname(summary(f, times = 365)$surv))
+  expect_true(all(is.na(per$lower)))          # no limits were requested
+  expect_true(all(is.na(per$upper)))
+})
+
+test_that("gglandmark does not clobber a user column named .landmark_*", {
+  # the damaging case is a user column that is ALSO the grouping variable:
+  # overwriting it with the re-origined time/status destroys the grouping.
+  d <- survival::lung
+  d$.landmark_status <- factor(ifelse(d$sex == 1, "male", "female"))
+  fit <- survival::survfit(survival::Surv(time, status) ~ .landmark_status, data = d)
+  p <- gglandmark(fit, data = d, landmark.time = 200)
+  info <- attr(p$plot, "landmark")
+  # two strata must survive, with their original labels
+  expect_equal(length(info$fit$strata), 2L)
+  expect_equal(sort(unname(names(info$fit$strata))),
+               sort(c(".landmark_status=female", ".landmark_status=male")))
+})
+
+test_that("surv_median_followup() also refuses a weighted fit", {
+  d <- survival::lung
+  d$w <- rep(c(1, 6), length.out = nrow(d))
+  fw <- survival::survfit(survival::Surv(time, status) ~ sex, data = d, weights = w)
+  expect_error(surv_median_followup(fw, data = d), "does not support a weighted")
+})
+
+test_that("ggmilestone() rejects a missing conf.level with a clear message", {
+  fit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung)
+  expect_error(ggmilestone(fit, data = survival::lung, milestone.times = 365,
+                           conf.level = NA_real_),
+               "single number in \\(0, 1\\)")
+})
+
+test_that("gglandmark() re-fits a multi-term transformed RHS with the right precedence", {
+  # reformulate() would paste the term labels as `sexf + age > 60`, which R parses
+  # as `(sexf + age) > 60` -- the right-hand side must be kept verbatim.
+  d <- survival::lung
+  d$sexf <- factor(d$sex, labels = c("M", "F"))
+  fit <- survival::survfit(survival::Surv(time, status) ~ sexf + (age > 60), data = d)
+  expect_equal(length(fit$strata), 4L)
+
+  p <- gglandmark(fit, data = d, landmark.time = 200)
+  lm.fit <- attr(p$plot, "landmark")$fit
+  expect_equal(length(lm.fit$strata), 4L)
+  expect_equal(sort(unname(names(lm.fit$strata))), sort(unname(names(fit$strata))))
+})
+
+test_that("ggmilestone() rejects a numeric conf.int instead of silently banding", {
+  fit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung)
+  expect_error(ggmilestone(fit, data = survival::lung, milestone.times = 365,
+                           conf.int = 0.90), "must be TRUE or FALSE")
+})
+
+test_that("a fit that collapses to one stratum is labelled All, like surv_median()", {
+  # survfit() stores no $strata for a factor with a single used level; the table,
+  # the caption and surv_median() must not disagree about what that group is called
+  d <- survival::lung
+  d$sexf <- factor(d$sex, labels = c("M", "F"))
+  d <- d[d$sexf == "M", ]
+  f <- survival::survfit(survival::Surv(time, status) ~ sexf, data = d)
+  expect_null(f$strata)
+
+  tab <- attr(ggmilestone(f, data = d, milestone.times = 365)$plot, "milestone.table")
+  expect_equal(unique(tab$group), "All")
+  expect_equal(surv_median(f)$strata, "All")
+  expect_equal(ggrmst_difference(f, data = d)$group, "All")
+})
+
+test_that("gglandmark() rejects a numeric conf.int, like its siblings", {
+  fit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung)
+  expect_error(gglandmark(fit, data = survival::lung, landmark.time = 200,
+                          conf.int = 0.9), "must be TRUE or FALSE")
+})
+
+test_that("the ggmilestone caption follows legend.labs and the table stays tidy", {
+  fit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung)
+  p <- ggmilestone(fit, data = survival::lung, milestone.times = 365,
+                   legend.labs = c("Male", "Female"))
+  # the caption must name the arms the legend shows, not the raw strata labels
+  expect_match(p$plot$labels$caption, "Female", fixed = TRUE)
+  expect_false(grepl("sex=2", p$plot$labels$caption, fixed = TRUE))
+  # the attached table keeps the fit's own labels, with clean row names
+  tab <- attr(p$plot, "milestone.table")
+  expect_true(any(grepl("sex=", tab$group, fixed = TRUE)))
+  expect_equal(rownames(tab), as.character(seq_len(nrow(tab))))
+})
+
+test_that("the documented band level is true for each function", {
+  f80 <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung,
+                           conf.int = 0.80, conf.type = "plain")
+  f95 <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung)
+  band <- function(p) {
+    g <- if (inherits(p, "ggsurvplot")) p$plot else p
+    d <- ggplot2::ggplot_build(g)$data
+    i <- which(vapply(g$layers, function(l) inherits(l$geom, "GeomConfint"),
+                      logical(1)))[1]
+    d[[i]]$ymin[2:4]
+  }
+  # ggmilestone plots the fit itself, so its band follows the fit's level
+  expect_false(isTRUE(all.equal(
+    band(ggmilestone(f95, data = survival::lung, milestone.times = 365, conf.int = TRUE)),
+    band(ggmilestone(f80, data = survival::lung, milestone.times = 365, conf.int = TRUE)))))
+  # gglandmark re-fits on the landmark cohort, so the band is survfit's default
+  expect_equal(
+    band(gglandmark(f95, data = survival::lung, landmark.time = 200, conf.int = TRUE)),
+    band(gglandmark(f80, data = survival::lung, landmark.time = 200, conf.int = TRUE)))
 })

--- a/tests/testthat/test-surv_median_followup.R
+++ b/tests/testthat/test-surv_median_followup.R
@@ -63,12 +63,12 @@ test_that("an ungrouped fit gives a single overall 'All' row", {
   expect_true(is.finite(tab$median))
 })
 
-test_that("conf.int overrides the fit's confidence level", {
+test_that("conf.level overrides the fit's confidence level", {
   fit90 <- surv_fit(Surv(time, status) ~ 1, data = lung, conf.int = 0.90)
   # honours the fit's level by default
   d90 <- surv_median_followup(fit90)
   # explicit override to 0.99 widens (or holds) the interval vs 0.90
-  d99 <- surv_median_followup(fit90, conf.int = 0.99)
+  d99 <- surv_median_followup(fit90, conf.level = 0.99)
   expect_equal(d90$median, d99$median)                 # point estimate unchanged
   # a wider confidence level cannot give a tighter lower limit
   expect_lte(d99$lower[1], d90$lower[1])
@@ -106,4 +106,16 @@ test_that("competing-risks / multi-state and left-censored data are refused", {
 test_that("non-survfit input is rejected", {
   expect_error(surv_median_followup(lm(time ~ status, data = lung)),
                "must be a survfit")
+})
+
+test_that("conf.level is validated", {
+  fit <- surv_fit(Surv(time, status) ~ sex, data = lung)
+  expect_error(surv_median_followup(fit, data = lung, conf.level = TRUE),
+               "single number in \\(0, 1\\)")
+  expect_error(surv_median_followup(fit, data = lung, conf.level = 42),
+               "single number in \\(0, 1\\)")
+  expect_error(surv_median_followup(fit, data = lung, conf.level = NA_real_),
+               "single number in \\(0, 1\\)")
+  # NULL is the documented default: inherit the fit's own level
+  expect_silent(surv_median_followup(fit, data = lung, conf.level = NULL))
 })

--- a/vignettes/Effect_measures.Rmd
+++ b/vignettes/Effect_measures.Rmd
@@ -103,9 +103,11 @@ ggmilestone(fit, data = lung, milestone.times = c(180, 360, 540),
 
 Each dashed line is a milestone; the caption gives, per timepoint, the survival
 in each arm and their difference with a 95% confidence interval and p-value. The
-difference is reported as Male − Female, so the negative values mean women do
-better at every timepoint -- consistent with the positive Female − Male RMST
-above. The full table is also attached to the plot:
+difference is the second arm minus the first -- Female − Male here -- so the
+positive values mean women do better at every timepoint, in the same direction as
+the positive Female − Male RMST above. Every difference row is labelled with its
+contrast, so the direction never has to be inferred. The full table is also
+attached to the plot:
 
 ```{r milestone-table}
 p <- ggmilestone(fit, data = lung, milestone.times = c(180, 360, 540))


### PR DESCRIPTION
`ggrmst()`, `ggmilestone()` and `gglandmark()` rebuilt their grouping with
`interaction()` over the variables of the formula's right-hand side. That orders the
levels differently from `survfit` when the right-hand side has more than one
variable, so each arm's statistics were attached to the wrong curve.

```r
library(survival)
library(survminer)

d <- lung[!is.na(lung$ph.ecog) & lung$ph.ecog %in% c(0, 1), ]
d$e <- factor(d$ph.ecog)
d$s <- factor(d$sex, labels = c("M", "F"))
fit <- survfit(Surv(time, status) ~ s + e, data = d)

ggmilestone(fit, data = d, milestone.times = 365)
summary(fit, times = 365)$surv   # the truth
#> 0.4801 0.3262 0.6184 0.6014
```

**Before** — the two middle arms are exchanged. `s=M, e=1` is captioned 62% when its
survival is 33%, and `s=F, e=0` is captioned 33% when its survival is 62%. The teal
`s=F, e=0` marker is drawn at 33%, sitting on the green curve:

![before](https://i.imgur.com/AAsWsz2.png)

**After** — every marker sits on its own curve and the caption matches `summary()`:

![after](https://i.imgur.com/EDkcNrs.png)

The grouping is now built the way `survfit` builds it, from the model frame's term
columns, so labels and their order agree with `names(fit$strata)` and with the plotted
curves by construction rather than by coincidence. A fit that collapses to a single
stratum reports `"All"`, as `surv_median()` and `surv_summary()` already do.

The same rebuild discarded a transformed term, so `~ (age > 60)` grouped by `age`:

```r
f <- survfit(Surv(time, status) ~ (age > 60), data = lung)
nrow(ggrmst_difference(f, data = lung))
#> before: 42 rows (one per distinct age)   after: 3 (two strata + the difference)
```

## Also in these functions

- `ggrmst_difference()` returned an RMST of 0, and a difference with the wrong sign,
  for an arm whose first observation falls after `tau`. The curve is 1 throughout that
  interval, so the restricted mean is `tau`.

  ```r
  d <- data.frame(time   = c(6, 10, 14, 20,  7, 11, 15, 22),
                  status = c(1,  1,  1,  0,  1,  1,  1,  0),
                  arm    = rep(c("A", "B"), each = 4))
  ggrmst_difference(survfit(Surv(time, status) ~ arm, data = d), data = d, tau = 6.5)
  #> before: arm B 0.000, difference -6.375 (p = 0)
  #> after:  arm B 6.500, difference +0.125   == survRM2::rmst2()
  ```

- A weighted `survfit()` is refused. These summaries read the risk and event counts off
  the curve, and the confidence-interval convention for weighted data is not determined
  by the fit, so the previous behaviour annotated an unweighted estimate onto a weighted
  curve.

- The confidence level is named `conf.level`, leaving `conf.int` its package-wide
  meaning of drawing the confidence band. Previously `ggrmst(conf.int = TRUE)` produced
  `100% CI -Inf to Inf`. The four plotting functions now reject a numeric `conf.int`
  rather than read it as `TRUE`.

- `ggmilestone()` reports the difference as the second arm minus the first, matching
  `ggrmst_difference()` and `survRM2`'s `arm1 - arm0`; every difference row is labelled
  with its contrast. It returns `NA` limits instead of failing on a fit stored with
  `conf.type = "none"`, and labels an empty factor level like `survfit` rather than
  refusing it.

- `gglandmark()` re-fits the landmark cohort with the right-hand side as written
  (`~ sexf + (age > 60)` previously produced one stratum per distinct age), and stores
  the re-origined time and status in columns that cannot collide with a column of the
  same name in the data.

- `ggrmst()`'s subtitle names the contrast it reports, using the labels shown in the
  legend, and selects the difference row by position so a group label containing `" - "`
  cannot be mistaken for one.

## Checks

- `ggrmst_difference()` matches `survRM2::rmst2()` on 300 random datasets (estimate and
  standard error, sign included); `ggmilestone()` matches an independent Greenwood
  recomputation from `summary.survfit`.
- `ggsurvplot()` and the rest of the package are unchanged: the shipped call grid
  returns identical results, as does `ggcoxnph()`, which shares the RMST internals.
- 1388 tests pass under `R --vanilla`; `R CMD check --as-cran` and the `_R_CHECK_DEPENDS_ONLY_`
  flavour are clean.

These five functions are new in the unreleased 1.0.0, so nothing on CRAN changes.
