### PR TITLE
Name the group column strata in the RMST and milestone tables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,11 +4,6 @@
 
 - `ggsurvplot()` now accepts `plotmath` expressions in `legend.labs` (e.g. `legend.labs = c(expression(beta[1]), expression(x^2))`), rendering superscripts, subscripts and Greek letters in the legend and the number-at-risk table while leaving the palette unchanged (#350). A plain character `legend.labs` behaves exactly as before.
 
-- `ggrmst_difference()` and `ggmilestone()`'s attached `milestone.table` name their
-  group column `strata`, matching `surv_median()`, `surv_summary()` and
-  `surv_median_followup()`. The labels themselves were already the fit's own; only
-  the column name differed.
-
 - `ggcoxnph()`, `ggforest_models()` and `ggforest_subgroup()` name their
   confidence-level argument `conf.level`, and reject a value outside (0, 1).
   Across the package `conf.int` now consistently means "draw the confidence band"
@@ -46,7 +41,8 @@
   comparison, the between-arm difference with confidence interval and p-value
   (three or more arms via `ref.group`). A milestone beyond an arm's follow-up is
   returned as `NA` with a warning rather than silently dropped, and the full
-  milestone table is attached as `attr(x$plot, "milestone.table")`. For two arms the
+  milestone table is attached as `attr(x$plot, "milestone.table")`, keyed by a
+  `strata` column as in `surv_median()` and `surv_summary()`. For two arms the
   difference is the second arm minus the first, matching `ggrmst_difference()`, and
   every difference row is labelled with its contrast. Arms are read from the fit's
   own strata, so the labels and their order match `names(fit$strata)` and the plotted
@@ -145,7 +141,8 @@
   interval and p-value;
   for three or more groups the area under each curve is shaded, per panel.
   `ggrmst_difference()` returns a tidy table of per-group RMST (with SE and CI) and the
-  RMST difference. The estimate is computed internally from the Kaplan-Meier curve and
+  RMST difference, keyed by a `strata` column as in `surv_median()` and
+  `surv_summary()`. The estimate is computed internally from the Kaplan-Meier curve and
   matches `survRM2::rmst2()`; `tau` defaults to the largest time at which every group's
   curve is defined. See Royston & Parmar (2013).
   The confidence level is set by `conf.level`, as in `ggmilestone()`; `ggrmst()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 - `ggsurvplot()` now accepts `plotmath` expressions in `legend.labs` (e.g. `legend.labs = c(expression(beta[1]), expression(x^2))`), rendering superscripts, subscripts and Greek letters in the legend and the number-at-risk table while leaving the palette unchanged (#350). A plain character `legend.labs` behaves exactly as before.
 
+- `ggrmst_difference()` and `ggmilestone()`'s attached `milestone.table` name their
+  group column `strata`, matching `surv_median()`, `surv_summary()` and
+  `surv_median_followup()`. The labels themselves were already the fit's own; only
+  the column name differed.
+
 - `ggcoxnph()`, `ggforest_models()` and `ggforest_subgroup()` name their
   confidence-level argument `conf.level`, and reject a value outside (0, 1).
   Across the package `conf.int` now consistently means "draw the confidence band"

--- a/R/ggmilestone.R
+++ b/R/ggmilestone.R
@@ -74,8 +74,9 @@ NULL
 #'   carries the fit's own label -- \code{"All"} for an ungrouped fit, as in
 #'   \code{\link{surv_median}()} and \code{\link{surv_summary}()} -- which is what
 #'   the caption shows unless \code{legend.labs} renames the arms on the plot. A
-#'   between-arm difference row is labelled with its contrast and is the only kind of
-#'   row with a non-\code{NA} \code{p.value}.
+#'   between-arm difference row is labelled with its contrast; only a difference row
+#'   can carry a \code{p.value}, though it is \code{NA} when the difference is not
+#'   estimable (a milestone beyond an arm's follow-up, or a zero standard error).
 #'
 #' @references
 #' Klein JP, Logan B, Harhoff M, Andersen PK (2007). Analyzing survival curves at a

--- a/R/ggmilestone.R
+++ b/R/ggmilestone.R
@@ -70,10 +70,12 @@ NULL
 #'   each milestone, the per-arm \eqn{S(t)} marked, and the milestone survival (and
 #'   between-arm difference) reported in the caption. The full milestone table --
 #'   per-arm \eqn{S(t)}, CI, and any between-arm differences with CI and p-value --
-#'   is attached as \code{attr(x$plot, "milestone.table")}. Its \code{group} column
-#'   carries the fit's own strata label -- \code{"All"} for an ungrouped fit, as in
-#'   \code{\link{surv_median}()} -- which is what the caption shows unless
-#'   \code{legend.labs} renames the arms on the plot.
+#'   is attached as \code{attr(x$plot, "milestone.table")}. Its \code{strata} column
+#'   carries the fit's own label -- \code{"All"} for an ungrouped fit, as in
+#'   \code{\link{surv_median}()} and \code{\link{surv_summary}()} -- which is what
+#'   the caption shows unless \code{legend.labs} renames the arms on the plot. A
+#'   between-arm difference row is labelled with its contrast and is the only kind of
+#'   row with a non-\code{NA} \code{p.value}.
 #'
 #' @references
 #' Klein JP, Logan B, Harhoff M, Andersen PK (2007). Analyzing survival curves at a
@@ -129,7 +131,7 @@ ggmilestone <- function(fit, data = NULL, milestone.times, conf.int = FALSE,
     tmax <- max(ti, na.rm = TRUE)
     s.end <- fa$surv[length(fa$surv)]
     do.call(rbind, lapply(milestone.times, function(t) {
-      na.row <- data.frame(group = g, time = t, surv = NA_real_, se = NA_real_,
+      na.row <- data.frame(strata = g, time = t, surv = NA_real_, se = NA_real_,
                            lower = NA_real_, upper = NA_real_,
                            row.names = NULL, stringsAsFactors = FALSE)
       if (t <= tmax) {
@@ -137,7 +139,7 @@ ggmilestone <- function(fit, data = NULL, milestone.times, conf.int = FALSE,
         # A fit stored with conf.type = "none" has no $lower/$upper at all; report
         # NA limits rather than failing to build the row.
         or_na <- function(v) if (is.null(v) || !length(v)) NA_real_ else as.numeric(v)
-        return(data.frame(group = g, time = t, surv = sm$surv, se = or_na(sm$std.err),
+        return(data.frame(strata = g, time = t, surv = sm$surv, se = or_na(sm$std.err),
                           lower = or_na(sm$lower), upper = or_na(sm$upper),
                           row.names = NULL, stringsAsFactors = FALSE))
       }
@@ -156,7 +158,7 @@ ggmilestone <- function(fit, data = NULL, milestone.times, conf.int = FALSE,
     b <- tab[is.na(tab$surv), ]
     warning(n.beyond, " arm x milestone combination(s) lie beyond the observed ",
             "follow-up and are not estimable (returned as NA): ",
-            paste(sprintf("%s @ %g", b$group, b$time), collapse = "; "), ".",
+            paste(sprintf("%s @ %g", b$strata, b$time), collapse = "; "), ".",
             call. = FALSE)
   }
 
@@ -169,7 +171,7 @@ ggmilestone <- function(fit, data = NULL, milestone.times, conf.int = FALSE,
     diffs <- list(c(glevels[2], glevels[1]))
   } else if (length(glevels) >= 3L && !is.null(ref.group)) {
     if (!ref.group %in% glevels)
-      stop("`ref.group` must be one of the arm labels: ",
+      stop("`ref.group` must be one of the strata labels: ",
            paste(glevels, collapse = ", "), call. = FALSE)
     diffs <- lapply(setdiff(glevels, ref.group), function(g) c(g, ref.group))
   }
@@ -189,7 +191,7 @@ ggmilestone <- function(fit, data = NULL, milestone.times, conf.int = FALSE,
     diff.tab <- do.call(rbind, lapply(diffs, function(pr) {
       do.call(rbind, lapply(seq_along(milestone.times), function(k) {
         s <- diff_stats(pr, k)
-        data.frame(group = paste(pr[1], "-", pr[2]), time = milestone.times[k],
+        data.frame(strata = paste(pr[1], "-", pr[2]), time = milestone.times[k],
                    surv = s$d, se = s$sd, lower = s$lower, upper = s$upper,
                    p.value = s$p, row.names = NULL, stringsAsFactors = FALSE)
       }))
@@ -212,7 +214,9 @@ ggmilestone <- function(fit, data = NULL, milestone.times, conf.int = FALSE,
   lab <- function(g) remap[[g]]
 
   pts <- tab[!is.na(tab$surv), , drop = FALSE]
-  pts$strata <- factor(remap[pts$group],
+  # Plotting copy only: swap the canonical strata label for the one the plot shows
+  # (ggsurvplot may rename via legend.labs). milestone.table keeps the canonical one.
+  pts$strata <- factor(remap[as.character(pts$strata)],
                        levels = if (!is.null(plot.strata)) plot.strata else glevels)
 
   # vertical dashed lines at each milestone (drawn before the points).
@@ -259,10 +263,10 @@ ggmilestone <- function(fit, data = NULL, milestone.times, conf.int = FALSE,
     lines <- vapply(seq_len(nrow(tab)), function(r) {
       if (is.na(tab$surv[r]))
         sprintf("%s @ t=%g: not estimable (beyond follow-up)",
-                lab(tab$group[r]), tab$time[r])
+                lab(tab$strata[r]), tab$time[r])
       else
         sprintf("%s @ t=%g: %s (%d%% CI %s to %s)",
-                lab(tab$group[r]), tab$time[r], pc(tab$surv[r]), cl,
+                lab(tab$strata[r]), tab$time[r], pc(tab$surv[r]), cl,
                 pc(tab$lower[r]), pc(tab$upper[r]))
     }, character(1))
   }

--- a/R/ggrmst.R
+++ b/R/ggrmst.R
@@ -75,10 +75,9 @@ NULL
 #'   the fit's own labels, as \code{\link{surv_median}()} and
 #'   \code{\link{surv_summary}()} do; a difference row is labelled with its contrast.
 #'   Only a difference row carries a \code{p.value}; the per-group rows have
-#'   \code{NA}. A comparison with zero estimated variance -- possible when every
-#'   observation in both groups falls at or beyond \code{tau} -- yields
-#'   \code{p = 0} for a non-zero difference and \code{NaN} for a zero one; treat
-#'   either as uninformative rather than significant.
+#'   \code{NA}. A comparison whose estimated variance is zero yields \code{p = 0}
+#'   for a non-zero difference and \code{NaN} for a zero one; treat either as
+#'   uninformative rather than significant.
 #'   \code{ggrmst()} returns a ggplot.
 #' @references
 #' Royston P, Parmar MKB (2013). Restricted mean survival time: an alternative to

--- a/R/ggrmst.R
+++ b/R/ggrmst.R
@@ -68,10 +68,14 @@ NULL
 #' @param palette,ggtheme,... passed to \code{\link{ggsurvplot}()} for the underlying
 #'   curves.
 #' @return \code{ggrmst_difference()} returns a data.frame with one row per group
-#'   (\code{group}, \code{rmst}, \code{se}, \code{lower}, \code{upper}, \code{tau})
+#'   (\code{strata}, \code{rmst}, \code{se}, \code{lower}, \code{upper}, \code{tau})
 #'   and, when a two-group (or \code{ref.group}) difference is defined, additional
 #'   \code{"... - ..."} rows carrying \code{rmst} (the difference), \code{se},
-#'   \code{lower}, \code{upper} and \code{p.value}. \code{ggrmst()} returns a ggplot.
+#'   \code{lower}, \code{upper} and \code{p.value}. The \code{strata} column holds
+#'   the fit's own labels, as \code{\link{surv_median}()} and
+#'   \code{\link{surv_summary}()} do; a difference row is labelled with its contrast
+#'   and is the only kind of row with a non-\code{NA} \code{p.value}.
+#'   \code{ggrmst()} returns a ggplot.
 #' @references
 #' Royston P, Parmar MKB (2013). Restricted mean survival time: an alternative to
 #' the hazard ratio for the design and analysis of randomized trials with a
@@ -102,7 +106,7 @@ ggrmst_difference <- function(fit, data = NULL, tau = NULL, conf.level = 0.95,
   z <- stats::qnorm(1 - alpha / 2)
 
   out <- data.frame(
-    group = glevels,
+    strata = glevels,
     rmst  = vapply(per, function(x) x[["rmst"]], numeric(1)),
     se    = vapply(per, function(x) x[["se"]],  numeric(1)),
     lower = vapply(per, function(x) x[["lower"]], numeric(1)),
@@ -117,7 +121,7 @@ ggrmst_difference <- function(fit, data = NULL, tau = NULL, conf.level = 0.95,
     diffs <- list(c(glevels[2], glevels[1]))
   } else if (length(glevels) >= 3L && !is.null(ref.group)) {
     if (!ref.group %in% glevels)
-      stop("`ref.group` must be one of the group levels: ",
+      stop("`ref.group` must be one of the strata labels: ",
            paste(glevels, collapse = ", "), call. = FALSE)
     others <- setdiff(glevels, ref.group)
     diffs <- lapply(others, function(g) c(g, ref.group))
@@ -128,7 +132,7 @@ ggrmst_difference <- function(fit, data = NULL, tau = NULL, conf.level = 0.95,
       a <- per[[pr[1]]]; b <- per[[pr[2]]]
       d  <- a[["rmst"]] - b[["rmst"]]
       sd <- sqrt(a[["var"]] + b[["var"]])
-      data.frame(group = paste(pr[1], "-", pr[2]),
+      data.frame(strata = paste(pr[1], "-", pr[2]),
                  rmst = d, se = sd, lower = d - z * sd, upper = d + z * sd,
                  tau = tau, p.value = 2 * stats::pnorm(-abs(d / sd)),
                  row.names = NULL, stringsAsFactors = FALSE)

--- a/R/ggrmst.R
+++ b/R/ggrmst.R
@@ -73,8 +73,9 @@ NULL
 #'   \code{"... - ..."} rows carrying \code{rmst} (the difference), \code{se},
 #'   \code{lower}, \code{upper} and \code{p.value}. The \code{strata} column holds
 #'   the fit's own labels, as \code{\link{surv_median}()} and
-#'   \code{\link{surv_summary}()} do; a difference row is labelled with its contrast
-#'   and is the only kind of row with a non-\code{NA} \code{p.value}.
+#'   \code{\link{surv_summary}()} do; a difference row is labelled with its contrast.
+#'   Only a difference row can carry a \code{p.value}, though it is \code{NA} when
+#'   the difference is not estimable (a zero standard error).
 #'   \code{ggrmst()} returns a ggplot.
 #' @references
 #' Royston P, Parmar MKB (2013). Restricted mean survival time: an alternative to

--- a/R/ggrmst.R
+++ b/R/ggrmst.R
@@ -74,8 +74,11 @@ NULL
 #'   \code{lower}, \code{upper} and \code{p.value}. The \code{strata} column holds
 #'   the fit's own labels, as \code{\link{surv_median}()} and
 #'   \code{\link{surv_summary}()} do; a difference row is labelled with its contrast.
-#'   Only a difference row can carry a \code{p.value}, though it is \code{NA} when
-#'   the difference is not estimable (a zero standard error).
+#'   Only a difference row carries a \code{p.value}; the per-group rows have
+#'   \code{NA}. A comparison with zero estimated variance -- possible when every
+#'   observation in both groups falls at or beyond \code{tau} -- yields
+#'   \code{p = 0} for a non-zero difference and \code{NaN} for a zero one; treat
+#'   either as uninformative rather than significant.
 #'   \code{ggrmst()} returns a ggplot.
 #' @references
 #' Royston P, Parmar MKB (2013). Restricted mean survival time: an alternative to

--- a/man/ggmilestone.Rd
+++ b/man/ggmilestone.Rd
@@ -52,10 +52,12 @@ a \code{ggsurvplot} object: the Kaplan-Meier curves with a dashed line at
   each milestone, the per-arm \eqn{S(t)} marked, and the milestone survival (and
   between-arm difference) reported in the caption. The full milestone table --
   per-arm \eqn{S(t)}, CI, and any between-arm differences with CI and p-value --
-  is attached as \code{attr(x$plot, "milestone.table")}. Its \code{group} column
-  carries the fit's own strata label -- \code{"All"} for an ungrouped fit, as in
-  \code{\link{surv_median}()} -- which is what the caption shows unless
-  \code{legend.labs} renames the arms on the plot.
+  is attached as \code{attr(x$plot, "milestone.table")}. Its \code{strata} column
+  carries the fit's own label -- \code{"All"} for an ungrouped fit, as in
+  \code{\link{surv_median}()} and \code{\link{surv_summary}()} -- which is what
+  the caption shows unless \code{legend.labs} renames the arms on the plot. A
+  between-arm difference row is labelled with its contrast and is the only kind of
+  row with a non-\code{NA} \code{p.value}.
 }
 \description{
 Annotates Kaplan-Meier curves with \strong{milestone survival}: the survival

--- a/man/ggmilestone.Rd
+++ b/man/ggmilestone.Rd
@@ -56,8 +56,9 @@ a \code{ggsurvplot} object: the Kaplan-Meier curves with a dashed line at
   carries the fit's own label -- \code{"All"} for an ungrouped fit, as in
   \code{\link{surv_median}()} and \code{\link{surv_summary}()} -- which is what
   the caption shows unless \code{legend.labs} renames the arms on the plot. A
-  between-arm difference row is labelled with its contrast and is the only kind of
-  row with a non-\code{NA} \code{p.value}.
+  between-arm difference row is labelled with its contrast; only a difference row
+  can carry a \code{p.value}, though it is \code{NA} when the difference is not
+  estimable (a milestone beyond an arm's follow-up, or a zero standard error).
 }
 \description{
 Annotates Kaplan-Meier curves with \strong{milestone survival}: the survival

--- a/man/ggrmst_difference.Rd
+++ b/man/ggrmst_difference.Rd
@@ -55,10 +55,14 @@ interval, not of the band.}
 }
 \value{
 \code{ggrmst_difference()} returns a data.frame with one row per group
-  (\code{group}, \code{rmst}, \code{se}, \code{lower}, \code{upper}, \code{tau})
+  (\code{strata}, \code{rmst}, \code{se}, \code{lower}, \code{upper}, \code{tau})
   and, when a two-group (or \code{ref.group}) difference is defined, additional
   \code{"... - ..."} rows carrying \code{rmst} (the difference), \code{se},
-  \code{lower}, \code{upper} and \code{p.value}. \code{ggrmst()} returns a ggplot.
+  \code{lower}, \code{upper} and \code{p.value}. The \code{strata} column holds
+  the fit's own labels, as \code{\link{surv_median}()} and
+  \code{\link{surv_summary}()} do; a difference row is labelled with its contrast
+  and is the only kind of row with a non-\code{NA} \code{p.value}.
+  \code{ggrmst()} returns a ggplot.
 }
 \description{
 Restricted mean survival time (RMST) is the area under the Kaplan-Meier curve

--- a/man/ggrmst_difference.Rd
+++ b/man/ggrmst_difference.Rd
@@ -60,8 +60,9 @@ interval, not of the band.}
   \code{"... - ..."} rows carrying \code{rmst} (the difference), \code{se},
   \code{lower}, \code{upper} and \code{p.value}. The \code{strata} column holds
   the fit's own labels, as \code{\link{surv_median}()} and
-  \code{\link{surv_summary}()} do; a difference row is labelled with its contrast
-  and is the only kind of row with a non-\code{NA} \code{p.value}.
+  \code{\link{surv_summary}()} do; a difference row is labelled with its contrast.
+  Only a difference row can carry a \code{p.value}, though it is \code{NA} when
+  the difference is not estimable (a zero standard error).
   \code{ggrmst()} returns a ggplot.
 }
 \description{

--- a/man/ggrmst_difference.Rd
+++ b/man/ggrmst_difference.Rd
@@ -61,8 +61,11 @@ interval, not of the band.}
   \code{lower}, \code{upper} and \code{p.value}. The \code{strata} column holds
   the fit's own labels, as \code{\link{surv_median}()} and
   \code{\link{surv_summary}()} do; a difference row is labelled with its contrast.
-  Only a difference row can carry a \code{p.value}, though it is \code{NA} when
-  the difference is not estimable (a zero standard error).
+  Only a difference row carries a \code{p.value}; the per-group rows have
+  \code{NA}. A comparison with zero estimated variance -- possible when every
+  observation in both groups falls at or beyond \code{tau} -- yields
+  \code{p = 0} for a non-zero difference and \code{NaN} for a zero one; treat
+  either as uninformative rather than significant.
   \code{ggrmst()} returns a ggplot.
 }
 \description{

--- a/man/ggrmst_difference.Rd
+++ b/man/ggrmst_difference.Rd
@@ -62,10 +62,9 @@ interval, not of the band.}
   the fit's own labels, as \code{\link{surv_median}()} and
   \code{\link{surv_summary}()} do; a difference row is labelled with its contrast.
   Only a difference row carries a \code{p.value}; the per-group rows have
-  \code{NA}. A comparison with zero estimated variance -- possible when every
-  observation in both groups falls at or beyond \code{tau} -- yields
-  \code{p = 0} for a non-zero difference and \code{NaN} for a zero one; treat
-  either as uninformative rather than significant.
+  \code{NA}. A comparison whose estimated variance is zero yields \code{p = 0}
+  for a non-zero difference and \code{NaN} for a zero one; treat either as
+  uninformative rather than significant.
   \code{ggrmst()} returns a ggplot.
 }
 \description{

--- a/tests/testthat/test-ggrmst.R
+++ b/tests/testthat/test-ggrmst.R
@@ -16,14 +16,14 @@ test_that("ggrmst_difference matches survRM2::rmst2() (numeric parity)", {
   # default tau
   expect_equal(tab$tau[1], ref$tau, tolerance = 1e-6)
   # per-arm RMST + SE
-  r_obs <- tab[tab$group == "rx=Obs", ]
-  r_trt <- tab[tab$group == "rx=Lev+5FU", ]
+  r_obs <- tab[tab$strata == "rx=Obs", ]
+  r_trt <- tab[tab$strata == "rx=Lev+5FU", ]
   expect_equal(r_obs$rmst, ref$RMST.arm0$rmst[[1]], tolerance = 1e-4)
   expect_equal(r_obs$se,   ref$RMST.arm0$rmst[[2]], tolerance = 1e-4)
   expect_equal(r_trt$rmst, ref$RMST.arm1$rmst[[1]], tolerance = 1e-4)
   expect_equal(r_trt$se,   ref$RMST.arm1$rmst[[2]], tolerance = 1e-4)
   # difference + CI + p (rmst2 unadjusted.result row 1 = RMST diff arm1 - arm0)
-  dr <- tab[grepl(" - ", tab$group), ]
+  dr <- tab[grepl(" - ", tab$strata), ]
   expect_equal(dr$rmst,    ref$unadjusted.result[1, 1], tolerance = 1e-4)
   expect_equal(dr$lower,   ref$unadjusted.result[1, 2], tolerance = 1e-4)
   expect_equal(dr$upper,   ref$unadjusted.result[1, 3], tolerance = 1e-4)
@@ -33,10 +33,10 @@ test_that("ggrmst_difference matches survRM2::rmst2() (numeric parity)", {
 test_that("ggrmst_difference structure and columns", {
   fit <- survfit(Surv(time, status) ~ sex, data = lung)
   tab <- ggrmst_difference(fit, data = lung)
-  expect_true(all(c("group", "rmst", "se", "lower", "upper", "tau", "p.value") %in% names(tab)))
+  expect_true(all(c("strata", "rmst", "se", "lower", "upper", "tau", "p.value") %in% names(tab)))
   expect_equal(nrow(tab), 3L)                 # 2 groups + 1 difference row
-  expect_true(any(grepl(" - ", tab$group)))
-  expect_true(is.na(tab$p.value[tab$group == "sex=1"]))   # per-group rows have no p
+  expect_true(any(grepl(" - ", tab$strata)))
+  expect_true(is.na(tab$p.value[tab$strata == "sex=1"]))   # per-group rows have no p
 })
 
 test_that("tau default is the admissible max; out-of-range tau errors", {
@@ -69,10 +69,10 @@ test_that("ggrmst() facets per arm for 3+ groups (no invented pairwise differenc
   expect_equal(nrow(b$layout$layout), 3L)   # 3 panels, not 6
   tab <- ggrmst_difference(fit, data = d)
   expect_equal(nrow(tab), 3L)               # 3 groups, no difference rows by default
-  expect_false(any(grepl(" - ", tab$group)))
+  expect_false(any(grepl(" - ", tab$strata)))
   # with a reference group, differences vs the reference appear
   tab2 <- ggrmst_difference(fit, data = d, ref.group = "ph.ecog=0")
-  expect_equal(sum(grepl(" - ", tab2$group)), 2L)
+  expect_equal(sum(grepl(" - ", tab2$strata)), 2L)
 })
 
 test_that("competing-risks / multi-state and left-censored data are refused", {
@@ -119,10 +119,10 @@ test_that("RMST is tau, not 0, for an arm with no observation before tau", {
   fit <- survival::survfit(survival::Surv(time, status) ~ arm, data = d)
   tab <- ggrmst_difference(fit, data = d, tau = 6.5)
 
-  expect_equal(tab$rmst[tab$group == "arm=B"], 6.5)
-  expect_equal(tab$se[tab$group == "arm=B"], 0)
-  dr <- tab[grepl(" - ", tab$group), ]
-  expect_equal(dr$rmst, 6.5 - tab$rmst[tab$group == "arm=A"])
+  expect_equal(tab$rmst[tab$strata == "arm=B"], 6.5)
+  expect_equal(tab$se[tab$strata == "arm=B"], 0)
+  dr <- tab[grepl(" - ", tab$strata), ]
+  expect_equal(dr$rmst, 6.5 - tab$rmst[tab$strata == "arm=A"])
   expect_gt(dr$rmst, 0)                       # B is better than A here
 })
 
@@ -135,13 +135,13 @@ test_that("groups come from the fit's strata: order, labels and expressions", {
   tab <- ggrmst_difference(fit, data = d)
   # labels AND order must match survfit's own strata, else the plot remap
   # attaches each arm's statistics to the wrong curve
-  expect_equal(tab$group, unname(names(fit$strata)))
+  expect_equal(tab$strata, unname(names(fit$strata)))
 
   # a transformed right-hand side is one group per stratum, not per distinct value
   f2 <- survival::survfit(survival::Surv(time, status) ~ (age > 60),
                           data = survival::lung)
   t2 <- ggrmst_difference(f2, data = survival::lung)
-  expect_equal(t2$group[1:2], unname(names(f2$strata)))
+  expect_equal(t2$strata[1:2], unname(names(f2$strata)))
   expect_equal(nrow(t2), 3L)                  # 2 groups + 1 difference row
 })
 
@@ -203,7 +203,7 @@ test_that("the strata helper survives cluster terms, hostile names and a bare fo
   # a cluster() term is not a stratum -- survfit drops it, so we must too,
   # otherwise every subject becomes its own "group"
   fc <- survival::survfit(survival::Surv(time, status) ~ sexf + cluster(id), data = d)
-  expect_equal(ggrmst_difference(fc, data = d)$group[1:2],
+  expect_equal(ggrmst_difference(fc, data = d)$strata[1:2],
                unname(names(fc$strata)))
   expect_equal(nrow(ggrmst_difference(fc, data = d)), 3L)   # 2 groups + difference
 
@@ -213,7 +213,7 @@ test_that("the strata helper survives cluster terms, hostile names and a bare fo
     dd <- d; dd[[nm]] <- dd$sexf
     f <- eval(bquote(survival::survfit(
       survival::Surv(time, status) ~ .(as.name(nm)), data = dd)))
-    expect_equal(ggrmst_difference(f, data = dd)$group[1:2],
+    expect_equal(ggrmst_difference(f, data = dd)$strata[1:2],
                  unname(names(f$strata)),
                  info = paste("grouping variable named", nm))
   }
@@ -248,7 +248,7 @@ test_that("a collapsed grouping variable with NAs keeps the fit's cohort", {
   expect_lt(fit$n, nrow(d))                      # the fit dropped the NA rows
 
   tab <- ggrmst_difference(fit, data = d, tau = 500)
-  expect_equal(tab$group, "All")
+  expect_equal(tab$strata, "All")
   # the estimate must be the one the plotted curve carries
   ref <- survminer:::.rmst_one_arm(
     d$time[!is.na(d$g)], d$status[!is.na(d$g)], tau = 500, alpha = 0.05)

--- a/tests/testthat/test-ggrmst.R
+++ b/tests/testthat/test-ggrmst.R
@@ -280,3 +280,21 @@ test_that("the Surv-type error names the function the user called", {
                "ggrmst_difference\\(\\) supports right-censored")
   expect_error(ggrmst(f, data = d), "ggrmst\\(\\) supports right-censored")
 })
+
+test_that("the documented p.value behaviour is what the code does", {
+  fit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung)
+  tab <- ggrmst_difference(fit, data = survival::lung)
+  # per-group rows never carry a p-value; only the difference row does
+  expect_true(all(is.na(tab$p.value[seq_len(nrow(tab) - 1L)])))
+  expect_false(is.na(tab$p.value[nrow(tab)]))
+
+  # a zero-variance comparison gives p = 0, not NA: the documentation must not
+  # promise NA, or a user filtering on !is.na() would treat 0 as a real result
+  d <- data.frame(time = c(2, 5, 5), status = c(1, 0, 0),
+                  arm = factor(c("A", "B", "B")))
+  z <- ggrmst_difference(survival::survfit(survival::Surv(time, status) ~ arm,
+                                           data = d), data = d)
+  expect_equal(z$se[nrow(z)], 0)
+  expect_equal(z$p.value[nrow(z)], 0)
+  expect_false(is.na(z$p.value[nrow(z)]))
+})

--- a/tests/testthat/test-landmark-milestone.R
+++ b/tests/testthat/test-landmark-milestone.R
@@ -71,13 +71,13 @@ test_that("ggmilestone tabulates per-arm S(t) and the between-arm difference", {
   tab <- attr(p$plot, "milestone.table")
   # per-arm S(t) matches summary.survfit
   s <- summary(fit, times = 365)
-  arm1 <- tab$surv[tab$group == levels(factor(tab$group))[1] & tab$time == 365]
+  arm1 <- tab$surv[tab$strata == levels(factor(tab$strata))[1] & tab$time == 365]
   expect_equal(round(arm1, 6), round(s$surv[1], 6))
   # difference row = S_A - S_B with additive Greenwood variance
-  dr <- tab[grepl(" - ", tab$group) & tab$time == 365, ]
+  dr <- tab[grepl(" - ", tab$strata) & tab$time == 365, ]
   expect_equal(nrow(dr), 1L)
-  a <- tab[tab$group == "sex=1" & tab$time == 365, ]
-  b <- tab[tab$group == "sex=2" & tab$time == 365, ]
+  a <- tab[tab$strata == "sex=1" & tab$time == 365, ]
+  b <- tab[tab$strata == "sex=2" & tab$time == 365, ]
   expect_equal(dr$surv, b$surv - a$surv)
   expect_equal(dr$se, sqrt(a$se^2 + b$se^2))
   expect_true(dr$p.value > 0 && dr$p.value < 1)
@@ -89,7 +89,7 @@ test_that("ggmilestone returns NA (with a warning) for a time beyond follow-up",
                                   milestone.times = c(365, 1e6)),
                  "beyond the observed follow-up")
   tab <- attr(p$plot, "milestone.table")
-  expect_true(all(is.na(tab$surv[tab$time == 1e6 & !grepl(" - ", tab$group)])))
+  expect_true(all(is.na(tab$surv[tab$time == 1e6 & !grepl(" - ", tab$strata)])))
 })
 
 test_that("ggmilestone gives no difference for one arm", {
@@ -106,10 +106,10 @@ test_that("ggmilestone needs ref.group for 3+ arms and validates it", {
   f3 <- survival::survfit(survival::Surv(time, status) ~ g, data = d)
   # no ref.group -> per-arm only (no difference rows)
   p <- ggmilestone(f3, data = d, milestone.times = 365)
-  expect_false(any(grepl(" - ", attr(p$plot, "milestone.table")$group)))
+  expect_false(any(grepl(" - ", attr(p$plot, "milestone.table")$strata)))
   # ref.group -> difference vs the reference
   pr <- ggmilestone(f3, data = d, milestone.times = 365, ref.group = "g=0")
-  expect_true(any(grepl(" - g=0$", attr(pr$plot, "milestone.table")$group)))
+  expect_true(any(grepl(" - g=0$", attr(pr$plot, "milestone.table")$strata)))
   expect_error(ggmilestone(f3, data = d, milestone.times = 365, ref.group = "z"),
                "ref.group")
 })
@@ -168,8 +168,8 @@ test_that("ggmilestone reports 0 beyond follow-up when the curve has reached 0",
   p <- suppressWarnings(ggmilestone(fit, data = d, milestone.times = 20))
   tab <- attr(p$plot, "milestone.table")
   # allevent's curve reaches 0 -> S(20) = 0 (estimable); censlast -> NA
-  expect_equal(tab$surv[tab$group == "g=allevent" & tab$time == 20], 0)
-  expect_true(is.na(tab$surv[tab$group == "g=censlast" & tab$time == 20]))
+  expect_equal(tab$surv[tab$strata == "g=allevent" & tab$time == 20], 0)
+  expect_true(is.na(tab$surv[tab$strata == "g=censlast" & tab$time == 20]))
 })
 
 test_that("an empty factor level is labelled like survfit, not refused", {
@@ -179,11 +179,11 @@ test_that("an empty factor level is labelled like survfit, not refused", {
   p <- ggmilestone(fit, data = d, milestone.times = 100)
   tab <- attr(p$plot, "milestone.table")
   # the composed label carries the variable name, so it is never itself empty
-  expect_equal(sort(unique(tab$group[!grepl(" - ", tab$group)])),
+  expect_equal(sort(unique(tab$strata[!grepl(" - ", tab$strata)])),
                sort(unname(names(fit$strata))))
   s <- summary(fit, times = 100)
-  expect_equal(tab$surv[tab$group == "arm="][1],  s$surv[1])
-  expect_equal(tab$surv[tab$group == "arm=X"][1], s$surv[2])
+  expect_equal(tab$surv[tab$strata == "arm="][1],  s$surv[1])
+  expect_equal(tab$surv[tab$strata == "arm=X"][1], s$surv[2])
 })
 
 test_that("gglandmark re-origined curve equals an independent manual survfit", {
@@ -205,9 +205,9 @@ test_that("ggmilestone difference equals the independent Greenwood formula", {
   fit <- .fit2()
   tab <- attr(ggmilestone(fit, data = survival::lung,
                           milestone.times = 365)$plot, "milestone.table")
-  a <- tab[tab$group == "sex=1" & tab$time == 365, ]
-  b <- tab[tab$group == "sex=2" & tab$time == 365, ]
-  dr <- tab[grepl(" - ", tab$group), ]
+  a <- tab[tab$strata == "sex=1" & tab$time == 365, ]
+  b <- tab[tab$strata == "sex=2" & tab$time == 365, ]
+  dr <- tab[grepl(" - ", tab$strata), ]
   # independent recomputation from survival::summary.survfit
   s <- summary(fit, times = 365)
   d.ref  <- s$surv[2] - s$surv[1]
@@ -238,10 +238,10 @@ test_that("ggmilestone arm labels and values line up with the plotted strata", {
   fit <- survival::survfit(survival::Surv(time, status) ~ s + e, data = d)
   tab <- attr(ggmilestone(fit, data = d, milestone.times = 365)$plot,
               "milestone.table")
-  per <- tab[!grepl(" - ", tab$group), ]
+  per <- tab[!grepl(" - ", tab$strata), ]
   # order AND value must agree with survfit; a positional remap that disagrees
   # attaches one arm's survival to another arm's label
-  expect_equal(per$group, unname(names(fit$strata)))
+  expect_equal(per$strata, unname(names(fit$strata)))
   expect_equal(per$surv, unname(summary(fit, times = 365)$surv))
 })
 
@@ -250,7 +250,7 @@ test_that("a transformed right-hand side groups into its strata", {
                          data = survival::lung)
   tab <- attr(ggmilestone(f, data = survival::lung, milestone.times = 365)$plot,
               "milestone.table")
-  expect_equal(sort(unique(tab$group[!grepl(" - ", tab$group)])),
+  expect_equal(sort(unique(tab$strata[!grepl(" - ", tab$strata)])),
                sort(unname(names(f$strata))))
 })
 
@@ -269,7 +269,7 @@ test_that("ggmilestone survives a fit stored with conf.type = 'none'", {
                          data = survival::lung, conf.type = "none")
   tab <- attr(ggmilestone(f, data = survival::lung, milestone.times = 365)$plot,
               "milestone.table")
-  per <- tab[!grepl(" - ", tab$group), ]
+  per <- tab[!grepl(" - ", tab$strata), ]
   expect_equal(per$surv, unname(summary(f, times = 365)$surv))
   expect_true(all(is.na(per$lower)))          # no limits were requested
   expect_true(all(is.na(per$upper)))
@@ -333,9 +333,9 @@ test_that("a fit that collapses to one stratum is labelled All, like surv_median
   expect_null(f$strata)
 
   tab <- attr(ggmilestone(f, data = d, milestone.times = 365)$plot, "milestone.table")
-  expect_equal(unique(tab$group), "All")
+  expect_equal(unique(tab$strata), "All")
   expect_equal(surv_median(f)$strata, "All")
-  expect_equal(ggrmst_difference(f, data = d)$group, "All")
+  expect_equal(ggrmst_difference(f, data = d)$strata, "All")
 })
 
 test_that("gglandmark() rejects a numeric conf.int, like its siblings", {
@@ -353,7 +353,7 @@ test_that("the ggmilestone caption follows legend.labs and the table stays tidy"
   expect_false(grepl("sex=2", p$plot$labels$caption, fixed = TRUE))
   # the attached table keeps the fit's own labels, with clean row names
   tab <- attr(p$plot, "milestone.table")
-  expect_true(any(grepl("sex=", tab$group, fixed = TRUE)))
+  expect_true(any(grepl("sex=", tab$strata, fixed = TRUE)))
   expect_equal(rownames(tab), as.character(seq_len(nrow(tab))))
 })
 

--- a/tests/testthat/test-landmark-milestone.R
+++ b/tests/testthat/test-landmark-milestone.R
@@ -377,3 +377,36 @@ test_that("the documented band level is true for each function", {
     band(gglandmark(f95, data = survival::lung, landmark.time = 200, conf.int = TRUE)),
     band(gglandmark(f80, data = survival::lung, landmark.time = 200, conf.int = TRUE)))
 })
+
+test_that("each caption line and each point is paired with its own arm", {
+  # Asserting only that the display names APPEAR lets a relabel swap the arms
+  # silently -- the caption can read "Male 53% vs Female 34%" while Female is the
+  # 53% arm. Pin every name to the value that belongs to it.
+  d <- survival::lung
+  fit <- survival::survfit(survival::Surv(time, status) ~ sex, data = d)
+  p <- ggmilestone(fit, data = d, milestone.times = 365,
+                   legend.labs = c("Male", "Female"))
+
+  truth <- summary(fit, times = 365)              # sex=1 then sex=2
+  pct <- round(100 * unname(truth$surv))
+  # legend.labs maps positionally onto the fit's strata order
+  expect_match(p$plot$labels$caption,
+               sprintf("Male %d%%", pct[1]), fixed = TRUE)
+  expect_match(p$plot$labels$caption,
+               sprintf("Female %d%%", pct[2]), fixed = TRUE)
+
+  # and the plotted point for each arm carries that arm's own survival, under the
+  # display label used by the curve it sits on
+  pts <- NULL
+  for (l in p$plot$layers)
+    if (inherits(l$geom, "GeomPoint") && !is.null(l$data) && nrow(l$data)) pts <- l$data
+  expect_false(is.null(pts))
+  # a dropped remap leaves values outside the forced levels, i.e. all NA
+  expect_false(anyNA(pts$strata))
+  expect_equal(levels(pts$strata), levels(p$plot$data$strata))
+  # each point's display label must be the label of the curve carrying that value
+  disp <- levels(p$plot$data$strata)
+  for (i in seq_along(disp))
+    expect_equal(unname(pts$surv[as.character(pts$strata) == disp[i]]),
+                 unname(truth$surv[i]), info = disp[i])
+})


### PR DESCRIPTION
The survival summaries in survminer name their group column `strata`. Two of them
called it `group`:

```r
library(survival)
fit <- survfit(Surv(time, status) ~ sex, data = lung)

names(surv_median(fit))                                 #> strata median lower upper
names(surv_summary(fit, data = lung))[1:4]              #> time n.risk n.event n.censor ... strata
names(surv_median_followup(fit, data = lung))           #> strata median lower upper

names(ggrmst_difference(fit, data = lung))              #> group  rmst se lower upper tau p.value
names(attr(ggmilestone(fit, data = lung,
                       milestone.times = 365)$plot, "milestone.table"))
                                                        #> group  time surv se lower upper p.value
```

The labels were already the fit's own (`"sex=1"`, `"All"`), so only the column
name differed — enough that joining one of these tables to a `surv_summary()`
frame meant renaming a column first. Both now use `strata`:

```r
names(ggrmst_difference(fit, data = lung))              #> strata rmst se lower upper tau p.value
```

## Values are unchanged

Every number, label and row is the same; only the column name moves. Comparing
the returned tables against `master`:

```
             master                              this branch
names        group, time, surv, se, lower, upper strata, time, surv, se, lower, upper
row          All  365  0.4092416245  0.03582…    All  365  0.4092416245  0.03582…
caption      All @ t=365: 41% (95% CI 34% to 49%)  (identical)
```

A between-arm difference row keeps its contrast label (`"sex=2 - sex=1"`) and is
still the only kind of row with a non-`NA` `p.value` — now stated in `@return`
rather than left to be inferred from the label, since `grepl(" - ", ...)` is not a
safe way to find those rows when an arm name can itself contain `" - "`.

The plot side is untouched: the caption still shows `legend.labs` names while the
attached table keeps the fit's own labels.

These functions are new in the unreleased 1.0.0, so nothing on CRAN changes.
