### PR TITLE
Map coefficients by name when a term has more of them than the summary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@
 
 - `ggsurvplot()` now accepts `plotmath` expressions in `legend.labs` (e.g. `legend.labs = c(expression(beta[1]), expression(x^2))`), rendering superscripts, subscripts and Greek letters in the legend and the number-at-risk table while leaving the palette unchanged (#350). A plain character `legend.labs` behaves exactly as before.
 
+- `ggforest()` draws a Cox model containing a penalised term -- `pspline()` or
+  `frailty()` -- correctly again. Such a term has more model coefficients than the
+  summary has rows, which left the plot with a block of blank "reference" rows and
+  dropped the fitted level of every variable after it, so a factor could show all
+  of its levels as the reference and its hazard ratio under a row of its own.
+
 - `ggcoxnph()`, `ggforest_models()` and `ggforest_subgroup()` name their
   confidence-level argument `conf.level`, and reject a value outside (0, 1).
   Across the package `conf.int` now consistently means "draw the confidence band"

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,8 @@
   covariate correctly again. Such a term has more model coefficients than the
   summary has rows, which left the plot with a block of blank "reference" rows and
   dropped the fitted level of every variable after it, so a factor could show all
-  of its levels as the reference and its hazard ratio under a row of its own. (A
+  of its levels as the reference and its hazard ratio under a row of its own. In a
+  larger model the same term instead drew every other covariate a second time. (A
   model of `pspline()` terms only still cannot be drawn: every one of its rows has
   an undefined confidence limit, so there is no axis to draw.)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,11 +4,18 @@
 
 - `ggsurvplot()` now accepts `plotmath` expressions in `legend.labs` (e.g. `legend.labs = c(expression(beta[1]), expression(x^2))`), rendering superscripts, subscripts and Greek letters in the legend and the number-at-risk table while leaving the palette unchanged (#350). A plain character `legend.labs` behaves exactly as before.
 
-- `ggforest()` draws a Cox model containing a penalised term -- `pspline()` or
-  `frailty()` -- correctly again. Such a term has more model coefficients than the
+- `ggforest()` draws a Cox model containing a `pspline()` term alongside another
+  covariate correctly again. Such a term has more model coefficients than the
   summary has rows, which left the plot with a block of blank "reference" rows and
   dropped the fitted level of every variable after it, so a factor could show all
-  of its levels as the reference and its hazard ratio under a row of its own.
+  of its levels as the reference and its hazard ratio under a row of its own. (A
+  model of `pspline()` terms only still cannot be drawn: every one of its rows has
+  an undefined confidence limit, so there is no axis to draw.)
+
+- `ggforest()` no longer draws a namespace-qualified term such as
+  `splines::ns(age, 3)` twice. The `::` was read as the `:` that separates
+  interacting variables, so the term was processed a second time as an
+  interaction.
 
 - `ggcoxnph()`, `ggforest_models()` and `ggforest_subgroup()` name their
   confidence-level argument `conf.level`, and reject a value outside (0, 1).

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -199,7 +199,8 @@ ggforest <- function(model, data = NULL,
     # would quietly absorb its neighbours' rows.
     # The rows-are-its-own test is skipped for an interaction, whose coefficient
     # ("grpb:grp2y") never starts with the term label ("grp:grp2").
-    ok <- !is.null(idx) && length(idx) && all(idx <= nrow(coef))
+    in.range <- !is.null(idx) && length(idx) && all(idx <= nrow(coef))
+    ok <- in.range
     if (ok && !grepl(":", var, fixed = TRUE))
       ok <- all(startsWith(gsub("`", "", coef$term[idx]), var))
     if (ok) return(idx)
@@ -209,7 +210,11 @@ ggforest <- function(model, data = NULL,
     # longer one's coefficients, which would draw that coefficient twice (#689).
     cterm <- gsub("`", "", coef$term)
     hit <- startsWith(cterm, var)
-    if (!any(hit)) return(NULL)
+    # No name match at all means the term simply is not named after its
+    # coefficients -- ridge(age, wt.loss, theta = 1) is summarised as "ridge(age)"
+    # and "ridge(wt.loss)" -- never that it was collapsed, since a collapsed term
+    # always matches its own rows. Keep its indices rather than dropping it.
+    if (!any(hit)) return(if (in.range) idx else NULL)
     # one-directional: this stops a shorter term absorbing a longer term's
     # coefficients, which is the shape #689 took. The reverse (a longer term name
     # matching a shorter factor's level coefficient) needs contrived naming and is

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -165,17 +165,41 @@ ggforest <- function(model, data = NULL,
   # contr.helmert/contr.sum/contr.poly, for which a per-level reference row is not
   # well defined) or the contrast matrix cannot be reconciled with the fitted
   # coefficients.
+  # Coefficient rows belonging to a model term.
+  #
+  # model$assign indexes the design columns of coef(model), and broom::tidy()
+  # normally returns one row per design column, so the two line up. A penalised
+  # term -- pspline(), frailty() -- is collapsed by tidy() into fewer rows than it
+  # has design columns, so those indices run off the end of `coef`: the term picks
+  # up NA rows and every term after it is mis-keyed. A pspline model therefore drew
+  # a block of blank "reference" rows and lost the fitted level of every later
+  # factor. When the two are not aligned, match the coefficient names instead --
+  # with startsWith() rather than a regex, both so a name carrying metacharacters
+  # such as "pspline(age)" is matched as written, and because the prefix collision
+  # of #689 came from the regex quantifier in "^var*." -- "add17TRUE" does not
+  # start with "add11". Aligned models -- every model without a penalised term --
+  # keep the model$assign path exactly as before.
+  .assign.aligned <- nrow(coef) == length(stats::coef(model))
+  .assign.names <- gsub("`", "", names(model$assign))
+  .coef.rows <- function(var) {
+    if (.assign.aligned) {
+      idx <- model$assign[[var]]
+      if (is.null(idx)) {
+        # A non-syntactic name (e.g. "risk grp") is stored backtick-quoted in
+        # names(model$assign) but bare in dataClasses / model$contrasts, so the
+        # direct [[var]] lookup misses it; match on the stripped names instead.
+        pos <- which(.assign.names == var)
+        if (length(pos) == 1L) idx <- model$assign[[pos]]
+      }
+      return(idx)
+    }
+    hit <- which(startsWith(gsub("`", "", coef$term), var))
+    if (length(hit)) hit else NULL
+  }
+
   .factor_level_keys <- function(var, levs) {
     fallback <- paste0(var, levs)
-    idx <- model$assign[[var]]
-    if (is.null(idx)) {
-      # A non-syntactic factor name (e.g. "risk grp") is stored backtick-quoted in
-      # names(model$assign) but bare in dataClasses / model$contrasts, so the direct
-      # [[var]] lookup misses it. Match on the backtick-stripped names so such a
-      # factor is routed too, instead of dropping to the (mislabelling) fallback.
-      pos <- which(gsub("`", "", names(model$assign)) == var)
-      if (length(pos) == 1L) idx <- model$assign[[pos]]
-    }
+    idx <- .coef.rows(var)
     if (is.null(idx)) return(fallback)
     # coef$term rownames are backtick-stripped below; strip here too so keys match
     cn <- gsub("`", "", coef$term[idx])         # coef names, in contrast-col order
@@ -226,7 +250,7 @@ ggforest <- function(model, data = NULL,
       # "^var*." treated trailing digits of the name as a regex quantifier, so
       # e.g. term "add11" matched coefficient "add17TRUE" and vice-versa,
       # producing duplicated/wrong rows for prefix-colliding names (#689).
-      idx <- model$assign[[var]]
+      idx <- .coef.rows(var)
       if (is.null(idx)) idx <- which(startsWith(coef$term, var)) # literal fallback
       vars = coef$term[idx]
       # key = the coefficient name itself (level is ""), matching the old
@@ -245,7 +269,7 @@ ggforest <- function(model, data = NULL,
   .inter.terms <- grep(":", names(model$assign), value = TRUE, fixed = TRUE)
   if (length(.inter.terms) > 0) {
     allTerms <- c(allTerms, lapply(.inter.terms, function(term){
-      idx <- model$assign[[term]]
+      idx <- .coef.rows(term)
       vars <- coef$term[idx]
       data.frame(var = vars, Var1 = "", Freq = nrow(data), pos = seq_along(vars),
                  key = vars)

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -187,8 +187,22 @@ ggforest <- function(model, data = NULL,
       pos <- which(.assign.bare == var)
       if (length(pos) == 1L) idx <- model$assign[[pos]]
     }
-    # In range means tidy() did not collapse this term: use the indices as before.
-    if (!is.null(idx) && length(idx) && all(idx <= nrow(coef))) return(idx)
+    # When the summary has exactly one row per design column nothing was collapsed
+    # and the indices address `coef` directly -- this is every ordinary model, and
+    # it also covers terms whose coefficients are not named after them, such as
+    # ridge(age, wt.loss) or an interaction.
+    if (nrow(coef) == length(stats::coef(model))) return(idx)
+    # Otherwise the counts differ somewhere in the model, so check this term: its
+    # indices must be inside the table AND land on rows that are actually its own.
+    # In range alone is not enough -- pspline() has 12 design columns, so in a model
+    # with ten or more other coefficients its indices fit inside the table and it
+    # would quietly absorb its neighbours' rows.
+    # The rows-are-its-own test is skipped for an interaction, whose coefficient
+    # ("grpb:grp2y") never starts with the term label ("grp:grp2").
+    ok <- !is.null(idx) && length(idx) && all(idx <= nrow(coef))
+    if (ok && !grepl(":", var, fixed = TRUE))
+      ok <- all(startsWith(gsub("`", "", coef$term[idx]), var))
+    if (ok) return(idx)
     # Otherwise match by name. startsWith() rather than a regex so a name carrying
     # metacharacters ("pspline(age)") is matched as written; a longer term name
     # that also matches is excluded so a shorter variable cannot absorb the
@@ -196,6 +210,10 @@ ggforest <- function(model, data = NULL,
     cterm <- gsub("`", "", coef$term)
     hit <- startsWith(cterm, var)
     if (!any(hit)) return(NULL)
+    # one-directional: this stops a shorter term absorbing a longer term's
+    # coefficients, which is the shape #689 took. The reverse (a longer term name
+    # matching a shorter factor's level coefficient) needs contrived naming and is
+    # caught downstream by the contrast reconciliation in .factor_level_keys().
     longer <- .assign.bare[.assign.bare != var & startsWith(.assign.bare, var)]
     for (o in longer) hit <- hit & !startsWith(cterm, o)
     if (!any(hit)) NULL else which(hit)

--- a/R/ggforest.R
+++ b/R/ggforest.R
@@ -168,33 +168,37 @@ ggforest <- function(model, data = NULL,
   # Coefficient rows belonging to a model term.
   #
   # model$assign indexes the design columns of coef(model), and broom::tidy()
-  # normally returns one row per design column, so the two line up. A penalised
-  # term -- pspline(), frailty() -- is collapsed by tidy() into fewer rows than it
-  # has design columns, so those indices run off the end of `coef`: the term picks
-  # up NA rows and every term after it is mis-keyed. A pspline model therefore drew
-  # a block of blank "reference" rows and lost the fitted level of every later
-  # factor. When the two are not aligned, match the coefficient names instead --
-  # with startsWith() rather than a regex, both so a name carrying metacharacters
-  # such as "pspline(age)" is matched as written, and because the prefix collision
-  # of #689 came from the regex quantifier in "^var*." -- "add17TRUE" does not
-  # start with "add11". Aligned models -- every model without a penalised term --
-  # keep the model$assign path exactly as before.
-  .assign.aligned <- nrow(coef) == length(stats::coef(model))
-  .assign.names <- gsub("`", "", names(model$assign))
+  # normally returns one row per design column, so the indices address `coef`
+  # directly. A penalised term -- pspline() -- is collapsed by tidy() into fewer
+  # rows than it has design columns, so from that term onwards the indices run
+  # past the end of `coef`: the term absorbs NA rows and every later term is
+  # mis-keyed. A pspline model therefore drew a block of blank "reference" rows
+  # and lost the fitted level of every factor after it.
+  #
+  # Only the terms whose indices actually overrun are re-keyed, by matching the
+  # coefficient names. Everything else -- including frailty(), whose tidy row sits
+  # at its own design-column index -- keeps model$assign untouched.
+  .assign.bare <- gsub("`", "", names(model$assign))
   .coef.rows <- function(var) {
-    if (.assign.aligned) {
-      idx <- model$assign[[var]]
-      if (is.null(idx)) {
-        # A non-syntactic name (e.g. "risk grp") is stored backtick-quoted in
-        # names(model$assign) but bare in dataClasses / model$contrasts, so the
-        # direct [[var]] lookup misses it; match on the stripped names instead.
-        pos <- which(.assign.names == var)
-        if (length(pos) == 1L) idx <- model$assign[[pos]]
-      }
-      return(idx)
+    idx <- model$assign[[var]]
+    if (is.null(idx)) {
+      # A non-syntactic name (e.g. "risk grp") is backtick-quoted in
+      # names(model$assign) but bare in dataClasses / model$contrasts.
+      pos <- which(.assign.bare == var)
+      if (length(pos) == 1L) idx <- model$assign[[pos]]
     }
-    hit <- which(startsWith(gsub("`", "", coef$term), var))
-    if (length(hit)) hit else NULL
+    # In range means tidy() did not collapse this term: use the indices as before.
+    if (!is.null(idx) && length(idx) && all(idx <= nrow(coef))) return(idx)
+    # Otherwise match by name. startsWith() rather than a regex so a name carrying
+    # metacharacters ("pspline(age)") is matched as written; a longer term name
+    # that also matches is excluded so a shorter variable cannot absorb the
+    # longer one's coefficients, which would draw that coefficient twice (#689).
+    cterm <- gsub("`", "", coef$term)
+    hit <- startsWith(cterm, var)
+    if (!any(hit)) return(NULL)
+    longer <- .assign.bare[.assign.bare != var & startsWith(.assign.bare, var)]
+    for (o in longer) hit <- hit & !startsWith(cterm, o)
+    if (!any(hit)) NULL else which(hit)
   }
 
   .factor_level_keys <- function(var, levs) {
@@ -251,8 +255,8 @@ ggforest <- function(model, data = NULL,
       # e.g. term "add11" matched coefficient "add17TRUE" and vice-versa,
       # producing duplicated/wrong rows for prefix-colliding names (#689).
       idx <- .coef.rows(var)
-      if (is.null(idx)) idx <- which(startsWith(coef$term, var)) # literal fallback
       vars = coef$term[idx]
+      if (length(vars) == 0L) return(NULL)   # nothing matched: drop, do not error
       # key = the coefficient name itself (level is ""), matching the old
       # paste0(var, level) = vars key exactly, so these terms are byte-identical.
       data.frame(var = vars, Var1 = "", Freq = nrow(data),
@@ -266,11 +270,15 @@ ggforest <- function(model, data = NULL,
   # coefficients via model$assign (the same reliable mechanism used for
   # multi-coefficient terms above). Models with no interaction terms are
   # unaffected: .inter.terms is empty, so allTerms is unchanged.
-  .inter.terms <- grep(":", names(model$assign), value = TRUE, fixed = TRUE)
+  # a namespace-qualified term ("splines::ns(age, 3)") is not an interaction, so
+  # strip "::" before looking for the ":" that separates interacting variables.
+  .inter.terms <- names(model$assign)[
+    grepl(":", gsub("::", "", names(model$assign), fixed = TRUE), fixed = TRUE)]
   if (length(.inter.terms) > 0) {
     allTerms <- c(allTerms, lapply(.inter.terms, function(term){
       idx <- .coef.rows(term)
       vars <- coef$term[idx]
+      if (length(vars) == 0L) return(NULL)   # nothing matched: drop, do not error
       data.frame(var = vars, Var1 = "", Freq = nrow(data), pos = seq_along(vars),
                  key = vars)
     }))

--- a/tests/testthat/test-ggforest-spline-terms.R
+++ b/tests/testthat/test-ggforest-spline-terms.R
@@ -240,3 +240,22 @@ test_that("a pspline() term is re-keyed even when its indices fit inside the tab
   expect_equal(sum(grepl("^\\(N=", L)), 12L)   # 2 pspline rows + 10 covariates
   for (z in paste0("z", 1:10)) expect_equal(sum(L == z), 1L, info = z)
 })
+
+test_that("a term not named after its coefficients keeps them", {
+  # ridge(age, wt.loss, theta = 1) is summarised as "ridge(age)" / "ridge(wt.loss)",
+  # so the term label matches neither. Inside a frailty() model -- where the summary
+  # and the coefficient vector already disagree -- that must not be read as the term
+  # having been collapsed: matching zero names means "not named after its
+  # coefficients", and dropping the term lost both hazard ratios silently.
+  d <- na.omit(survival::lung[, c("time", "status", "age", "sex", "wt.loss", "inst")])
+  d$sexf <- factor(d$sex, labels = c("M", "F"))
+  m <- survival::coxph(survival::Surv(time, status) ~
+                         ridge(age, wt.loss, theta = 1) + frailty(inst) + sexf,
+                       data = d)
+  L <- .forest_labels(m, d)
+  ci <- summary(m)$conf.int
+  for (r in rownames(ci))
+    expect_true(any(grepl(sprintf("%.2f", ci[r, "exp(coef)"]), L, fixed = TRUE)),
+                info = r)
+  expect_equal(sum(grepl("^\\(N=", L)), 5L)
+})

--- a/tests/testthat/test-ggforest-spline-terms.R
+++ b/tests/testthat/test-ggforest-spline-terms.R
@@ -1,3 +1,12 @@
+.forest_labels <- function(model, data) {
+  p <- ggforest(model, data = data)
+  gt <- grid::grid.force(ggplot2::ggplotGrob(p)); L <- character()
+  w <- function(g) { if (inherits(g, "gTree") && !is.null(g$children))
+    for (n in names(g$children)) w(g$children[[n]])
+    if (!is.null(g$label)) L <<- c(L, as.character(g$label)) }
+  w(gt); L
+}
+
 context("ggforest draws one row per coefficient for multi-coefficient spline terms (#411)")
 
 # #411: with spline terms a coxph produces several coefficients per term
@@ -96,4 +105,90 @@ test_that("no-regression: a plain numeric+factor model still draws one row per l
   walk(gt)
   expect_true(any(grepl("age", seen)))
   expect_true(any(grepl("sex", seen)))
+})
+
+test_that("a pspline() term does not mis-key the terms after it", {
+  # model$assign indexes design columns (12 for pspline(age)) while broom::tidy()
+  # collapses the term to 2 rows, so the old mapping ran off the end of the
+  # coefficient table: pspline picked up NA rows and `sex` lost its fitted level.
+  d <- na.omit(survival::lung[, c("time", "status", "age", "sex")])
+  d$sex <- factor(d$sex, labels = c("M", "F"))
+  m <- survival::coxph(survival::Surv(time, status) ~ pspline(age) + sex, data = d)
+  expect_gt(length(stats::coef(m)), nrow(broom::tidy(m)))   # the mismatch itself
+
+  labs <- function(p) {
+    gt <- grid::grid.force(ggplot2::ggplotGrob(p)); L <- character()
+    w <- function(g) { if (inherits(g, "gTree") && !is.null(g$children))
+      for (n in names(g$children)) w(g$children[[n]])
+      if (!is.null(g$label)) L <<- c(L, as.character(g$label)) }
+    w(gt); L
+  }
+  L <- labs(ggforest(m, data = d))
+
+  # exactly two reference rows: pspline's nonlin, and sex's baseline level
+  expect_equal(sum(L == "reference"), 2L)
+  # the fitted level keeps its hazard ratio, and no stray "sexF" variable row
+  ref <- summary(m)$conf.int["sexF", ]
+  expect_true(any(grepl(sprintf("%.1f", ref[["exp(coef)"]]), L, fixed = TRUE)))
+  expect_false("sexF" %in% L)
+  # both levels of sex are drawn, once each
+  expect_equal(sum(L == "M"), 1L)
+  expect_equal(sum(L == "F"), 1L)
+})
+
+test_that("a frailty() term is mapped the same way", {
+  # frailty() mismatches in the other direction -- tidy() adds a row the
+  # coefficient vector does not have -- so the alignment test must catch both.
+  d <- na.omit(survival::lung[, c("time", "status", "age", "inst", "sex")])
+  d$sex <- factor(d$sex, labels = c("M", "F"))
+  m <- survival::coxph(survival::Surv(time, status) ~ frailty(inst) + sex, data = d)
+  expect_true(nrow(broom::tidy(m)) != length(stats::coef(m)))
+
+  labs <- function(p) {
+    gt <- grid::grid.force(ggplot2::ggplotGrob(p)); L <- character()
+    w <- function(g) { if (inherits(g, "gTree") && !is.null(g$children))
+      for (n in names(g$children)) w(g$children[[n]])
+      if (!is.null(g$label)) L <<- c(L, as.character(g$label)) }
+    w(gt); L
+  }
+  L <- labs(ggforest(m, data = d))
+  # sex still gets both levels and keeps its fitted hazard ratio
+  expect_equal(sum(L == "M"), 1L)
+  expect_equal(sum(L == "F"), 1L)
+  ref <- summary(m)$conf.int["sexF", ]
+  expect_true(any(grepl(sprintf("%.1f", ref[["exp(coef)"]]), L, fixed = TRUE)))
+})
+
+test_that("name matching on the penalised path cannot claim a longer term's coefficients", {
+  # With a penalised term the coefficient rows are matched by name, so a variable
+  # whose name is a prefix of another ("flag" vs "flag2") must not absorb the
+  # other's coefficients -- the collision that made "add11" match "add17TRUE"
+  # (#689). Logical variables are used because they are routed by coefficient name
+  # rather than by contrast matrix, so a wrong match is not caught downstream.
+  d <- na.omit(survival::lung[, c("time", "status", "age", "sex", "wt.loss")])
+  d$flag  <- d$age > 60
+  d$flag2 <- d$wt.loss > 0
+  d$grp  <- factor(ifelse(d$sex == 1, "a", "b"))
+  d$grp2 <- factor(ifelse(d$wt.loss > 0, "x", "y"))
+  ml <- survival::coxph(survival::Surv(time, status) ~ pspline(age) + flag + flag2,
+                        data = d)
+  Ll <- .forest_labels(ml, d)
+  expect_equal(sum(Ll == "flagTRUE"), 1L)
+  expect_equal(sum(Ll == "flag2TRUE"), 1L)
+
+  m <- survival::coxph(survival::Surv(time, status) ~ pspline(age) + grp + grp2,
+                       data = d)
+  expect_true(nrow(broom::tidy(m)) != length(stats::coef(m)))   # penalised path
+  expect_true(any(startsWith(broom::tidy(m)$term, "grp")))      # the collision
+
+  L <- .forest_labels(m, d)
+  # each factor keeps exactly its own two levels, drawn once each
+  for (lv in c("a", "b", "x", "y")) expect_equal(sum(L == lv), 1L, info = lv)
+  # one reference per factor plus pspline's nonlin row
+  expect_equal(sum(L == "reference"), 3L)
+  # and each fitted level keeps its own hazard ratio
+  ci <- summary(m)$conf.int
+  for (nm in c("grpb", "grp2y"))
+    expect_true(any(grepl(sprintf("%.2f", ci[nm, "exp(coef)"]), L, fixed = TRUE)),
+                info = nm)
 })

--- a/tests/testthat/test-ggforest-spline-terms.R
+++ b/tests/testthat/test-ggforest-spline-terms.R
@@ -219,3 +219,24 @@ test_that("a penalised term alongside an interaction or a namespaced term draws"
   Ln <- .forest_labels(mn, d)
   expect_equal(sum(grepl("^\\(N=", Ln)), 5L)   # 2 pspline + 3 spline rows
 })
+
+test_that("a pspline() term is re-keyed even when its indices fit inside the table", {
+  # pspline() has 12 design columns, so once the model carries ten or more other
+  # coefficients those indices fall INSIDE the summary and stop overrunning it --
+  # the term then quietly absorbed its neighbours' rows and every covariate was
+  # drawn twice. Being in range is not the same as not having been collapsed.
+  set.seed(3)
+  n <- 400
+  D <- data.frame(time = rexp(n, 0.05), status = rbinom(n, 1, 0.7),
+                  age = rnorm(n, 60, 10))
+  for (i in 1:10) D[[paste0("z", i)]] <- rnorm(n)
+  m <- survival::coxph(
+    stats::as.formula(paste("survival::Surv(time, status) ~ pspline(age) +",
+                            paste0("z", 1:10, collapse = " + "))), data = D)
+  # the indices no longer overrun, which is what makes this case slip through
+  expect_lte(max(m$assign[["pspline(age)"]]), nrow(broom::tidy(m)))
+
+  L <- .forest_labels(m, D)
+  expect_equal(sum(grepl("^\\(N=", L)), 12L)   # 2 pspline rows + 10 covariates
+  for (z in paste0("z", 1:10)) expect_equal(sum(L == z), 1L, info = z)
+})

--- a/tests/testthat/test-ggforest-spline-terms.R
+++ b/tests/testthat/test-ggforest-spline-terms.R
@@ -136,27 +136,28 @@ test_that("a pspline() term does not mis-key the terms after it", {
   expect_equal(sum(L == "F"), 1L)
 })
 
-test_that("a frailty() term is mapped the same way", {
-  # frailty() mismatches in the other direction -- tidy() adds a row the
-  # coefficient vector does not have -- so the alignment test must catch both.
-  d <- na.omit(survival::lung[, c("time", "status", "age", "inst", "sex")])
-  d$sex <- factor(d$sex, labels = c("M", "F"))
-  m <- survival::coxph(survival::Surv(time, status) ~ frailty(inst) + sex, data = d)
+test_that("a frailty() model keeps the model$assign mapping", {
+  # tidy() adds a frailty row that coef() does not have, so the two counts differ
+  # for EVERY frailty model -- but each term's indices still address its own tidy
+  # row. Rerouting them onto name matching shifted every hazard ratio down one
+  # level and dropped the last one, so the mapping must be left alone.
+  d <- na.omit(survival::lung[, c("time", "status", "age", "ph.ecog",
+                                  "wt.loss", "inst")])
+  d$ecogB <- factor(d$ph.ecog)
+  contrasts(d$ecogB) <- contr.treatment(nlevels(d$ecogB), base = 2)
+  d$ecogBnum <- d$wt.loss          # name prefixed by "ecogB": the collision case
+  m <- survival::coxph(survival::Surv(time, status) ~ frailty(inst) + ecogB +
+                         ecogBnum, data = d)
   expect_true(nrow(broom::tidy(m)) != length(stats::coef(m)))
 
-  labs <- function(p) {
-    gt <- grid::grid.force(ggplot2::ggplotGrob(p)); L <- character()
-    w <- function(g) { if (inherits(g, "gTree") && !is.null(g$children))
-      for (n in names(g$children)) w(g$children[[n]])
-      if (!is.null(g$label)) L <<- c(L, as.character(g$label)) }
-    w(gt); L
-  }
-  L <- labs(ggforest(m, data = d))
-  # sex still gets both levels and keeps its fitted hazard ratio
-  expect_equal(sum(L == "M"), 1L)
-  expect_equal(sum(L == "F"), 1L)
-  ref <- summary(m)$conf.int["sexF", ]
-  expect_true(any(grepl(sprintf("%.1f", ref[["exp(coef)"]]), L, fixed = TRUE)))
+  L <- .forest_labels(m, d)
+  ci <- summary(m)$conf.int
+  # every fitted hazard ratio reaches the plot, on its own row
+  for (r in rownames(ci))
+    expect_true(any(grepl(sprintf("%.2f", ci[r, "exp(coef)"]), L, fixed = TRUE)),
+                info = r)
+  # exactly one reference level for the factor (plus none invented elsewhere)
+  expect_equal(sum(L == "reference"), 2L)
 })
 
 test_that("name matching on the penalised path cannot claim a longer term's coefficients", {
@@ -173,6 +174,10 @@ test_that("name matching on the penalised path cannot claim a longer term's coef
   ml <- survival::coxph(survival::Surv(time, status) ~ pspline(age) + flag + flag2,
                         data = d)
   Ll <- .forest_labels(ml, d)
+  # count DRAWN rows, not labels: a duplicated row has its variable label blanked
+  # by duplicated(), so a label count cannot see it (the point, interval, N and
+  # p-value are still drawn twice).
+  expect_equal(sum(grepl("^\\(N=", Ll)), 4L)   # 2 pspline rows + flag + flag2
   expect_equal(sum(Ll == "flagTRUE"), 1L)
   expect_equal(sum(Ll == "flag2TRUE"), 1L)
 
@@ -182,6 +187,7 @@ test_that("name matching on the penalised path cannot claim a longer term's coef
   expect_true(any(startsWith(broom::tidy(m)$term, "grp")))      # the collision
 
   L <- .forest_labels(m, d)
+  expect_equal(sum(grepl("^\\(N=", L)), 6L)    # 2 pspline + 2 grp + 2 grp2 levels
   # each factor keeps exactly its own two levels, drawn once each
   for (lv in c("a", "b", "x", "y")) expect_equal(sum(L == lv), 1L, info = lv)
   # one reference per factor plus pspline's nonlin row
@@ -191,4 +197,25 @@ test_that("name matching on the penalised path cannot claim a longer term's coef
   for (nm in c("grpb", "grp2y"))
     expect_true(any(grepl(sprintf("%.2f", ci[nm, "exp(coef)"]), L, fixed = TRUE)),
                 info = nm)
+})
+
+test_that("a penalised term alongside an interaction or a namespaced term draws", {
+  d <- na.omit(survival::lung[, c("time", "status", "age", "wt.loss", "sex")])
+  d$grp  <- factor(ifelse(d$sex == 1, "a", "b"))
+  d$grp2 <- factor(ifelse(d$wt.loss > 0, "x", "y"))
+
+  # an interaction label ("grp:grp2") is never a prefix of its coefficient
+  # ("grpb:grp2y"), so the name match finds nothing; that has to degrade to no
+  # rows rather than error out of the data.frame() call
+  mi <- survival::coxph(survival::Surv(time, status) ~ pspline(age) + grp * grp2,
+                        data = d)
+  Li <- .forest_labels(mi, d)
+  expect_equal(sum(grepl("^\\(N=", Li)), 6L)   # 2 pspline + 2 grp + 2 grp2
+
+  # "splines::ns(age, 3)" contains "::" and is not an interaction: treating it as
+  # one processed the term twice and drew every spline row a second time
+  mn <- survival::coxph(survival::Surv(time, status) ~ pspline(wt.loss) +
+                          splines::ns(age, 3), data = d)
+  Ln <- .forest_labels(mn, d)
+  expect_equal(sum(grepl("^\\(N=", Ln)), 5L)   # 2 pspline + 3 spline rows
 })


### PR DESCRIPTION
`ggforest()` on a Cox model containing a penalised term draws a block of blank
"reference" rows, shows every level of the following variable as the reference,
and puts that variable's hazard ratio on a row of its own. It is a regression
against 0.5.2, which drew this model correctly.

```r
library(survival)
library(survminer)

d <- na.omit(lung[, c("time", "status", "age", "sex")])
d$sex <- factor(d$sex, labels = c("M", "F"))
m <- coxph(Surv(time, status) ~ pspline(age) + sex, data = d)
ggforest(m, data = d)
```

**Before** — 14 rows: nine blank ones, a `sexF` row carrying HR 0.6, and a `sex`
block whose *both* levels read "reference", so the fitted level has no hazard
ratio at all:

![before](https://i.imgur.com/Tk2i64q.png)

**After** — the four rows 0.5.2 produced:

![after](https://i.imgur.com/irCT6ac.png)

## Cause

Each term is routed to its coefficients through `model$assign`, which indexes the
design columns. `broom::tidy()` normally returns one row per design column, so the
two line up — but a penalised term is collapsed:

```r
length(coef(m))       #> 13   (pspline(age) has 12 design columns)
nrow(broom::tidy(m))  #>  3   ("pspline(age), linear", ", nonlin", "sexF")

broom::tidy(m)$term[m$assign[["pspline(age)"]]]
#> "pspline(age), linear" "pspline(age), nonlin" "sexF" NA NA NA NA NA NA NA NA NA
broom::tidy(m)$term[m$assign[["sex"]]]
#> NA
```

`pspline(age)` swallows `sexF` plus nine `NA`s, and `sex` gets `NA` — hence the
blank rows and the two "reference" levels. `frailty()` mismatches the other way
(more summary rows than coefficients).

When the two do not line up, the coefficient names are matched instead. The match
is literal rather than a regular expression, so a name containing parentheses is
matched as written — and that also avoids the quantifier in the old `"^var*."`
pattern that once let `add11` match `add17TRUE` (#689).

## Nothing else changes

Only a model whose summary and coefficient vector disagree takes the new path.
Checked across every other shape — numeric, factor, several factors, mixed,
interaction, interaction-only, `ns()` splines, `strata()`, `cluster()`, character,
logical, non-syntactic names, aliased/collinear, three-level factors,
`contr.treatment(base=)`, and the `columns` / `palette` / `noDigits` arguments —
the built plot is identical to `master` in all 18:

```
18 / 18 identical
```

`ns()` splines are worth calling out: they are multi-coefficient too, but `tidy()`
returns one row each, so they keep the `model$assign` path untouched.
