### PR TITLE
Name the confidence level conf.level in the Cox diagnostic and forest plots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,13 @@
 - `ggsurvplot()` now accepts `plotmath` expressions in `legend.labs` (e.g. `legend.labs = c(expression(beta[1]), expression(x^2))`), rendering superscripts, subscripts and Greek letters in the legend and the number-at-risk table while leaving the palette unchanged (#350). A plain character `legend.labs` behaves exactly as before.
 
 - `ggcoxnph()`, `ggforest_models()` and `ggforest_subgroup()` name their
-  confidence-level argument `conf.level`. Across the package `conf.int` now
-  consistently means "draw the confidence band" and `conf.level` means "at what
-  level".
+  confidence-level argument `conf.level`, and reject a value outside (0, 1).
+  Across the package `conf.int` now consistently means "draw the confidence band"
+  and `conf.level` means "at what level".
+
+- `ggforest_subgroup()`'s hazard-ratio column header states the confidence level
+  actually used; it read "HR (95% CI)" whatever `conf.level` was set to, while the
+  intervals beneath it and the axis title both followed the requested level.
 
 - New `ggforest_models()` draws a forest plot comparing one covariate's hazard ratio across several Cox models -- one row per model -- for the crude-versus-adjusted (or naive-versus-time-varying) comparison. The hazard ratio, CI and p-value are read from each model (robust variance when present); a model missing the term is dropped with a warning, and a very wide interval is clamped to a robust axis window with an arrow (the full interval stays in the table) so one model cannot crush the shared scale. It is the model-wise sibling of `ggforest()` and `ggforest_subgroup()`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 - `ggsurvplot()` now accepts `plotmath` expressions in `legend.labs` (e.g. `legend.labs = c(expression(beta[1]), expression(x^2))`), rendering superscripts, subscripts and Greek letters in the legend and the number-at-risk table while leaving the palette unchanged (#350). A plain character `legend.labs` behaves exactly as before.
 
+- `ggcoxnph()`, `ggforest_models()` and `ggforest_subgroup()` name their
+  confidence-level argument `conf.level`. Across the package `conf.int` now
+  consistently means "draw the confidence band" and `conf.level` means "at what
+  level".
+
 - New `ggforest_models()` draws a forest plot comparing one covariate's hazard ratio across several Cox models -- one row per model -- for the crude-versus-adjusted (or naive-versus-time-varying) comparison. The hazard ratio, CI and p-value are read from each model (robust variance when present); a model missing the term is dropped with a warning, and a very wide interval is clamped to a robust axis window with an arrow (the full interval stays in the table) so one model cannot crush the shared scale. It is the model-wise sibling of `ggforest()` and `ggforest_subgroup()`.
 
 - `ggsurvplot_facet()` gains `pval.stratified = TRUE`, showing a single pooled stratified log-rank p-value -- `survdiff(Surv(time, status) ~ group + strata(facet.by))`, the group effect adjusting for the faceting variable -- as a figure-level subtitle. This is the statistic the whole figure illustrates: the per-panel p-values are within-facet, and several may be non-significant even when the pooled effect is strong. It is independent of `pval` (they combine). Only the log-rank / Peto (`rho`) family is used; the pooled test assumes a consistent group effect across strata.

--- a/R/ggcoxnph.R
+++ b/R/ggcoxnph.R
@@ -62,7 +62,8 @@ NULL
 #'  vector).
 #'@param ggtheme a ggplot2 theme. Default \code{\link{theme_survminer}()}.
 #'@param title an overall title used when the panel is printed.
-#'@param ... additional arguments (currently unused).
+#'@param ... additional arguments (currently unused). Passing `conf.int` here
+#'  is an error: use `conf.level`.
 #'
 #'@return an object of class \code{c("ggcoxnph", "ggsurv", "list")}: a named list
 #'  of the drawn ggplots (one per surviving panel). Printing it arranges the
@@ -114,7 +115,13 @@ ggcoxnph <- function(fit, variable = NULL, data = NULL,
     stop("`conf.level` must be a single number in (0, 1).", call. = FALSE)
   # `conf.int` means "draw the confidence band" throughout survminer; it is not a
   # ggcoxnph() argument, and `...` would otherwise swallow the older spelling.
-  if ("conf.int" %in% names(list(...)))
+  # Catch abbreviations too: `conf.i` used to partial-match the old `conf.int`,
+  # but it is not a prefix of `conf.level`, so it would otherwise fall into `...`
+  # and be ignored. ...names() avoids forcing the dots promises.
+  .dots <- if (getRversion() >= "4.1.0") ...names() else names(list(...))
+  if (is.null(.dots)) .dots <- character(0)          # no dots, or none named
+  .dots <- .dots[nzchar(.dots)]
+  if (length(.dots) && any(startsWith("conf.int", .dots)))
     stop("`conf.int` is not a ggcoxnph() argument. Use `conf.level` to set the ",
          "confidence level of the pointwise bands.", call. = FALSE)
   z <- stats::qnorm(1 - (1 - conf.level) / 2)

--- a/R/ggcoxnph.R
+++ b/R/ggcoxnph.R
@@ -50,7 +50,8 @@ NULL
 #'  fit and can change the drawn shape.
 #'@param tau maximum horizon for the \code{rmst} panel. \code{NULL} (default)
 #'  uses the largest admissible time.
-#'@param conf.int confidence level for the pointwise bands. Default \code{0.95}.
+#'@param conf.level confidence level for the pointwise bands, a single number in
+#'  (0, 1). Default \code{0.95}.
 #'@param df degrees of freedom of the natural-spline smooth of the Schoenfeld
 #'  residuals. Default \code{4}; \code{df = 2} gives an almost-linear fit.
 #'@param numeric.split for a numeric covariate, whether to split it at its median
@@ -100,7 +101,7 @@ NULL
 #'@export
 ggcoxnph <- function(fit, variable = NULL, data = NULL,
                      panels = c("cloglog", "schoenfeld", "hr", "rmst"),
-                     transform = "km", tau = NULL, conf.int = 0.95, df = 4,
+                     transform = "km", tau = NULL, conf.level = 0.95, df = 4,
                      numeric.split = FALSE,
                      palette = NULL, ggtheme = theme_survminer(),
                      title = NULL, ...) {
@@ -108,7 +109,15 @@ ggcoxnph <- function(fit, variable = NULL, data = NULL,
   if (!methods::is(fit, "coxph"))
     stop("`fit` must be a coxph model.", call. = FALSE)
   panels <- match.arg(panels, several.ok = TRUE)
-  z <- stats::qnorm(1 - (1 - conf.int) / 2)
+  if (!is.numeric(conf.level) || length(conf.level) != 1L || is.na(conf.level) ||
+      conf.level <= 0 || conf.level >= 1)
+    stop("`conf.level` must be a single number in (0, 1).", call. = FALSE)
+  # `conf.int` means "draw the confidence band" throughout survminer; it is not a
+  # ggcoxnph() argument, and `...` would otherwise swallow the older spelling.
+  if ("conf.int" %in% names(list(...)))
+    stop("`conf.int` is not a ggcoxnph() argument. Use `conf.level` to set the ",
+         "confidence level of the pointwise bands.", call. = FALSE)
+  z <- stats::qnorm(1 - (1 - conf.level) / 2)
 
   # ---- resolve the covariate and its term structure ----------------------
   term.labels <- attr(stats::terms(fit), "term.labels")
@@ -246,7 +255,7 @@ ggcoxnph <- function(fit, variable = NULL, data = NULL,
     plots$hr <- .nph_panel_hr(beta_t, beta_hat, variable, ggtheme)
   rmst_tau <- NULL
   if ("rmst" %in% want) {
-    rp <- .nph_panel_rmst(time, status, group, tau, z, conf.int, variable,
+    rp <- .nph_panel_rmst(time, status, group, tau, z, conf.level, variable,
                           palette, ggtheme, group.msg)
     plots$rmst <- rp$plot
     rmst_tau <- rp$data
@@ -417,7 +426,7 @@ ggcoxnph <- function(fit, variable = NULL, data = NULL,
   data.frame(tau = taus, rmst = out["rmst", ], var = out["var", ])
 }
 
-.nph_panel_rmst <- function(time, status, group, tau, z, conf.int, variable,
+.nph_panel_rmst <- function(time, status, group, tau, z, conf.level, variable,
                             palette, ggtheme, group.msg) {
   d <- data.frame(time = time, status = status, .g = group)
   d <- d[stats::complete.cases(d), , drop = FALSE]

--- a/R/ggforest_models.R
+++ b/R/ggforest_models.R
@@ -31,7 +31,8 @@ NULL
 #'  "Model 1", "Model 2", ...).
 #' @param term the model variable (or a single coefficient name) whose hazard ratio
 #'  is compared across the models.
-#' @param conf.int the confidence level for the intervals. Default 0.95.
+#' @param conf.level the confidence level for the intervals, a single number in
+#'   (0, 1). Default 0.95.
 #' @param model.names optional character vector of row labels, used when the
 #'  \code{models} list is unnamed.
 #' @param show.p logical. Show the per-model Wald p-value column. Default TRUE.
@@ -61,7 +62,7 @@ NULL
 #' ggforest_models(list("Crude" = m.crude, "Adjusted" = m.adjusted), term = "age")
 #'
 #' @export
-ggforest_models <- function(models, term, conf.int = 0.95, model.names = NULL,
+ggforest_models <- function(models, term, conf.level = 0.95, model.names = NULL,
                             show.p = TRUE, show.n = TRUE, favours = NULL,
                             point.size.by.precision = FALSE,
                             main = "Hazard ratio comparison", xlab = NULL,
@@ -76,7 +77,7 @@ ggforest_models <- function(models, term, conf.int = 0.95, model.names = NULL,
     stop("Every element of `models` must be a coxph model; element(s) ",
          paste(bad, collapse = ", "), " are not.", call. = FALSE)
 
-  tab <- .models_forest_table(models, term, conf.int, model.names)
+  tab <- .models_forest_table(models, term, conf.level, model.names)
   if (!nrow(tab))
     stop("No model contained `", term, "`; nothing to plot.", call. = FALSE)
 
@@ -87,7 +88,7 @@ ggforest_models <- function(models, term, conf.int = 0.95, model.names = NULL,
   if (!is.null(favours) && length(favours) == 2L) yr[1] <- yr[1] - 0.6
 
   if (is.null(xlab))
-    xlab <- sprintf("Hazard ratio for %s (%g%% CI, log scale)", term, conf.int * 100)
+    xlab <- sprintf("Hazard ratio for %s (%g%% CI, log scale)", term, conf.level * 100)
 
   # robust drawing window from the point HRs, so one wide CI cannot dominate the
   # shared axis; clip whiskers to it and flag the clipped ends with an arrow.
@@ -184,7 +185,7 @@ ggforest_models <- function(models, term, conf.int = 0.95, model.names = NULL,
     widths <- c(widths, 0.5 + 0.095 * max(nchar(c(n.df$nlab, "Events/N"))))
   }
 
-  ci.header <- sprintf("HR (%g%% CI)", conf.int * 100)
+  ci.header <- sprintf("HR (%g%% CI)", conf.level * 100)
   tab$hrci <- .fmt_hrci(tab, noDigits)
   hrci.panel <- ggplot2::ggplot(tab, ggplot2::aes(x = 1, y = y)) +
     ggplot2::geom_text(ggplot2::aes(label = hrci), hjust = 1, size = 3.3) +
@@ -218,7 +219,7 @@ ggforest_models <- function(models, term, conf.int = 0.95, model.names = NULL,
 
 # Extract one term's HR / CI / p from each coxph model (base survival, robust-safe).
 # Returns a data.frame of estimable + dropped rows (one per kept model).
-.models_forest_table <- function(models, term, conf.int, model.names) {
+.models_forest_table <- function(models, term, conf.level, model.names) {
   # Row labels: list names, filling only the missing ones (a partially named list
   # keeps its real names), then model.names, then "Model i".
   labs <- names(models); if (is.null(labs)) labs <- rep("", length(models))
@@ -226,7 +227,7 @@ ggforest_models <- function(models, term, conf.int = 0.95, model.names = NULL,
           else paste("Model", seq_along(models))
   empty <- !nzchar(labs); labs[empty] <- fill[empty]
   labs <- make.unique(labs)
-  z <- stats::qnorm(1 - (1 - conf.int) / 2)
+  z <- stats::qnorm(1 - (1 - conf.level) / 2)
 
   rows <- list(); classes <- character(); coef.names <- character()
   for (i in seq_along(models)) {

--- a/R/ggforest_models.R
+++ b/R/ggforest_models.R
@@ -77,6 +77,9 @@ ggforest_models <- function(models, term, conf.level = 0.95, model.names = NULL,
     stop("Every element of `models` must be a coxph model; element(s) ",
          paste(bad, collapse = ", "), " are not.", call. = FALSE)
 
+  if (!is.numeric(conf.level) || length(conf.level) != 1L || is.na(conf.level) ||
+      conf.level <= 0 || conf.level >= 1)
+    stop("`conf.level` must be a single number in (0, 1).", call. = FALSE)
   tab <- .models_forest_table(models, term, conf.level, model.names)
   if (!nrow(tab))
     stop("No model contained `", term, "`; nothing to plot.", call. = FALSE)

--- a/R/ggforest_subgroup.R
+++ b/R/ggforest_subgroup.R
@@ -194,10 +194,10 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
   # HR text is right-aligned so it sits adjacent to the p-int column (rather than
   # drifting to a wide right-edge gap as the figure widens).
   est$hrci <- .fmt_hrci(est, noDigits)
+  ci.header <- sprintf("HR (%g%% CI)", conf.level * 100)
   hrci.panel <- ggplot2::ggplot(est, ggplot2::aes(x = 1, y = y)) +
     ggplot2::geom_text(ggplot2::aes(label = hrci), hjust = 1, size = 3.3) +
-    ggplot2::annotate("text", x = 1, y = head.y,
-                    label = sprintf("HR (%g%% CI)", conf.level * 100),
+    ggplot2::annotate("text", x = 1, y = head.y, label = ci.header,
                       hjust = 1, fontface = "bold", size = 3.15) +
     ggplot2::scale_x_continuous(limits = c(0, 1),
                                 expand = ggplot2::expansion(mult = c(0.04, 0.02))) + void
@@ -213,7 +213,7 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
     widths <- c(widths, 0.5 + 0.095 * max(nchar(c(n.df$nlab, "No. (%)"))))
   }
   panels <- c(panels, list(forest, hrci.panel))
-  widths <- c(widths, 3.4, 0.5 + 0.085 * max(nchar(c(est$hrci, "HR (95% CI)"))))
+  widths <- c(widths, 3.4, 0.5 + 0.085 * max(nchar(c(est$hrci, ci.header))))
   if (has.pint) {
     # bare p-value under a "P-int" header (shorter than an inline "p-int x" label,
     # so the rightmost column does not clip at narrow widths), centred in its panel.

--- a/R/ggforest_subgroup.R
+++ b/R/ggforest_subgroup.R
@@ -100,6 +100,9 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
                               xlab = NULL, noDigits = 2,
                               ggtheme = theme_survminer()) {
 
+  if (!is.numeric(conf.level) || length(conf.level) != 1L || is.na(conf.level) ||
+      conf.level <= 0 || conf.level >= 1)
+    stop("`conf.level` must be a single number in (0, 1).", call. = FALSE)
   tab <- .subgroup_forest_table(model, data, treatment, subgroups,
                                 conf.level, show.overall)
   if (nrow(tab[tab$type != "header", , drop = FALSE]) == 0L)
@@ -193,7 +196,8 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
   est$hrci <- .fmt_hrci(est, noDigits)
   hrci.panel <- ggplot2::ggplot(est, ggplot2::aes(x = 1, y = y)) +
     ggplot2::geom_text(ggplot2::aes(label = hrci), hjust = 1, size = 3.3) +
-    ggplot2::annotate("text", x = 1, y = head.y, label = "HR (95% CI)",
+    ggplot2::annotate("text", x = 1, y = head.y,
+                    label = sprintf("HR (%g%% CI)", conf.level * 100),
                       hjust = 1, fontface = "bold", size = 3.15) +
     ggplot2::scale_x_continuous(limits = c(0, 1),
                                 expand = ggplot2::expansion(mult = c(0.04, 0.02))) + void

--- a/R/ggforest_subgroup.R
+++ b/R/ggforest_subgroup.R
@@ -47,7 +47,8 @@ NULL
 #'   May be named, in which case the names are used as the display labels, e.g.
 #'   \code{c(Sex = "sex", "Age group" = "age.grp")}. Continuous variables must be
 #'   binned first.
-#' @param conf.int the confidence level for the intervals. Default 0.95.
+#' @param conf.level the confidence level for the intervals, a single number in
+#'   (0, 1). Default 0.95.
 #' @param show.overall logical; add an overall (all-subjects) treatment hazard
 #'   ratio row at the top. Default \code{TRUE}.
 #' @param show.pinteraction logical; show the per-variable interaction p-value.
@@ -91,7 +92,7 @@ NULL
 #'                   subgroups = c(Sex = "sex", Age = "age.grp", Differentiation = "differ"))
 #' @export
 ggforest_subgroup <- function(model, data = NULL, treatment,
-                              subgroups, conf.int = 0.95,
+                              subgroups, conf.level = 0.95,
                               show.overall = TRUE, show.pinteraction = TRUE,
                               show.n = TRUE, favours = NULL,
                               point.size.by.precision = TRUE,
@@ -100,7 +101,7 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
                               ggtheme = theme_survminer()) {
 
   tab <- .subgroup_forest_table(model, data, treatment, subgroups,
-                                conf.int, show.overall)
+                                conf.level, show.overall)
   if (nrow(tab[tab$type != "header", , drop = FALSE]) == 0L)
     stop("No subgroup level could be estimated; nothing to plot.", call. = FALSE)
 
@@ -116,7 +117,7 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
     xlab <- sprintf("Hazard ratio (%s, %g%% CI, log scale)",
                     if (!is.na(trt.lev) && !is.na(ref.lev))
                       paste(trt.lev, "vs", ref.lev) else "treatment",
-                    conf.int * 100)
+                    conf.level * 100)
 
   # ---- forest panel (the only one with an x-axis) --------------------------
   rng <- range(c(est$lower, est$upper), na.rm = TRUE)
@@ -239,7 +240,7 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
 # treatment HR + CI and the per-variable interaction p-value. Attaches the
 # treatment/reference labels used in the axis title.
 .subgroup_forest_table <- function(model, data, treatment, subgroups,
-                                    conf.int = 0.95, show.overall = TRUE) {
+                                    conf.level = 0.95, show.overall = TRUE) {
   if (!inherits(model, "coxph"))
     stop("`model` must be a coxph object.", call. = FALSE)
   if (missing(treatment) || length(treatment) != 1L || !is.character(treatment))
@@ -257,7 +258,7 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
   if (length(miss) > 0)
     stop("Not found in the data: ", paste(miss, collapse = ", "), ".", call. = FALSE)
 
-  alpha <- 1 - conf.int
+  alpha <- 1 - conf.level
   tkey  <- .treatment_key(model, treatment, data)   # coef name + labels
 
   # per-subset treatment HR/CI/precision from a refit of the model formula

--- a/man/ggcoxnph.Rd
+++ b/man/ggcoxnph.Rd
@@ -67,7 +67,8 @@ vector).}
 
 \item{title}{an overall title used when the panel is printed.}
 
-\item{...}{additional arguments (currently unused).}
+\item{...}{additional arguments (currently unused). Passing `conf.int` here
+is an error: use `conf.level`.}
 
 \item{x}{a \code{ggcoxnph} object.}
 

--- a/man/ggcoxnph.Rd
+++ b/man/ggcoxnph.Rd
@@ -13,7 +13,7 @@ ggcoxnph(
   panels = c("cloglog", "schoenfeld", "hr", "rmst"),
   transform = "km",
   tau = NULL,
-  conf.int = 0.95,
+  conf.level = 0.95,
   df = 4,
   numeric.split = FALSE,
   palette = NULL,
@@ -49,7 +49,8 @@ fit and can change the drawn shape.}
 \item{tau}{maximum horizon for the \code{rmst} panel. \code{NULL} (default)
 uses the largest admissible time.}
 
-\item{conf.int}{confidence level for the pointwise bands. Default \code{0.95}.}
+\item{conf.level}{confidence level for the pointwise bands, a single number in
+(0, 1). Default \code{0.95}.}
 
 \item{df}{degrees of freedom of the natural-spline smooth of the Schoenfeld
 residuals. Default \code{4}; \code{df = 2} gives an almost-linear fit.}

--- a/man/ggforest_models.Rd
+++ b/man/ggforest_models.Rd
@@ -7,7 +7,7 @@
 ggforest_models(
   models,
   term,
-  conf.int = 0.95,
+  conf.level = 0.95,
   model.names = NULL,
   show.p = TRUE,
   show.n = TRUE,
@@ -27,7 +27,8 @@ names are used as the row labels (falling back to \code{model.names}, then
 \item{term}{the model variable (or a single coefficient name) whose hazard ratio
 is compared across the models.}
 
-\item{conf.int}{the confidence level for the intervals. Default 0.95.}
+\item{conf.level}{the confidence level for the intervals, a single number in
+(0, 1). Default 0.95.}
 
 \item{model.names}{optional character vector of row labels, used when the
 \code{models} list is unnamed.}

--- a/man/ggforest_subgroup.Rd
+++ b/man/ggforest_subgroup.Rd
@@ -9,7 +9,7 @@ ggforest_subgroup(
   data = NULL,
   treatment,
   subgroups,
-  conf.int = 0.95,
+  conf.level = 0.95,
   show.overall = TRUE,
   show.pinteraction = TRUE,
   show.n = TRUE,
@@ -38,7 +38,8 @@ May be named, in which case the names are used as the display labels, e.g.
 \code{c(Sex = "sex", "Age group" = "age.grp")}. Continuous variables must be
 binned first.}
 
-\item{conf.int}{the confidence level for the intervals. Default 0.95.}
+\item{conf.level}{the confidence level for the intervals, a single number in
+(0, 1). Default 0.95.}
 
 \item{show.overall}{logical; add an overall (all-subjects) treatment hazard
 ratio row at the top. Default \code{TRUE}.}

--- a/tests/testthat/test-ggcoxnph.R
+++ b/tests/testthat/test-ggcoxnph.R
@@ -112,3 +112,18 @@ test_that("panels= subsets the drawn panels", {
 test_that("a non-coxph input errors", {
   expect_error(ggcoxnph(lm(1 ~ 1)), "must be a coxph")
 })
+
+test_that("conf.level is validated and a stale conf.int is refused", {
+  skip_if_not_installed("survival")
+  d <- survival::lung
+  d$sexf <- factor(d$sex, labels = c("M", "F"))
+  fit <- survival::coxph(survival::Surv(time, status) ~ sexf, data = d)
+  # ggcoxnph() has `...`, so a stale conf.int would otherwise be swallowed and
+  # the bands would silently stay at 95%
+  expect_error(ggcoxnph(fit, data = d, variable = "sexf", conf.int = 0.9),
+               "not a ggcoxnph\\(\\) argument")
+  expect_error(ggcoxnph(fit, data = d, variable = "sexf", conf.level = 42),
+               "single number in \\(0, 1\\)")
+  expect_error(ggcoxnph(fit, data = d, variable = "sexf", conf.level = NA_real_),
+               "single number in \\(0, 1\\)")
+})

--- a/tests/testthat/test-ggcoxnph.R
+++ b/tests/testthat/test-ggcoxnph.R
@@ -127,3 +127,26 @@ test_that("conf.level is validated and a stale conf.int is refused", {
   expect_error(ggcoxnph(fit, data = d, variable = "sexf", conf.level = NA_real_),
                "single number in \\(0, 1\\)")
 })
+
+test_that("the conf.int guard covers abbreviations and does not force the dots", {
+  skip_if_not_installed("survival")
+  d <- survival::lung
+  d$sexf <- factor(d$sex, labels = c("M", "F"))
+  fit <- survival::coxph(survival::Surv(time, status) ~ sexf, data = d)
+
+  # `conf.i` used to partial-match the old `conf.int`; it is not a prefix of
+  # `conf.level`, so without the prefix test it lands in ... and is ignored
+  for (nm in c("conf.int", "conf.in", "conf.i")) {
+    args <- list(fit, data = d, variable = "sexf", panels = "hr")
+    args[[nm]] <- 0.9
+    expect_error(do.call(ggcoxnph, args), "not a ggcoxnph\\(\\) argument",
+                 info = nm)
+  }
+
+  # the guard must inspect the dots NAMES only -- evaluating them would turn an
+  # unused argument into an error
+  expect_error(
+    suppressWarnings(ggcoxnph(fit, data = d, variable = "sexf", panels = "hr",
+                              unused = stop("must not be forced"))),
+    NA)
+})

--- a/tests/testthat/test-ggforest-models.R
+++ b/tests/testthat/test-ggforest-models.R
@@ -33,7 +33,7 @@ test_that("the HR / CI / p per model match a direct coxph extraction (and broom)
   }
 })
 
-test_that("conf.int controls the interval width", {
+test_that("conf.level controls the interval width", {
   models <- .mm()
   t95 <- survminer:::.models_forest_table(models, "age", 0.95, NULL)
   t90 <- survminer:::.models_forest_table(models, "age", 0.90, NULL)
@@ -105,7 +105,7 @@ test_that("a partially named models list keeps the provided names", {
   expect_equal(tab$model, c("Named", "Model 2"))
 })
 
-test_that("the CI-column header tracks conf.int (no hardcoded 95%)", {
+test_that("the CI-column header tracks conf.level (no hardcoded 95%)", {
   library(survival)
   m <- coxph(Surv(time, status) ~ age, data = lung)
   labs <- function(p) {
@@ -124,9 +124,13 @@ test_that("conf.level is validated and names the confidence level", {
   # a narrower level must give a strictly narrower interval
   w95 <- survminer:::.models_forest_table(list(A = m), "age", 0.95, NULL)
   w80 <- survminer:::.models_forest_table(list(A = m), "age", 0.80, NULL)
-  expect_true(all(w80$hi - w80$lo < w95$hi - w95$lo))
+  expect_true(all(w80$upper - w80$lower < w95$upper - w95$lower))
   # the stale spelling has no `...` to hide in, so it fails loudly
   # match the argument name, not R's "unused argument" wording, which is translated
   expect_error(ggforest_models(list(A = m), term = "age", conf.int = 0.9),
                "conf\\.int")
+  expect_error(ggforest_models(list(A = m, B = m), term = "age", conf.level = TRUE),
+               "single number in \\(0, 1\\)")
+  expect_error(ggforest_models(list(A = m, B = m), term = "age", conf.level = 42),
+               "single number in \\(0, 1\\)")
 })

--- a/tests/testthat/test-ggforest-models.R
+++ b/tests/testthat/test-ggforest-models.R
@@ -116,5 +116,17 @@ test_that("the CI-column header tracks conf.int (no hardcoded 95%)", {
     w(gt); L
   }
   expect_true(any(grepl("HR (80% CI)", labs(
-    ggforest_models(list(A = m, B = m), term = "age", conf.int = 0.8)), fixed = TRUE)))
+    ggforest_models(list(A = m, B = m), term = "age", conf.level = 0.8)), fixed = TRUE)))
+})
+
+test_that("conf.level is validated and names the confidence level", {
+  m <- survival::coxph(survival::Surv(time, status) ~ age + sex, data = survival::lung)
+  # a narrower level must give a strictly narrower interval
+  w95 <- survminer:::.models_forest_table(list(A = m), "age", 0.95, NULL)
+  w80 <- survminer:::.models_forest_table(list(A = m), "age", 0.80, NULL)
+  expect_true(all(w80$hi - w80$lo < w95$hi - w95$lo))
+  # the stale spelling has no `...` to hide in, so it fails loudly
+  # match the argument name, not R's "unused argument" wording, which is translated
+  expect_error(ggforest_models(list(A = m), term = "age", conf.int = 0.9),
+               "conf\\.int")
 })

--- a/tests/testthat/test-ggforest_subgroup.R
+++ b/tests/testthat/test-ggforest_subgroup.R
@@ -17,7 +17,7 @@ test_that("within-level hazard ratios match a manual coxph on each subset", {
   d <- .cc()
   fit <- coxph(Surv(time, status) ~ rx, data = d)
   tab <- survminer:::.subgroup_forest_table(fit, d, "rx",
-            c("sex", "age.grp", "differ"), conf.int = 0.95, show.overall = TRUE)
+            c("sex", "age.grp", "differ"), conf.level = 0.95, show.overall = TRUE)
 
   # overall
   m0 <- coxph(Surv(time, status) ~ rx, data = d)

--- a/tests/testthat/test-ggforest_subgroup.R
+++ b/tests/testthat/test-ggforest_subgroup.R
@@ -157,3 +157,30 @@ test_that("non-coxph input and unknown variables are refused", {
   expect_error(ggforest_subgroup(fit, data = d, treatment = "rx", subgroups = "nope"),
                "Not found")
 })
+
+test_that("conf.level is validated and the CI column header tracks it", {
+  d <- survival::colon[survival::colon$etype == 2 &
+                         survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  d$rx  <- droplevels(d$rx)
+  d$sex <- factor(d$sex, labels = c("F", "M"))
+  fit <- survival::coxph(survival::Surv(time, status) ~ rx, data = d)
+
+  expect_error(ggforest_subgroup(fit, d, "rx", "sex", conf.level = TRUE),
+               "single number in \\(0, 1\\)")
+  expect_error(ggforest_subgroup(fit, d, "rx", "sex", conf.level = 42),
+               "single number in \\(0, 1\\)")
+
+  # the header must state the level actually used, not a hardcoded 95%. The plot
+  # is an assembled multi-panel object, so walk the rendered grob tree for the
+  # text labels (same technique as the ggforest_models() header test).
+  labs <- function(p) {
+    gt <- grid::grid.force(ggplot2::ggplotGrob(p)); L <- character()
+    w <- function(g) { if (inherits(g, "gTree") && !is.null(g$children))
+      for (n in names(g$children)) w(g$children[[n]])
+      if (!is.null(g$label)) L <<- c(L, as.character(g$label)) }
+    w(gt); L
+  }
+  L <- labs(ggforest_subgroup(fit, d, "rx", c(Sex = "sex"), conf.level = 0.80))
+  expect_true(any(grepl("HR (80% CI)", L, fixed = TRUE)))
+  expect_false(any(grepl("HR (95% CI)", L, fixed = TRUE)))
+})


### PR DESCRIPTION
Across survminer, `conf.int` means "draw the confidence band" and takes `TRUE`/`FALSE`.
Three functions used it as the numeric confidence level instead:

```r
ggforest_models(models, term = "age", conf.int = 0.90)   # 0.90 = the level
ggsurvplot(fit, data = lung, conf.int = TRUE)            # TRUE  = draw the band
```

#864 made the effect-measure functions reject a numeric `conf.int` and point at
`conf.level`, so as it stands the package tells users that three of its own
functions are called wrongly:

```r
ggrmst(fit, data = lung, conf.int = 0.9)
#> Error: `conf.int` must be TRUE or FALSE (it draws the confidence band around the
#>   curves). Use `conf.level` to set the confidence level of the RMST interval.
```

This renames the argument in `ggcoxnph()`, `ggforest_models()` and
`ggforest_subgroup()`, and validates it:

```r
ggforest_models(models, term = "age", conf.level = 0.90)
ggforest_subgroup(model, data, "rx", c(Sex = "sex"), conf.level = 0.80)
ggcoxnph(fit, data = d, variable = "sexf", conf.level = 0.99)
```

`ggcoxnph()` takes `...`, so a stale `conf.int` would be swallowed and the bands
would silently stay at 95%. It now refuses it:

```r
ggcoxnph(fit, data = d, variable = "sexf", conf.int = 0.9)
#> Error: `conf.int` is not a ggcoxnph() argument. Use `conf.level` to set the
#>   confidence level of the pointwise bands.
```

`ggforest_models()` and `ggforest_subgroup()` have no `...`, so the old spelling
already fails as an unused argument.

## Output is unchanged

Defaults are untouched, so these functions return exactly what they did before.
Fingerprints of the built plots (layer data, geom classes, labels) and of
`ggcoxnph()`'s attached data are identical to `master`:

```
models       IDENTICAL
subgroup     IDENTICAL
nph_data     IDENTICAL
nph_geoms    IDENTICAL
```

The rest of the package is untouched, and these three functions are new in the
unreleased 1.0.0, so nothing on CRAN changes.
