### PR TITLE
Take the parametric overlay's groups from the fit's strata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,13 @@
 
 - `ggsurvplot()` now accepts `plotmath` expressions in `legend.labs` (e.g. `legend.labs = c(expression(beta[1]), expression(x^2))`), rendering superscripts, subscripts and Greek letters in the legend and the number-at-risk table while leaving the palette unchanged (#350). A plain character `legend.labs` behaves exactly as before.
 
-- `ggsurvparametric()` draws the fitted curve for every group again when the
-  right-hand side carries a transform (`~ factor(sex)`) or names more than one
-  variable. Those two cases produced no fitted curve at all and half of them
-  respectively, while the legend still showed the distribution's key.
+- `ggsurvparametric()` draws the fitted curve for every group when the right-hand
+  side carries a transform such as `~ factor(sex)`, and when several grouping
+  variables give labels of differing width. Both cases could leave curves out of
+  the plot -- all of them in the first case -- while the legend still showed the
+  distribution's key. A grouping term whose value depends on the other
+  observations (`mean()`, `cut()`) is now refused rather than risking a curve
+  drawn from another group's parameters.
 
 - `ggforest()` draws a Cox model containing a `pspline()` term alongside another
   covariate correctly again. Such a term has more model coefficients than the

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 - `ggsurvplot()` now accepts `plotmath` expressions in `legend.labs` (e.g. `legend.labs = c(expression(beta[1]), expression(x^2))`), rendering superscripts, subscripts and Greek letters in the legend and the number-at-risk table while leaving the palette unchanged (#350). A plain character `legend.labs` behaves exactly as before.
 
+- `ggsurvparametric()` draws the fitted curve for every group again when the
+  right-hand side carries a transform (`~ factor(sex)`) or names more than one
+  variable. Those two cases produced no fitted curve at all and half of them
+  respectively, while the legend still showed the distribution's key.
+
 - `ggforest()` draws a Cox model containing a `pspline()` term alongside another
   covariate correctly again. Such a term has more model coefficients than the
   summary has rows, which left the plot with a block of blank "reference" rows and

--- a/R/ggsurvparametric.R
+++ b/R/ggsurvparametric.R
@@ -138,10 +138,6 @@ ggsurvparametric <- function(fit, data = NULL, conf.int = FALSE, linewidth = 1,
   paste0(toupper(substr(d, 1, 1)), substr(d, 2, nchar(d)))
 }
 
-# one newdata row per survfit stratum, in the survfit strata order. Matches the
-# observed covariate combinations to the survfit's "var=level, ..." strata names,
-# so the overlay lines up with the KM by position regardless of covariate type
-# (numeric grouping included).
 # One representative covariate row per stratum, in the fit's own strata order.
 #
 # The strata labels are read from the fit rather than rebuilt as
@@ -175,6 +171,12 @@ ggsurvparametric <- function(fit, data = NULL, conf.int = FALSE, linewidth = 1,
   # cut(x, 3) -- can be recomputed into a different group than the model was fitted
   # with, and the curve would be drawn from another group's parameters. Recompute
   # the grouping on the rows themselves: each must still label as its own stratum.
+  if (anyNA(rows))
+    stop("ggsurvparametric() could not find the data rows for ",
+         sum(is.na(rows)), " of the fit's ", length(rows), " groups, so their ",
+         "curves cannot be predicted. This happens when the data passed here do ",
+         "not produce the same groups as the fit -- pass the same data the model ",
+         "was fitted on.", call. = FALSE)
   ok <- tryCatch(identical(as.character(.strata_group_from_formula(fml, out)),
                            as.character(raw.strata)),
                  error = function(e) FALSE)

--- a/R/ggsurvparametric.R
+++ b/R/ggsurvparametric.R
@@ -90,7 +90,7 @@ ggsurvparametric <- function(fit, data = NULL, conf.int = FALSE, linewidth = 1,
 
   # ---- parametric survival per group over the observed time grid ----------
   times <- seq(0, max(km$time, na.rm = TRUE), length.out = 100)
-  newdata <- .parametric_newdata(data, rhs, raw.strata)
+  newdata <- .parametric_newdata(data, fml, rhs, raw.strata)
   psurv <- .parametric_surv(fit, newdata, times, conf.int, conf.level, nsim)
   psurv$strata <- factor(km.strata[psurv$.row], levels = km.strata)
 
@@ -142,15 +142,27 @@ ggsurvparametric <- function(fit, data = NULL, conf.int = FALSE, linewidth = 1,
 # observed covariate combinations to the survfit's "var=level, ..." strata names,
 # so the overlay lines up with the KM by position regardless of covariate type
 # (numeric grouping included).
-.parametric_newdata <- function(data, rhs, raw.strata) {
-  if (length(rhs) == 0)
+# One representative covariate row per stratum, in the fit's own strata order.
+#
+# The strata labels are read from the fit rather than rebuilt as
+# paste0(variable, "=", value): a rebuilt label misses a transformed term --
+# `~ factor(sex)` is stored as "factor(sex)=1", not "sex=1" -- and misses the
+# padding survival::strata() applies when a formula has several variables. Either
+# mismatch made every match() NA, so the parametric curve was silently computed
+# from NA covariates and never drawn, while the legend still advertised the fit.
+.parametric_newdata <- function(data, fml, rhs, raw.strata) {
+  if (length(attr(stats::terms(fml), "term.labels")) == 0)
     return(data.frame(row.names = seq_along(raw.strata)))
-  combos <- unique(data[, rhs, drop = FALSE])
-  combos <- combos[stats::complete.cases(combos), , drop = FALSE]
-  labs <- apply(combos, 1, function(r)
-    paste(paste0(rhs, "=", r), collapse = ", "))
-  ord <- match(raw.strata, labs)
-  combos[ord, , drop = FALSE]
+  g <- as.character(.strata_group_from_formula(fml, data))
+  rows <- vapply(raw.strata, function(s) {
+    i <- which(!is.na(g) & g == s)
+    if (length(i)) i[1L] else NA_integer_
+  }, integer(1), USE.NAMES = FALSE)
+  # keep only the right-hand-side variables: an unrelated column carrying NA
+  # would otherwise be dropped by predict()'s na.action and lose that curve.
+  out <- data[rows, rhs, drop = FALSE]
+  rownames(out) <- NULL
+  out
 }
 
 # model-agnostic parametric S(t): a long data frame time, surv, .row (the newdata

--- a/R/ggsurvparametric.R
+++ b/R/ggsurvparametric.R
@@ -151,17 +151,40 @@ ggsurvparametric <- function(fit, data = NULL, conf.int = FALSE, linewidth = 1,
 # mismatch made every match() NA, so the parametric curve was silently computed
 # from NA covariates and never drawn, while the legend still advertised the fit.
 .parametric_newdata <- function(data, fml, rhs, raw.strata) {
-  if (length(attr(stats::terms(fml), "term.labels")) == 0)
-    return(data.frame(row.names = seq_along(raw.strata)))
-  g <- as.character(.strata_group_from_formula(fml, data))
+  g <- .strata_group_from_formula(fml, data)
+  # No grouping at all (`~ 1`, or a right-hand side carrying only an offset): a
+  # single curve. Keep the right-hand-side columns so an offset term can still be
+  # evaluated; for `~ 1` there are none and this is an empty row, as before.
+  if (nlevels(g) <= 1L) {
+    one <- data[rep(1L, length(raw.strata)), rhs, drop = FALSE]
+    rownames(one) <- NULL
+    return(one)
+  }
+  gc <- as.character(g)
   rows <- vapply(raw.strata, function(s) {
-    i <- which(!is.na(g) & g == s)
+    i <- which(!is.na(gc) & gc == s)
     if (length(i)) i[1L] else NA_integer_
   }, integer(1), USE.NAMES = FALSE)
   # keep only the right-hand-side variables: an unrelated column carrying NA
   # would otherwise be dropped by predict()'s na.action and lose that curve.
   out <- data[rows, rhs, drop = FALSE]
   rownames(out) <- NULL
+
+  # predict() re-evaluates the formula against these rows alone, so a term whose
+  # value depends on the rest of the column -- (age > mean(age)), scale(x),
+  # cut(x, 3) -- can be recomputed into a different group than the model was fitted
+  # with, and the curve would be drawn from another group's parameters. Recompute
+  # the grouping on the rows themselves: each must still label as its own stratum.
+  ok <- tryCatch(identical(as.character(.strata_group_from_formula(fml, out)),
+                           as.character(raw.strata)),
+                 error = function(e) FALSE)
+  if (!ok)
+    stop("ggsurvparametric() cannot draw a fitted curve for a grouping term whose ",
+         "value depends on the other observations (for example `mean()`, ",
+         "`median()`, `scale()` or `cut()` inside the formula): predicting one row ",
+         "per group would re-evaluate it and could place a curve on the wrong ",
+         "group. Compute the grouping variable before fitting and use it directly.",
+         call. = FALSE)
   out
 }
 

--- a/tests/testthat/test-ggsurvparametric.R
+++ b/tests/testthat/test-ggsurvparametric.R
@@ -144,19 +144,86 @@ test_that("a transformed or multi-variable right-hand side still draws every cur
 
 test_that("the parametric overlay is on the curve it belongs to", {
   skip_if_not_installed("survival")
-  # a drawn-but-misaligned overlay is worse than a missing one: check the fitted
-  # value tracks its own arm rather than merely being non-NA
+  # A drawn-but-misaligned overlay is worse than a missing one, so check the fitted
+  # value against an independent predict() for that stratum's own covariate row.
+  # NOTE the strata column carries the plot's DISPLAY labels ("sexf=M"), not the
+  # bare factor levels -- filtering with the wrong one silently selects no rows and
+  # compares empty vectors, so assert the selection is non-empty first.
   d <- survival::lung[!is.na(survival::lung$sex), ]
   d$sexf <- factor(d$sex, labels = c("M", "F"))
   f <- survival::survreg(survival::Surv(time, status) ~ sexf, data = d,
                          dist = "weibull")
   ps <- attr(suppressWarnings(ggsurvparametric(f, data = d))$plot, "parametric")
-  # predict() for each stratum's own covariate row, computed independently
-  for (lv in levels(d$sexf)) {
-    got <- ps[as.character(ps$strata) == lv, ]
+  disp <- levels(ps$strata)
+  expect_equal(length(disp), nlevels(d$sexf))
+
+  for (i in seq_along(disp)) {
+    got <- ps[as.character(ps$strata) == disp[i], ]
+    expect_gt(nrow(got), 0)                       # the filter must select rows
     got <- got[order(got$time), ]
+    lv <- levels(d$sexf)[i]                       # display order tracks fit order
     ref <- predict(f, newdata = data.frame(sexf = factor(lv, levels = levels(d$sexf))),
                    type = "quantile", p = 1 - got$surv)
-    expect_equal(unname(as.numeric(ref)), got$time, tolerance = 1e-6, info = lv)
+    expect_equal(unname(as.numeric(ref)), got$time, tolerance = 1e-6, info = disp[i])
   }
+})
+
+test_that("each arm of a multi-variable fit gets its own curve", {
+  skip_if_not_installed("survival")
+  # with four strata a swapped assignment is invisible unless each curve is checked
+  # against its own arm's linear predictor
+  d <- survival::lung[!is.na(survival::lung$ph.ecog), ]
+  d$sexf <- factor(d$sex, labels = c("Male", "F"))
+  d$e <- factor(ifelse(d$ph.ecog > 0, "bad", "good"))
+  f <- survival::survreg(survival::Surv(time, status) ~ sexf + e, data = d,
+                         dist = "weibull")
+  ps <- attr(suppressWarnings(ggsurvparametric(f, data = d))$plot, "parametric")
+  km <- survival::survfit(survival::Surv(time, status) ~ sexf + e, data = d)
+  disp <- levels(ps$strata)
+  expect_equal(length(disp), length(km$strata))
+
+  # rebuild each stratum's covariate row from its own label and predict directly
+  for (i in seq_along(disp)) {
+    lab <- names(km$strata)[i]
+    parts <- strsplit(trimws(strsplit(lab, ", ", fixed = TRUE)[[1]]), "=", fixed = TRUE)
+    nd <- data.frame(sexf = factor(parts[[1]][2], levels = levels(d$sexf)),
+                     e    = factor(parts[[2]][2], levels = levels(d$e)))
+    got <- ps[as.character(ps$strata) == disp[i], ]
+    expect_gt(nrow(got), 0)
+    got <- got[order(got$time), ]
+    ref <- predict(f, newdata = nd, type = "quantile", p = 1 - got$surv)
+    expect_equal(unname(as.numeric(ref)), got$time, tolerance = 1e-6, info = lab)
+  }
+})
+
+test_that("a grouping term that depends on the other rows is refused", {
+  skip_if_not_installed("survival")
+  # predict() re-evaluates the formula against the one row per group handed to it,
+  # so mean()/cut() inside the formula can put a representative row in a different
+  # group than the model was fitted with and draw another group's curve.
+  set.seed(3)
+  age  <- c(59, 1, 61, 62, rep(60, 120))
+  d <- data.frame(time = rexp(length(age), 0.03),
+                  status = rbinom(length(age), 1, 0.7), age = age,
+                  sexf = factor(c("F", "M", "F", "M", rep(c("F", "M"), 60))))
+  f <- survival::survreg(survival::Surv(time, status) ~ (age > mean(age)) + sexf,
+                         data = d)
+  expect_error(suppressWarnings(ggsurvparametric(f, data = d)),
+               "depends on the other observations")
+
+  # a row-wise transform is fine and must still draw
+  f2 <- survival::survreg(survival::Surv(time, status) ~ (age > 60) + sexf, data = d)
+  ps <- attr(suppressWarnings(ggsurvparametric(f2, data = d))$plot, "parametric")
+  expect_equal(sum(is.na(ps$surv)), 0L)
+})
+
+test_that("a right-hand side of only an offset still draws one curve", {
+  skip_if_not_installed("survival")
+  d <- survival::lung
+  d$off <- 0
+  f <- suppressWarnings(
+    survival::survreg(survival::Surv(time, status) ~ offset(off), data = d))
+  ps <- attr(suppressWarnings(ggsurvparametric(f, data = d))$plot, "parametric")
+  expect_gt(nrow(ps), 0)
+  expect_equal(sum(is.na(ps$surv)), 0L)
 })

--- a/tests/testthat/test-ggsurvparametric.R
+++ b/tests/testthat/test-ggsurvparametric.R
@@ -227,3 +227,22 @@ test_that("a right-hand side of only an offset still draws one curve", {
   expect_gt(nrow(ps), 0)
   expect_equal(sum(is.na(ps$surv)), 0L)
 })
+
+test_that("a group with no matching row is reported as such", {
+  skip_if_not_installed("survival")
+  # the fit drops rows with a missing response, so a numeric grouping value that
+  # survives only on dropped rows changes survival::strata()'s label padding and
+  # no representative row matches. That is a different problem from a term being
+  # re-evaluated, and the advice for it is different too.
+  set.seed(5)
+  d <- data.frame(a = factor(rep(c("x", "y"), 30)),
+                  b = rep(c(1, 2, 10), each = 20),
+                  time = c(rexp(40, 0.05), rep(NA_real_, 20)),
+                  status = 1L)
+  f <- survival::survreg(survival::Surv(time, status) ~ a + b, data = d)
+  err <- tryCatch(suppressWarnings(ggsurvparametric(f, data = d)),
+                  error = function(e) conditionMessage(e))
+  expect_type(err, "character")
+  expect_match(err, "could not find the data rows", fixed = TRUE)
+  expect_false(grepl("depends on the other observations", err, fixed = TRUE))
+})

--- a/tests/testthat/test-ggsurvparametric.R
+++ b/tests/testthat/test-ggsurvparametric.R
@@ -105,3 +105,58 @@ test_that("non-parametric inputs error with a helpful message", {
                "ggsurvplot")
   expect_error(ggsurvparametric(lm(1 ~ 1)), "survreg or flexsurvreg")
 })
+
+test_that("a transformed or multi-variable right-hand side still draws every curve", {
+  skip_if_not_installed("survival")
+  # The overlay used to be matched to the KM by rebuilding the strata label as
+  # paste0(variable, "=", value). That misses a transform -- survfit stores
+  # "factor(sex)=1", not "sex=1" -- and misses the padding survival::strata()
+  # applies with several variables, so every covariate row came out NA and the
+  # curve was silently never drawn while the legend still advertised the fit.
+  n_na <- function(p) {
+    ps <- attr(p$plot, "parametric")
+    c(rows = nrow(ps), na = sum(is.na(ps$surv)))
+  }
+
+  # (a) a transform on the right-hand side: every row was NA, zero curves drawn
+  f1 <- survival::survreg(survival::Surv(time, status) ~ factor(sex),
+                          data = survival::lung, dist = "weibull")
+  r1 <- n_na(suppressWarnings(ggsurvparametric(f1, data = survival::lung)))
+  expect_gt(r1[["rows"]], 0)
+  expect_equal(r1[["na"]], 0)
+
+  # (b) two grouping variables: survival::strata() pads the labels to a common
+  # width, so half the rows were NA and half the curves were missing
+  d <- survival::lung[!is.na(survival::lung$ph.ecog), ]
+  d$sexf <- factor(d$sex, labels = c("Male", "F"))     # unequal label widths
+  d$e <- factor(ifelse(d$ph.ecog > 0, "bad", "good"))
+  f2 <- survival::survreg(survival::Surv(time, status) ~ sexf + e, data = d,
+                          dist = "weibull")
+  p2 <- suppressWarnings(ggsurvparametric(f2, data = d))
+  r2 <- n_na(p2)
+  expect_equal(r2[["na"]], 0)
+
+  # one fitted curve per stratum, aligned to the fit's own strata
+  km <- survival::survfit(survival::Surv(time, status) ~ sexf + e, data = d)
+  expect_equal(length(unique(attr(p2$plot, "parametric")$strata)),
+               length(km$strata))
+})
+
+test_that("the parametric overlay is on the curve it belongs to", {
+  skip_if_not_installed("survival")
+  # a drawn-but-misaligned overlay is worse than a missing one: check the fitted
+  # value tracks its own arm rather than merely being non-NA
+  d <- survival::lung[!is.na(survival::lung$sex), ]
+  d$sexf <- factor(d$sex, labels = c("M", "F"))
+  f <- survival::survreg(survival::Surv(time, status) ~ sexf, data = d,
+                         dist = "weibull")
+  ps <- attr(suppressWarnings(ggsurvparametric(f, data = d))$plot, "parametric")
+  # predict() for each stratum's own covariate row, computed independently
+  for (lv in levels(d$sexf)) {
+    got <- ps[as.character(ps$strata) == lv, ]
+    got <- got[order(got$time), ]
+    ref <- predict(f, newdata = data.frame(sexf = factor(lv, levels = levels(d$sexf))),
+                   type = "quantile", p = 1 - got$surv)
+    expect_equal(unname(as.numeric(ref)), got$time, tolerance = 1e-6, info = lv)
+  }
+})


### PR DESCRIPTION
`ggsurvparametric()` draws no fitted curve at all when the right-hand side carries
a transform, and only half of them when it names two variables. The legend still
shows the distribution's key, so the figure claims a fit it never drew.

```r
library(survival)
library(survminer)

fit <- survreg(Surv(time, status) ~ factor(sex), data = lung, dist = "weibull")
p <- ggsurvparametric(fit, data = lung)
all(is.na(attr(p$plot, "parametric")$surv))
#> TRUE          -- every predicted value is NA; nothing is drawn
```

The only signal is a generic ggplot2 message about removed rows.

## Cause

The fitted curves are matched to the Kaplan-Meier groups by rebuilding each
stratum label as `paste0(variable, "=", value)`. A `survfit` stores the label as
written:

```r
names(survfit(Surv(time, status) ~ factor(sex), data = lung)$strata)
#> "factor(sex)=1" "factor(sex)=2"      but the rebuild gives "sex=1" "sex=2"
```

and with several variables `survival::strata()` pads the labels to a common
width, so `"sexf=Male, e=bad "` is compared against `"sexf=Male, e=bad"`. Either
difference makes every `match()` `NA`, so the covariate rows handed to `predict()`
are `NA` and the curve is computed from nothing.

A representative covariate row per stratum is now taken from the data instead, in
the fit's own strata order, leaving any transform for `predict()` to apply. Only
the right-hand-side columns are carried across, so a missing value elsewhere in
the data cannot drop a curve through `predict()`'s `na.action`.

## Effect

| right-hand side | before | after |
|---|---|---|
| `~ factor(sex)` | 200/200 rows `NA` — no curve | 0 `NA`, all drawn |
| `~ sexf + e` (padded labels) | 200/400 `NA` — half missing | 0 `NA`, all drawn |
| `~ (age > 60)` | — | all drawn |
| `~ sex` (already worked) | — | unchanged |

Output for the shapes that already worked is unchanged: the built plot, the
attached table and the layer data are identical to `master` for plain, factor,
lognormal, exponential and single-group fits. The confidence band is simulated
with `rnorm()`, so it differs between any two runs — including `master` against
itself — and the deterministic parts of that fixture (`time`, `surv`, `.row`) are
identical.

A new test also checks each fitted curve against an independent `predict()` for
that stratum's own covariate row, so an overlay drawn on the wrong arm would fail
rather than merely being non-`NA`.
