### PR TITLE
Carry the model's weights and tie handling into ggforest_subgroup() refits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -148,8 +148,8 @@
   clustered one cluster-robust intervals. Each subgroup variable gets one
   interaction p-value (the test of effect modification, as opposed to the per-level
   estimates): a likelihood-ratio test, or a Wald chi-square on the
-  treatment-by-subgroup coefficients when the refit carries a robust variance,
-  where a likelihood comparison would not be valid. Unstratifiable
+  treatment-by-subgroup coefficients for any weighted or clustered fit, where a
+  likelihood comparison would not be valid. Unstratifiable
   levels are dropped with a warning. Returns a themeable ggplot with an optional
   overall row, a "No. of patients (\%)" column, precision-weighted boxes and a
   "favours" annotation. Complements `ggforest()` (see #271 and #366).

--- a/NEWS.md
+++ b/NEWS.md
@@ -141,11 +141,14 @@
 - New `ggforest_subgroup()` draws the subgroup forest plot used in clinical
   reporting: the hazard ratio of a treatment *within* each level of one or more
   subgroup variables, with the treatment-by-subgroup interaction test. Per-level
-  hazard ratios come from refitting the Cox model on each subset, reproducing the
-  fit supplied: the case weights and the tie handling of the model are carried
-  into every refit, so a weighted model reports weighted subgroup estimates. Each
-  subgroup variable gets one interaction p-value from a likelihood-ratio test (the
-  test of effect modification, as opposed to the per-level estimates). Unstratifiable
+  hazard ratios come from refitting the Cox model on each subset, with the case
+  weights, tie handling, clustering and robust-variance setting of the model
+  carried into every refit -- so a weighted model reports weighted subgroup
+  estimates and a clustered one cluster-robust intervals. Each subgroup variable
+  gets one interaction p-value (the test of effect modification, as opposed to the
+  per-level estimates): a likelihood-ratio test, or a Wald chi-square on the
+  treatment-by-subgroup coefficients when the fit carries a robust variance, where
+  a likelihood comparison would not be valid. Unstratifiable
   levels are dropped with a warning. Returns a themeable ggplot with an optional
   overall row, a "No. of patients (\%)" column, precision-weighted boxes and a
   "favours" annotation. Complements `ggforest()` (see #271 and #366).

--- a/NEWS.md
+++ b/NEWS.md
@@ -142,13 +142,14 @@
   reporting: the hazard ratio of a treatment *within* each level of one or more
   subgroup variables, with the treatment-by-subgroup interaction test. Per-level
   hazard ratios come from refitting the Cox model on each subset, with the case
-  weights, tie handling, clustering and robust-variance setting of the model
-  carried into every refit -- so a weighted model reports weighted subgroup
-  estimates and a clustered one cluster-robust intervals. Each subgroup variable
-  gets one interaction p-value (the test of effect modification, as opposed to the
-  per-level estimates): a likelihood-ratio test, or a Wald chi-square on the
-  treatment-by-subgroup coefficients when the fit carries a robust variance, where
-  a likelihood comparison would not be valid. Unstratifiable
+  weights, tie handling, robust-variance setting and clustering of the model --
+  `cluster()` in the formula, or the `cluster` or `id` argument -- carried into
+  every refit, so a weighted model reports weighted subgroup estimates and a
+  clustered one cluster-robust intervals. Each subgroup variable gets one
+  interaction p-value (the test of effect modification, as opposed to the per-level
+  estimates): a likelihood-ratio test, or a Wald chi-square on the
+  treatment-by-subgroup coefficients when the refit carries a robust variance,
+  where a likelihood comparison would not be valid. Unstratifiable
   levels are dropped with a warning. Returns a themeable ggplot with an optional
   overall row, a "No. of patients (\%)" column, precision-weighted boxes and a
   "favours" annotation. Complements `ggforest()` (see #271 and #366).

--- a/NEWS.md
+++ b/NEWS.md
@@ -141,9 +141,11 @@
 - New `ggforest_subgroup()` draws the subgroup forest plot used in clinical
   reporting: the hazard ratio of a treatment *within* each level of one or more
   subgroup variables, with the treatment-by-subgroup interaction test. Per-level
-  hazard ratios come from refitting the Cox model on each subset; each subgroup
-  variable gets one interaction p-value from a likelihood-ratio test (the test of
-  effect modification, as opposed to the per-level estimates). Unstratifiable
+  hazard ratios come from refitting the Cox model on each subset, reproducing the
+  fit supplied: the case weights and the tie handling of the model are carried
+  into every refit, so a weighted model reports weighted subgroup estimates. Each
+  subgroup variable gets one interaction p-value from a likelihood-ratio test (the
+  test of effect modification, as opposed to the per-level estimates). Unstratifiable
   levels are dropped with a warning. Returns a themeable ggplot with an optional
   overall row, a "No. of patients (\%)" column, precision-weighted boxes and a
   "favours" annotation. Complements `ggforest()` (see #271 and #366).

--- a/R/ggforest_subgroup.R
+++ b/R/ggforest_subgroup.R
@@ -31,6 +31,15 @@ NULL
 #' interaction test is the inference; the individual per-level hazard ratios are
 #' descriptive and subject to multiplicity (see Wang et al., 2007).
 #'
+#' The refits reproduce the fit the user supplied: the case weights and the tie
+#' handling of \code{model} are carried into every subset fit, so a subgroup
+#' hazard ratio is the weighted one whenever the model is weighted. The two
+#' models compared by the interaction test are fit without a robust variance,
+#' which \code{\link[survival]{coxph}()} otherwise attaches to a weighted fit:
+#' the likelihood-ratio test compares log-likelihoods, which the variance
+#' estimator does not change, and \code{\link[stats]{anova}()} declines a fit
+#' that carries one.
+#'
 #' The plot is composed of three aligned panels (labels, forest, statistics), so
 #' the text columns keep a fixed width and do not collide with the forest at any
 #' figure size.
@@ -265,10 +274,38 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
   alpha <- 1 - conf.level
   tkey  <- .treatment_key(model, treatment, data)   # coef name + labels
 
+  # Every subgroup hazard ratio comes from refitting the model on that subset, so
+  # the refit has to be the user's model: dropping the weights or the tie handling
+  # reported a different estimate than the one the model carries, with nothing on
+  # the plot to say so. The weights ride along as a data column, so subsetting the
+  # data subsets them too.
+  wcol <- NULL
+  w.all <- .model_weights(model, data)
+  if (!is.null(w.all)) {
+    wcol <- ".ggf_weights"
+    while (wcol %in% names(data)) wcol <- paste0(wcol, "_")
+    data[[wcol]] <- w.all
+  }
+  fit.args <- list()
+  if (!is.null(model$call$ties)) fit.args$ties <- eval(model$call$ties)
+  if (!is.null(model$call$robust)) fit.args$robust <- eval(model$call$robust)
+  .coxph_like <- function(fo, dsub, robust = NULL) {
+    a <- c(list(formula = fo, data = dsub), fit.args)
+    if (!is.null(wcol)) a$weights <- dsub[[wcol]]
+    if (!is.null(robust)) a$robust <- robust
+    do.call(survival::coxph, a)
+  }
+  # The interaction test is a likelihood-ratio test, which compares log-likelihoods
+  # and so does not use the variance estimator -- but anova() refuses a fit that
+  # carries a robust variance, which coxph() gives any weighted fit by default.
+  # Fit the two comparison models without it: same coefficients, same likelihoods,
+  # and the test is then the weighted one rather than an unweighted stand-in.
+  .coxph_lrt <- function(fo, dsub) .coxph_like(fo, dsub, robust = FALSE)
+
   # per-subset treatment HR/CI/precision from a refit of the model formula
   one <- function(dsub) {
     fo <- .drop_constant_terms(stats::formula(model), dsub, keep = treatment)
-    fit <- tryCatch(survival::coxph(fo, data = dsub),
+    fit <- tryCatch(.coxph_like(fo, dsub),
                     error = function(e) NULL, warning = function(w) NULL)
     if (is.null(fit)) return(NULL)
     est <- stats::coef(fit)
@@ -296,7 +333,7 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
            "categories first.", call. = FALSE)
     f <- if (is.factor(x)) x else factor(x)
     hrow <- .row("header", sg.labs[j], NULL)
-    hrow$pint <- .interaction_p(model, data, treatment, v)
+    hrow$pint <- .interaction_p(model, data, treatment, v, fitter = .coxph_lrt)
     rows[[length(rows) + 1L]] <- hrow
     for (lv in levels(f)) {
       dsub <- data[!is.na(x) & x == lv, , drop = FALSE]
@@ -354,9 +391,11 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
 
 # Likelihood-ratio interaction p-value for one subgroup variable: additive
 # (model + subgroup) vs interaction (+ treatment:subgroup), on the shared
-# complete cases. Names are back-quoted so non-syntactic variable names do not
-# break the formula. Returns NA if either fit fails.
-.interaction_p <- function(model, data, treatment, v) {
+# complete cases, both fitted the way the model itself was (`fitter`). Names
+# are back-quoted so non-syntactic variable names do not break the formula.
+# Returns NA if either fit fails.
+.interaction_p <- function(model, data, treatment, v,
+                           fitter = function(fo, dd) survival::coxph(fo, data = dd)) {
   bt  <- function(x) paste0("`", gsub("`", "", x), "`")
   rhs <- attr(stats::terms(model), "term.labels")
   resp <- deparse(stats::formula(model)[[2]])
@@ -367,9 +406,23 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
                 paste(c(base, paste0(bt(treatment), ":", bt(v))), collapse = " + ")))
     vars <- unique(c(all.vars(add_f), v))
     dd <- data[stats::complete.cases(data[, intersect(vars, colnames(data)), drop = FALSE]), ]
-    a <- survival::coxph(add_f, data = dd); i <- survival::coxph(int_f, data = dd)
+    a <- fitter(add_f, dd); i <- fitter(int_f, dd)
     stats::anova(a, i)[["Pr(>|Chi|)"]][2]
   }, error = function(e) NA_real_, warning = function(w) NA_real_)
+}
+
+# The weights the model was fitted with, aligned to the rows of `data`, or NULL.
+# Evaluated in `data` first (the usual `weights = w` naming a column), then in the
+# call's own environment for a weights vector held outside the data frame.
+.model_weights <- function(model, data) {
+  wq <- model$call$weights
+  if (is.null(wq)) return(NULL)
+  env <- environment(stats::formula(model))
+  if (is.null(env)) env <- parent.frame()
+  w <- tryCatch(eval(wq, envir = data, enclos = env), error = function(e) NULL)
+  if (is.null(w)) w <- tryCatch(eval(wq, envir = env), error = function(e) NULL)
+  if (is.null(w) || !is.numeric(w) || length(w) != nrow(data)) return(NULL)
+  as.numeric(w)
 }
 
 # Drop from a model formula any RHS term that is constant in `dsub` (would make

--- a/R/ggforest_subgroup.R
+++ b/R/ggforest_subgroup.R
@@ -35,10 +35,14 @@ NULL
 #' tie handling, its \code{robust} setting, and its clustering -- whether written
 #' as \code{cluster()} in the formula or passed as \code{cluster} or \code{id}.
 #' So a weighted model reports weighted subgroup estimates and a clustered model
-#' cluster-robust intervals. Nothing else is carried: a \code{subset} argument, an
-#' \code{offset()} term, \code{control} settings and \code{tt()} transforms are
-#' not, so pass the data the model was fitted on rather than relying on
-#' \code{subset}.
+#' cluster-robust intervals. Anything written into the formula --
+#' \code{\link[survival]{strata}()}, \code{\link[survival]{frailty}()},
+#' \code{ridge()}, \code{pspline()} -- travels with it. Arguments outside the
+#' formula do not: a \code{subset}, an \code{offset()} term, \code{control}
+#' settings and \code{tt()} transforms are all lost, so pass the rows you want as
+#' \code{data} rather than relying on \code{subset}. As a backstop the whole-data
+#' refit is compared with \code{model} itself, and a disagreement in the treatment
+#' coefficient is reported rather than plotted.
 #'
 #' The weights are read from the fitted object. Survival keeps no copy of the
 #' cluster vector, so that one is re-evaluated from the call. Either way they are
@@ -56,17 +60,23 @@ NULL
 #' distribution, and \code{\link[survival]{anova.coxph}} declines to compare
 #' them for that reason; the interaction is then tested by a Wald chi-square on
 #' the treatment-by-subgroup coefficients, taken from that robust variance.
-#' Whether \code{\link[survival]{coxph}()} attaches a robust variance turns on
-#' whether the weights are integral, not on what they mean, so integer-valued
-#' weights take the likelihood-ratio branch. That suits frequency weights, which is
-#' what whole-numbered weights usually are; sampling weights that happen to be
-#' integral would be tested as though they were counts, so pass those unrounded.
-#' A robust Wald test is also anticonservative when there are few clusters -- treat
-#' an interaction p-value from a fit with only a handful of them as approximate.
+#' Any weighted model is tested this way, including one whose weights are whole
+#' numbers. \code{\link[survival]{coxph}()} decides whether to attach a robust
+#' variance from whether the weights are integral, which cannot distinguish a
+#' frequency count from a sampling weight that happens to be a whole number, and a
+#' likelihood-ratio test is only valid for counts; a Wald test on a robust variance
+#' is valid for either, so one is requested when the fit does not already carry it.
+#'
+#' A robust Wald test is anticonservative when there are few clusters, and the
+#' cluster-robust intervals are then too narrow as well; the function warns below
+#' fifty clusters, and both should be read as approximate there.
 #'
 #' The per-level hazard ratio is estimated by refitting on that level alone, so
 #' each level carries its own baseline hazard and, in an adjusted model, its own
-#' covariate coefficients. It is the estimate a reader reproduces by running
+#' covariate coefficients. Rows the model itself dropped for missing covariates
+#' stay out of the subset fits even where the covariate that excluded them is no
+#' longer in the formula, so a weighted fit can rest on fewer rows than the count
+#' column shows. It is the estimate a reader reproduces by running
 #' \code{\link[survival]{coxph}()} on that subset by hand, with the same weights
 #' and tie handling. Some tools instead
 #' read the within-level effects off a single treatment-by-subgroup interaction
@@ -80,6 +90,9 @@ NULL
 #'
 #' @param model a \code{coxph} object whose terms include \code{treatment}. It may
 #'   be crude (\code{~ treatment}) or adjusted (\code{~ treatment + covariates}).
+#'   A weighted or clustered model must have been fitted with the default
+#'   \code{y = TRUE}, since its stored response is what \code{data} is checked
+#'   against.
 #' @param data the data frame used to fit \code{model}. If not supplied it is
 #'   extracted from \code{model}.
 #' @param treatment the name of the treatment variable (a term of \code{model}).
@@ -325,9 +338,7 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
     w.all <- .fit_vector(model$weights, model, data)
     if (is.null(w.all) || !isTRUE(aligned))
       stop("ggforest_subgroup() cannot match the case weights of `model` to the rows ",
-           "of `data`. Supply the data frame `model` was fitted on, fitted with the ",
-           "default `y = TRUE` so the two can be checked against each other.",
-           call. = FALSE)
+           "of `data`. ", .why_unmatched(model), call. = FALSE)
     wcol <- ".ggf_weights"
     while (wcol %in% names(data)) wcol <- paste0(wcol, "_")
     data[[wcol]] <- w.all
@@ -341,24 +352,54 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
     v <- .model_call_vector(q, data, menv)
     if (is.null(v) || !isTRUE(aligned))
       stop("ggforest_subgroup() cannot match the `", nm, "` of `model` to the rows of ",
-           "`data`. Supply the data frame `model` was fitted on.", call. = FALSE)
+           "`data`. ", .why_unmatched(model), call. = FALSE)
     col <- paste0(".ggf_", nm)
     while (col %in% names(data)) col <- paste0(col, "_")
     data[[col]] <- v
     if (nm == "cluster") ccol <- col else icol <- col
   }
   fit.args <- list()
-  if (!is.null(model$call$ties))
-    fit.args$ties <- tryCatch(eval(model$call$ties, envir = menv), error = function(e) NULL)
+  # coxph resolves `ties` / its `method` alias and stores the answer, so take it
+  # from the fit -- reading the call would miss the `method =` spelling entirely
+  if (!is.null(model$method)) fit.args$ties <- model$method
   if (!is.null(model$call$robust))
     fit.args$robust <- tryCatch(eval(model$call$robust, envir = menv), error = function(e) NULL)
   fit.args <- fit.args[!vapply(fit.args, is.null, logical(1))]
-  .coxph_like <- function(fo, dsub) {
+  if (!is.null(ccol) || !is.null(icol)) {
+    nclus <- length(unique(data[[if (!is.null(ccol)) ccol else icol]]))
+    if (nclus < 50L)
+      warning("ggforest_subgroup(): `model` has only ", nclus, " clusters. The ",
+              "cluster-robust intervals are too narrow and the interaction test ",
+              "rejects too often at this many clusters; read both as approximate.",
+              call. = FALSE)
+  }
+  .coxph_like <- function(fo, dsub, robust = NULL) {
     a <- c(list(formula = fo, data = dsub), fit.args)
     if (!is.null(wcol)) a$weights <- dsub[[wcol]]
     if (!is.null(ccol)) a$cluster <- dsub[[ccol]]
     if (!is.null(icol)) a$id <- dsub[[icol]]
+    if (!is.null(robust)) a$robust <- robust
     do.call(survival::coxph, a)
+  }
+
+  # A reconstruction that has quietly lost something -- a fit setting we do not
+  # know to carry, a `subset`, a cluster vector overwritten since the fit -- shows
+  # up as the whole-data refit disagreeing with the model it came from. Cheaper to
+  # check once than to let a wrong number onto the plot.
+  chk <- tryCatch(.coxph_like(.drop_constant_terms(stats::formula(model), data,
+                                                   keep = treatment), data),
+                  error = function(e) NULL, warning = function(w) NULL)
+  if (!is.null(chk) && tkey$coef %in% names(stats::coef(chk)) &&
+      tkey$coef %in% names(stats::coef(model))) {
+    b0 <- stats::coef(model)[[tkey$coef]]; b1 <- stats::coef(chk)[[tkey$coef]]
+    if (is.finite(b0) && is.finite(b1) &&
+        !isTRUE(all.equal(b0, b1, tolerance = 1e-6)))
+      warning("ggforest_subgroup(): refitting `model` on all of `data` gives a ",
+              "treatment coefficient of ", format(b1, digits = 6), " where `model` ",
+              "itself has ", format(b0, digits = 6), ". The subgroup estimates do ",
+              "not come from the model as fitted -- check for a `subset`, an ",
+              "`offset()` or `control` settings, which are not carried over.",
+              call. = FALSE)
   }
 
   # per-subset treatment HR/CI/precision from a refit of the model formula
@@ -462,7 +503,8 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
 # Wald chi-square built on the robust variance itself. Returns NA if the fits or
 # the test fail.
 .interaction_p <- function(model, data, treatment, v,
-                           fitter = function(fo, dd) survival::coxph(fo, data = dd)) {
+                           fitter = function(fo, dd, robust = NULL)
+                             survival::coxph(fo, data = dd)) {
   bt  <- function(x) paste0("`", gsub("`", "", x), "`")
   rhs <- attr(stats::terms(model), "term.labels")
   resp <- deparse(stats::formula(model)[[2]])
@@ -474,6 +516,15 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
     vars <- unique(c(all.vars(add_f), v))
     dd <- data[stats::complete.cases(data[, intersect(vars, colnames(data)), drop = FALSE]), ]
     i <- fitter(int_f, dd)
+    if (is.null(i$naive.var) && !is.null(model$weights)) {
+      # coxph leaves the variance model-based when the weights are integral, but
+      # it cannot tell a frequency count from a sampling weight that happens to be
+      # whole, and the likelihood-ratio test is only valid for counts. A Wald test
+      # on a robust variance is valid either way, so ask for one.
+      i2 <- tryCatch(fitter(int_f, dd, robust = TRUE), error = function(e) NULL,
+                     warning = function(w) NULL)
+      if (!is.null(i2) && !is.null(i2$naive.var)) i <- i2
+    }
     if (is.null(i$naive.var)) {                      # model-based variance
       a <- fitter(add_f, dd)
       return(stats::anova(a, i)[["Pr(>|Chi|)"]][2])
@@ -524,11 +575,31 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
   om <- model$na.action
   if (!is.null(om) && NROW(yd) == NROW(y) + length(om))
     yd <- yd[-as.integer(om), , drop = FALSE]
-  if (NROW(yd) != NROW(y)) return(FALSE)
-  # default tolerance, not 0: coxph's timefix snaps near-tied times, so the
-  # stored response is not bit-identical to one rebuilt from the same frame.
-  # This is looking for rows in a different order, not for float noise.
-  isTRUE(all.equal(unclass(yd), unclass(y), check.attributes = FALSE))
+  yy <- unclass(y); yd <- unclass(yd)
+  if (!identical(dim(yy), dim(yd))) return(FALSE)
+  # coxph's timefix snaps near-tied times by up to sqrt(eps) times the time
+  # range -- an absolute budget -- so the stored response is not bit-identical to
+  # one rebuilt from the same frame, and a relative tolerance is the wrong ruler
+  # for wide time scales. Compare the times on their own scale and the status
+  # exactly. Rows in a different order differ by far more than this.
+  tc <- seq_len(ncol(yy) - 1L)
+  sc <- suppressWarnings(diff(range(yy[, tc], na.rm = TRUE)))
+  if (!is.finite(sc) || sc <= 0) sc <- 1
+  isTRUE(all.equal(yy[, tc], yd[, tc], check.attributes = FALSE, scale = sc)) &&
+    isTRUE(all.equal(yy[, ncol(yy)], yd[, ncol(yy)], check.attributes = FALSE))
+}
+
+# Why `data` could not be lined up with the fit, as advice the user can act on.
+.why_unmatched <- function(model) {
+  if (!is.null(model$call$subset))
+    return(paste0("`model` was fitted with `subset = ",
+                  paste(deparse(model$call$subset), collapse = ""),
+                  "`, which is not carried into the subgroup fits: pass the rows it ",
+                  "selected as `data` instead."))
+  if (is.null(model$y))
+    return(paste0("`model` was fitted with `y = FALSE`, so it kept no response to ",
+                  "check `data` against: refit with the default `y = TRUE`."))
+  "Supply the data frame `model` was fitted on, in its original row order."
 }
 
 # A vector the model call refers to (weights, cluster), aligned to the rows of

--- a/R/ggforest_subgroup.R
+++ b/R/ggforest_subgroup.R
@@ -31,14 +31,33 @@ NULL
 #' interaction test is the inference; the individual per-level hazard ratios are
 #' descriptive and subject to multiplicity (see Wang et al., 2007).
 #'
-#' The refits reproduce the fit the user supplied: the case weights and the tie
-#' handling of \code{model} are carried into every subset fit, so a subgroup
-#' hazard ratio is the weighted one whenever the model is weighted. The two
-#' models compared by the interaction test are fit without a robust variance,
-#' which \code{\link[survival]{coxph}()} otherwise attaches to a weighted fit:
-#' the likelihood-ratio test compares log-likelihoods, which the variance
-#' estimator does not change, and \code{\link[stats]{anova}()} declines a fit
-#' that carries one.
+#' The subset fits are made the way \code{model} itself was: its case weights,
+#' tie handling and clustering are carried over, so a weighted model reports
+#' weighted subgroup estimates and a clustered model cluster-robust intervals.
+#' The weights and the clustering are read from the fitted object and matched to
+#' the rows of \code{data}; if they cannot be matched -- \code{data} reordered,
+#' or not the frame the model was fitted on -- that is an error rather than a
+#' quietly unweighted plot.
+#'
+#' Which interaction test is used follows the variance the fit carries. With the
+#' ordinary model-based variance it is the likelihood-ratio test described above.
+#' When the fit carries a robust variance -- \code{\link[survival]{coxph}()}
+#' attaches one to any clustered, \code{robust = TRUE} or non-integer weighted
+#' fit -- differences in the log-partial-likelihood no longer have a chi-square
+#' distribution, and \code{\link[survival]{anova.coxph}} declines to compare
+#' them for that reason; the interaction is then tested by a Wald chi-square on
+#' the treatment-by-subgroup coefficients, taken from that robust variance.
+#' Integer (frequency) weights leave the variance model-based, so they keep the
+#' likelihood-ratio test.
+#'
+#' The per-level hazard ratio is estimated by refitting on that level alone, so
+#' each level carries its own baseline hazard and, in an adjusted model, its own
+#' covariate coefficients. It is the estimate a reader reproduces by running
+#' \code{\link[survival]{coxph}()} on that subset by hand. Some tools instead
+#' read the within-level effects off a single treatment-by-subgroup interaction
+#' model fitted to everyone, which pools the baseline hazard across levels; the
+#' two agree closely in large balanced strata and can differ appreciably in small
+#' or heterogeneous ones.
 #'
 #' The plot is composed of three aligned panels (labels, forest, statistics), so
 #' the text columns keep a fixed width and do not collide with the forest at any
@@ -66,7 +85,8 @@ NULL
 #'   subjects in each subgroup level (and their percentage of the total). Default
 #'   \code{TRUE}. This count is the subgroup size; when the model has adjusting
 #'   covariates with missing values it can exceed the complete-case sample the
-#'   hazard ratio is actually fit on.
+#'   hazard ratio is actually fit on. It counts subjects, so for a weighted model
+#'   it does not equal the sum of the weights the hazard ratio is estimated from.
 #' @param favours optional length-2 character vector
 #'   \code{c("Favours treatment", "Favours control")} drawn under the axis on the
 #'   left (HR < 1) and right (HR > 1) sides of the reference line. Default
@@ -279,28 +299,46 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
   # reported a different estimate than the one the model carries, with nothing on
   # the plot to say so. The weights ride along as a data column, so subsetting the
   # data subsets them too.
-  wcol <- NULL
-  w.all <- .model_weights(model, data)
-  if (!is.null(w.all)) {
+  menv <- environment(stats::formula(model))
+  if (is.null(menv)) menv <- parent.frame()
+  # Weights and clustering ride along as data columns, so subsetting the data
+  # subsets them too. Both are taken from the fitted object where survival stores
+  # them, never re-evaluated from the call: re-evaluating would resolve the name
+  # wherever this function happens to be standing and can pick up an unrelated
+  # object of the same name.
+  wcol <- ccol <- NULL
+  if (!is.null(model$weights)) {
+    w.all <- .fit_vector(model$weights, model, data)
+    if (is.null(w.all) || isFALSE(.data_is_fit_data(model, data)))
+      stop("ggforest_subgroup() cannot match the case weights of `model` to the rows ",
+           "of `data`. Supply the data frame `model` was fitted on.", call. = FALSE)
     wcol <- ".ggf_weights"
     while (wcol %in% names(data)) wcol <- paste0(wcol, "_")
     data[[wcol]] <- w.all
   }
+  # cluster() written in the formula is moved to the call by coxph(), so both
+  # spellings arrive here the same way.
+  if (!is.null(model$call$cluster)) {
+    c.all <- .model_call_vector(model$call$cluster, data, menv)
+    if (is.null(c.all) || isFALSE(.data_is_fit_data(model, data)))
+      stop("ggforest_subgroup() cannot match the clustering of `model` to the rows of ",
+           "`data`. Supply the data frame `model` was fitted on.", call. = FALSE)
+    ccol <- ".ggf_cluster"
+    while (ccol %in% names(data)) ccol <- paste0(ccol, "_")
+    data[[ccol]] <- c.all
+  }
   fit.args <- list()
-  if (!is.null(model$call$ties)) fit.args$ties <- eval(model$call$ties)
-  if (!is.null(model$call$robust)) fit.args$robust <- eval(model$call$robust)
-  .coxph_like <- function(fo, dsub, robust = NULL) {
+  if (!is.null(model$call$ties))
+    fit.args$ties <- tryCatch(eval(model$call$ties, envir = menv), error = function(e) NULL)
+  if (!is.null(model$call$robust))
+    fit.args$robust <- tryCatch(eval(model$call$robust, envir = menv), error = function(e) NULL)
+  fit.args <- fit.args[!vapply(fit.args, is.null, logical(1))]
+  .coxph_like <- function(fo, dsub) {
     a <- c(list(formula = fo, data = dsub), fit.args)
     if (!is.null(wcol)) a$weights <- dsub[[wcol]]
-    if (!is.null(robust)) a$robust <- robust
+    if (!is.null(ccol)) a$cluster <- dsub[[ccol]]
     do.call(survival::coxph, a)
   }
-  # The interaction test is a likelihood-ratio test, which compares log-likelihoods
-  # and so does not use the variance estimator -- but anova() refuses a fit that
-  # carries a robust variance, which coxph() gives any weighted fit by default.
-  # Fit the two comparison models without it: same coefficients, same likelihoods,
-  # and the test is then the weighted one rather than an unweighted stand-in.
-  .coxph_lrt <- function(fo, dsub) .coxph_like(fo, dsub, robust = FALSE)
 
   # per-subset treatment HR/CI/precision from a refit of the model formula
   one <- function(dsub) {
@@ -333,7 +371,7 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
            "categories first.", call. = FALSE)
     f <- if (is.factor(x)) x else factor(x)
     hrow <- .row("header", sg.labs[j], NULL)
-    hrow$pint <- .interaction_p(model, data, treatment, v, fitter = .coxph_lrt)
+    hrow$pint <- .interaction_p(model, data, treatment, v, fitter = .coxph_like)
     rows[[length(rows) + 1L]] <- hrow
     for (lv in levels(f)) {
       dsub <- data[!is.na(x) & x == lv, , drop = FALSE]
@@ -389,11 +427,19 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
   list(coef = coefs, trt = trt, ref = ref)
 }
 
-# Likelihood-ratio interaction p-value for one subgroup variable: additive
-# (model + subgroup) vs interaction (+ treatment:subgroup), on the shared
-# complete cases, both fitted the way the model itself was (`fitter`). Names
-# are back-quoted so non-syntactic variable names do not break the formula.
-# Returns NA if either fit fails.
+# Interaction p-value for one subgroup variable, comparing the additive model
+# (model + subgroup) with the interaction model (+ treatment:subgroup) on the
+# shared complete cases, both fitted the way the model itself was (`fitter`).
+# Names are back-quoted so non-syntactic variable names do not break the formula.
+#
+# Which test is used follows the variance the fit carries. With the model-based
+# variance this is the likelihood-ratio test. When the fit carries a robust
+# variance -- coxph() attaches one to any non-integer weighted, clustered or
+# robust = TRUE fit -- differences in the log-partial-likelihood no longer have
+# a chi-square distribution (see ?anova.coxph, which declines such a comparison
+# for exactly that reason), so the interaction coefficients are tested with a
+# Wald chi-square built on the robust variance itself. Returns NA if the fits or
+# the test fail.
 .interaction_p <- function(model, data, treatment, v,
                            fitter = function(fo, dd) survival::coxph(fo, data = dd)) {
   bt  <- function(x) paste0("`", gsub("`", "", x), "`")
@@ -406,23 +452,73 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
                 paste(c(base, paste0(bt(treatment), ":", bt(v))), collapse = " + ")))
     vars <- unique(c(all.vars(add_f), v))
     dd <- data[stats::complete.cases(data[, intersect(vars, colnames(data)), drop = FALSE]), ]
-    a <- fitter(add_f, dd); i <- fitter(int_f, dd)
-    stats::anova(a, i)[["Pr(>|Chi|)"]][2]
+    i <- fitter(int_f, dd)
+    if (is.null(i$naive.var)) {                      # model-based variance
+      a <- fitter(add_f, dd)
+      return(stats::anova(a, i)[["Pr(>|Chi|)"]][2])
+    }
+    newt <- setdiff(attr(stats::terms(i), "term.labels"),
+                    attr(stats::terms(add_f), "term.labels"))
+    k <- unlist(i$assign[newt], use.names = FALSE)
+    if (!length(k)) return(NA_real_)
+    b <- stats::coef(i)[k]
+    V <- stats::vcov(i)[k, k, drop = FALSE]
+    if (anyNA(b) || anyNA(V)) return(NA_real_)
+    stats::pchisq(drop(t(b) %*% solve(V, b)), df = length(k), lower.tail = FALSE)
   }, error = function(e) NA_real_, warning = function(w) NA_real_)
 }
 
-# The weights the model was fitted with, aligned to the rows of `data`, or NULL.
-# Evaluated in `data` first (the usual `weights = w` naming a column), then in the
-# call's own environment for a weights vector held outside the data frame.
-.model_weights <- function(model, data) {
-  wq <- model$call$weights
-  if (is.null(wq)) return(NULL)
-  env <- environment(stats::formula(model))
-  if (is.null(env)) env <- parent.frame()
-  w <- tryCatch(eval(wq, envir = data, enclos = env), error = function(e) NULL)
-  if (is.null(w)) w <- tryCatch(eval(wq, envir = env), error = function(e) NULL)
-  if (is.null(w) || !is.numeric(w) || length(w) != nrow(data)) return(NULL)
-  as.numeric(w)
+# A vector survival kept from the fit (weights), put back on the rows of `data`:
+# coxph stores it post-na.action, and `model$na.action` says which rows it dropped.
+# Those rows come back as NA, which drops them from the refits as well -- they
+# were not in the model either. NULL when the two cannot be lined up.
+.fit_vector <- function(x, model, data) {
+  if (is.null(x)) return(NULL)
+  n <- nrow(data)
+  if (length(x) == n) return(as.numeric(x))
+  om <- model$na.action
+  if (!is.null(om) && length(x) + length(om) == n) {
+    full <- rep(NA_real_, n)
+    full[-as.integer(om)] <- as.numeric(x)
+    return(full)
+  }
+  NULL
+}
+
+# TRUE when `data` is, row for row, the data `model` was fitted on -- checked by
+# rebuilding the model's response from `data` and comparing it with the one the
+# fit stored. Only consulted when something is being carried across from the fit,
+# where a reordered or different `data` would attach a weight to the wrong
+# subject. NA when there is nothing to compare against.
+.data_is_fit_data <- function(model, data) {
+  y <- model$y
+  if (is.null(y)) return(NA)
+  yd <- tryCatch(eval(stats::formula(model)[[2]], envir = data,
+                      enclos = environment(stats::formula(model))),
+                 error = function(e) NULL)
+  if (is.null(yd)) return(NA)
+  om <- model$na.action
+  if (!is.null(om) && NROW(yd) == NROW(y) + length(om))
+    yd <- yd[-as.integer(om), , drop = FALSE]
+  if (NROW(yd) != NROW(y)) return(FALSE)
+  isTRUE(all.equal(unclass(yd), unclass(y), check.attributes = FALSE, tolerance = 0))
+}
+
+# A vector the model call refers to (weights, cluster), aligned to the rows of
+# `data`, or NULL. Evaluated in `data` first -- the usual `weights = w` naming a
+# column -- then in the call's own environment for a vector held outside the data
+# frame. A length that does not match `data` means the two do not correspond, so
+# nothing is carried.
+.model_call_vector <- function(q, data, env, numeric = FALSE) {
+  if (is.null(q)) return(NULL)
+  x <- tryCatch(eval(q, envir = data, enclos = env), error = function(e) NULL)
+  if (is.null(x)) x <- tryCatch(eval(q, envir = env), error = function(e) NULL)
+  if (is.null(x) || length(x) != nrow(data)) return(NULL)
+  if (numeric) {
+    if (!is.numeric(x)) return(NULL)
+    return(as.numeric(x))
+  }
+  x
 }
 
 # Drop from a model formula any RHS term that is constant in `dsub` (would make

--- a/R/ggforest_subgroup.R
+++ b/R/ggforest_subgroup.R
@@ -297,15 +297,13 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
   # Every subgroup hazard ratio comes from refitting the model on that subset, so
   # the refit has to be the user's model: dropping the weights or the tie handling
   # reported a different estimate than the one the model carries, with nothing on
-  # the plot to say so. The weights ride along as a data column, so subsetting the
-  # data subsets them too.
+  # the plot to say so. Weights and clustering ride along as data columns, so
+  # subsetting the data subsets them too, and both are taken from the fitted
+  # object where survival stores them rather than re-evaluated from the call --
+  # re-evaluating resolves the name wherever this function happens to be standing
+  # and can pick up an unrelated object of the same name.
   menv <- environment(stats::formula(model))
   if (is.null(menv)) menv <- parent.frame()
-  # Weights and clustering ride along as data columns, so subsetting the data
-  # subsets them too. Both are taken from the fitted object where survival stores
-  # them, never re-evaluated from the call: re-evaluating would resolve the name
-  # wherever this function happens to be standing and can pick up an unrelated
-  # object of the same name.
   wcol <- ccol <- NULL
   if (!is.null(model$weights)) {
     w.all <- .fit_vector(model$weights, model, data)

--- a/R/ggforest_subgroup.R
+++ b/R/ggforest_subgroup.R
@@ -31,13 +31,22 @@ NULL
 #' interaction test is the inference; the individual per-level hazard ratios are
 #' descriptive and subject to multiplicity (see Wang et al., 2007).
 #'
-#' The subset fits are made the way \code{model} itself was: its case weights,
-#' tie handling and clustering are carried over, so a weighted model reports
-#' weighted subgroup estimates and a clustered model cluster-robust intervals.
-#' The weights and the clustering are read from the fitted object and matched to
-#' the rows of \code{data}; if they cannot be matched -- \code{data} reordered,
-#' or not the frame the model was fitted on -- that is an error rather than a
-#' quietly unweighted plot.
+#' The subset fits carry four things over from \code{model}: its case weights, its
+#' tie handling, its \code{robust} setting, and its clustering -- whether written
+#' as \code{cluster()} in the formula or passed as \code{cluster} or \code{id}.
+#' So a weighted model reports weighted subgroup estimates and a clustered model
+#' cluster-robust intervals. Nothing else is carried: a \code{subset} argument, an
+#' \code{offset()} term, \code{control} settings and \code{tt()} transforms are
+#' not, so pass the data the model was fitted on rather than relying on
+#' \code{subset}.
+#'
+#' The weights are read from the fitted object. Survival keeps no copy of the
+#' cluster vector, so that one is re-evaluated from the call. Either way they are
+#' matched to the rows of \code{data}, and a \code{data} whose response disagrees
+#' with the one the fit stored -- reordered, or simply not the frame the model was
+#' fitted on -- is an error rather than a quietly mis-weighted plot. Because the
+#' check compares responses, it cannot see a reordering confined to rows that share
+#' the same time and status.
 #'
 #' Which interaction test is used follows the variance the fit carries. With the
 #' ordinary model-based variance it is the likelihood-ratio test described above.
@@ -47,13 +56,19 @@ NULL
 #' distribution, and \code{\link[survival]{anova.coxph}} declines to compare
 #' them for that reason; the interaction is then tested by a Wald chi-square on
 #' the treatment-by-subgroup coefficients, taken from that robust variance.
-#' Integer (frequency) weights leave the variance model-based, so they keep the
-#' likelihood-ratio test.
+#' Whether \code{\link[survival]{coxph}()} attaches a robust variance turns on
+#' whether the weights are integral, not on what they mean, so integer-valued
+#' weights take the likelihood-ratio branch. That suits frequency weights, which is
+#' what whole-numbered weights usually are; sampling weights that happen to be
+#' integral would be tested as though they were counts, so pass those unrounded.
+#' A robust Wald test is also anticonservative when there are few clusters -- treat
+#' an interaction p-value from a fit with only a handful of them as approximate.
 #'
 #' The per-level hazard ratio is estimated by refitting on that level alone, so
 #' each level carries its own baseline hazard and, in an adjusted model, its own
 #' covariate coefficients. It is the estimate a reader reproduces by running
-#' \code{\link[survival]{coxph}()} on that subset by hand. Some tools instead
+#' \code{\link[survival]{coxph}()} on that subset by hand, with the same weights
+#' and tie handling. Some tools instead
 #' read the within-level effects off a single treatment-by-subgroup interaction
 #' model fitted to everyone, which pools the baseline hazard across levels; the
 #' two agree closely in large balanced strata and can differ appreciably in small
@@ -304,26 +319,33 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
   # and can pick up an unrelated object of the same name.
   menv <- environment(stats::formula(model))
   if (is.null(menv)) menv <- parent.frame()
-  wcol <- ccol <- NULL
+  wcol <- ccol <- icol <- NULL
+  aligned <- .data_is_fit_data(model, data)
   if (!is.null(model$weights)) {
     w.all <- .fit_vector(model$weights, model, data)
-    if (is.null(w.all) || isFALSE(.data_is_fit_data(model, data)))
+    if (is.null(w.all) || !isTRUE(aligned))
       stop("ggforest_subgroup() cannot match the case weights of `model` to the rows ",
-           "of `data`. Supply the data frame `model` was fitted on.", call. = FALSE)
+           "of `data`. Supply the data frame `model` was fitted on, fitted with the ",
+           "default `y = TRUE` so the two can be checked against each other.",
+           call. = FALSE)
     wcol <- ".ggf_weights"
     while (wcol %in% names(data)) wcol <- paste0(wcol, "_")
     data[[wcol]] <- w.all
   }
-  # cluster() written in the formula is moved to the call by coxph(), so both
-  # spellings arrive here the same way.
-  if (!is.null(model$call$cluster)) {
-    c.all <- .model_call_vector(model$call$cluster, data, menv)
-    if (is.null(c.all) || isFALSE(.data_is_fit_data(model, data)))
-      stop("ggforest_subgroup() cannot match the clustering of `model` to the rows of ",
+  # survival keeps no copy of the cluster/id vector, so unlike the weights these
+  # have to be re-evaluated from the call. cluster() written in the formula is
+  # moved to the call by coxph(), so both spellings arrive here the same way.
+  for (nm in c("cluster", "id")) {
+    q <- model$call[[nm]]
+    if (is.null(q)) next
+    v <- .model_call_vector(q, data, menv)
+    if (is.null(v) || !isTRUE(aligned))
+      stop("ggforest_subgroup() cannot match the `", nm, "` of `model` to the rows of ",
            "`data`. Supply the data frame `model` was fitted on.", call. = FALSE)
-    ccol <- ".ggf_cluster"
-    while (ccol %in% names(data)) ccol <- paste0(ccol, "_")
-    data[[ccol]] <- c.all
+    col <- paste0(".ggf_", nm)
+    while (col %in% names(data)) col <- paste0(col, "_")
+    data[[col]] <- v
+    if (nm == "cluster") ccol <- col else icol <- col
   }
   fit.args <- list()
   if (!is.null(model$call$ties))
@@ -335,6 +357,7 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
     a <- c(list(formula = fo, data = dsub), fit.args)
     if (!is.null(wcol)) a$weights <- dsub[[wcol]]
     if (!is.null(ccol)) a$cluster <- dsub[[ccol]]
+    if (!is.null(icol)) a$id <- dsub[[icol]]
     do.call(survival::coxph, a)
   }
 
@@ -458,6 +481,9 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
     newt <- setdiff(attr(stats::terms(i), "term.labels"),
                     attr(stats::terms(add_f), "term.labels"))
     k <- unlist(i$assign[newt], use.names = FALSE)
+    # an empty factor level or a level seen in only one arm leaves an aliased
+    # coefficient; test the estimable ones rather than giving up on the whole term
+    k <- k[!is.na(stats::coef(i)[k])]
     if (!length(k)) return(NA_real_)
     b <- stats::coef(i)[k]
     V <- stats::vcov(i)[k, k, drop = FALSE]
@@ -499,7 +525,10 @@ ggforest_subgroup <- function(model, data = NULL, treatment,
   if (!is.null(om) && NROW(yd) == NROW(y) + length(om))
     yd <- yd[-as.integer(om), , drop = FALSE]
   if (NROW(yd) != NROW(y)) return(FALSE)
-  isTRUE(all.equal(unclass(yd), unclass(y), check.attributes = FALSE, tolerance = 0))
+  # default tolerance, not 0: coxph's timefix snaps near-tied times, so the
+  # stored response is not bit-identical to one rebuilt from the same frame.
+  # This is looking for rows in a different order, not for float noise.
+  isTRUE(all.equal(unclass(yd), unclass(y), check.attributes = FALSE))
 }
 
 # A vector the model call refers to (weights, cluster), aligned to the rows of

--- a/man/ggforest_subgroup.Rd
+++ b/man/ggforest_subgroup.Rd
@@ -23,7 +23,10 @@ ggforest_subgroup(
 }
 \arguments{
 \item{model}{a \code{coxph} object whose terms include \code{treatment}. It may
-be crude (\code{~ treatment}) or adjusted (\code{~ treatment + covariates}).}
+be crude (\code{~ treatment}) or adjusted (\code{~ treatment + covariates}).
+A weighted or clustered model must have been fitted with the default
+\code{y = TRUE}, since its stored response is what \code{data} is checked
+against.}
 
 \item{data}{the data frame used to fit \code{model}. If not supplied it is
 extracted from \code{model}.}
@@ -110,10 +113,14 @@ The subset fits carry four things over from \code{model}: its case weights, its
 tie handling, its \code{robust} setting, and its clustering -- whether written
 as \code{cluster()} in the formula or passed as \code{cluster} or \code{id}.
 So a weighted model reports weighted subgroup estimates and a clustered model
-cluster-robust intervals. Nothing else is carried: a \code{subset} argument, an
-\code{offset()} term, \code{control} settings and \code{tt()} transforms are
-not, so pass the data the model was fitted on rather than relying on
-\code{subset}.
+cluster-robust intervals. Anything written into the formula --
+\code{\link[survival]{strata}()}, \code{\link[survival]{frailty}()},
+\code{ridge()}, \code{pspline()} -- travels with it. Arguments outside the
+formula do not: a \code{subset}, an \code{offset()} term, \code{control}
+settings and \code{tt()} transforms are all lost, so pass the rows you want as
+\code{data} rather than relying on \code{subset}. As a backstop the whole-data
+refit is compared with \code{model} itself, and a disagreement in the treatment
+coefficient is reported rather than plotted.
 
 The weights are read from the fitted object. Survival keeps no copy of the
 cluster vector, so that one is re-evaluated from the call. Either way they are
@@ -131,17 +138,23 @@ fit -- differences in the log-partial-likelihood no longer have a chi-square
 distribution, and \code{\link[survival]{anova.coxph}} declines to compare
 them for that reason; the interaction is then tested by a Wald chi-square on
 the treatment-by-subgroup coefficients, taken from that robust variance.
-Whether \code{\link[survival]{coxph}()} attaches a robust variance turns on
-whether the weights are integral, not on what they mean, so integer-valued
-weights take the likelihood-ratio branch. That suits frequency weights, which is
-what whole-numbered weights usually are; sampling weights that happen to be
-integral would be tested as though they were counts, so pass those unrounded.
-A robust Wald test is also anticonservative when there are few clusters -- treat
-an interaction p-value from a fit with only a handful of them as approximate.
+Any weighted model is tested this way, including one whose weights are whole
+numbers. \code{\link[survival]{coxph}()} decides whether to attach a robust
+variance from whether the weights are integral, which cannot distinguish a
+frequency count from a sampling weight that happens to be a whole number, and a
+likelihood-ratio test is only valid for counts; a Wald test on a robust variance
+is valid for either, so one is requested when the fit does not already carry it.
+
+A robust Wald test is anticonservative when there are few clusters, and the
+cluster-robust intervals are then too narrow as well; the function warns below
+fifty clusters, and both should be read as approximate there.
 
 The per-level hazard ratio is estimated by refitting on that level alone, so
 each level carries its own baseline hazard and, in an adjusted model, its own
-covariate coefficients. It is the estimate a reader reproduces by running
+covariate coefficients. Rows the model itself dropped for missing covariates
+stay out of the subset fits even where the covariate that excluded them is no
+longer in the formula, so a weighted fit can rest on fewer rows than the count
+column shows. It is the estimate a reader reproduces by running
 \code{\link[survival]{coxph}()} on that subset by hand, with the same weights
 and tie handling. Some tools instead
 read the within-level effects off a single treatment-by-subgroup interaction

--- a/man/ggforest_subgroup.Rd
+++ b/man/ggforest_subgroup.Rd
@@ -51,7 +51,8 @@ Default \code{TRUE}.}
 subjects in each subgroup level (and their percentage of the total). Default
 \code{TRUE}. This count is the subgroup size; when the model has adjusting
 covariates with missing values it can exceed the complete-case sample the
-hazard ratio is actually fit on.}
+hazard ratio is actually fit on. It counts subjects, so for a weighted model
+it does not equal the sum of the weights the hazard ratio is estimated from.}
 
 \item{favours}{optional length-2 character vector
 \code{c("Favours treatment", "Favours control")} drawn under the axis on the
@@ -105,14 +106,33 @@ fit on the observations complete for both. As with any subgroup analysis the
 interaction test is the inference; the individual per-level hazard ratios are
 descriptive and subject to multiplicity (see Wang et al., 2007).
 
-The refits reproduce the fit the user supplied: the case weights and the tie
-handling of \code{model} are carried into every subset fit, so a subgroup
-hazard ratio is the weighted one whenever the model is weighted. The two
-models compared by the interaction test are fit without a robust variance,
-which \code{\link[survival]{coxph}()} otherwise attaches to a weighted fit:
-the likelihood-ratio test compares log-likelihoods, which the variance
-estimator does not change, and \code{\link[stats]{anova}()} declines a fit
-that carries one.
+The subset fits are made the way \code{model} itself was: its case weights,
+tie handling and clustering are carried over, so a weighted model reports
+weighted subgroup estimates and a clustered model cluster-robust intervals.
+The weights and the clustering are read from the fitted object and matched to
+the rows of \code{data}; if they cannot be matched -- \code{data} reordered,
+or not the frame the model was fitted on -- that is an error rather than a
+quietly unweighted plot.
+
+Which interaction test is used follows the variance the fit carries. With the
+ordinary model-based variance it is the likelihood-ratio test described above.
+When the fit carries a robust variance -- \code{\link[survival]{coxph}()}
+attaches one to any clustered, \code{robust = TRUE} or non-integer weighted
+fit -- differences in the log-partial-likelihood no longer have a chi-square
+distribution, and \code{\link[survival]{anova.coxph}} declines to compare
+them for that reason; the interaction is then tested by a Wald chi-square on
+the treatment-by-subgroup coefficients, taken from that robust variance.
+Integer (frequency) weights leave the variance model-based, so they keep the
+likelihood-ratio test.
+
+The per-level hazard ratio is estimated by refitting on that level alone, so
+each level carries its own baseline hazard and, in an adjusted model, its own
+covariate coefficients. It is the estimate a reader reproduces by running
+\code{\link[survival]{coxph}()} on that subset by hand. Some tools instead
+read the within-level effects off a single treatment-by-subgroup interaction
+model fitted to everyone, which pools the baseline hazard across levels; the
+two agree closely in large balanced strata and can differ appreciably in small
+or heterogeneous ones.
 
 The plot is composed of three aligned panels (labels, forest, statistics), so
 the text columns keep a fixed width and do not collide with the forest at any

--- a/man/ggforest_subgroup.Rd
+++ b/man/ggforest_subgroup.Rd
@@ -106,13 +106,22 @@ fit on the observations complete for both. As with any subgroup analysis the
 interaction test is the inference; the individual per-level hazard ratios are
 descriptive and subject to multiplicity (see Wang et al., 2007).
 
-The subset fits are made the way \code{model} itself was: its case weights,
-tie handling and clustering are carried over, so a weighted model reports
-weighted subgroup estimates and a clustered model cluster-robust intervals.
-The weights and the clustering are read from the fitted object and matched to
-the rows of \code{data}; if they cannot be matched -- \code{data} reordered,
-or not the frame the model was fitted on -- that is an error rather than a
-quietly unweighted plot.
+The subset fits carry four things over from \code{model}: its case weights, its
+tie handling, its \code{robust} setting, and its clustering -- whether written
+as \code{cluster()} in the formula or passed as \code{cluster} or \code{id}.
+So a weighted model reports weighted subgroup estimates and a clustered model
+cluster-robust intervals. Nothing else is carried: a \code{subset} argument, an
+\code{offset()} term, \code{control} settings and \code{tt()} transforms are
+not, so pass the data the model was fitted on rather than relying on
+\code{subset}.
+
+The weights are read from the fitted object. Survival keeps no copy of the
+cluster vector, so that one is re-evaluated from the call. Either way they are
+matched to the rows of \code{data}, and a \code{data} whose response disagrees
+with the one the fit stored -- reordered, or simply not the frame the model was
+fitted on -- is an error rather than a quietly mis-weighted plot. Because the
+check compares responses, it cannot see a reordering confined to rows that share
+the same time and status.
 
 Which interaction test is used follows the variance the fit carries. With the
 ordinary model-based variance it is the likelihood-ratio test described above.
@@ -122,13 +131,19 @@ fit -- differences in the log-partial-likelihood no longer have a chi-square
 distribution, and \code{\link[survival]{anova.coxph}} declines to compare
 them for that reason; the interaction is then tested by a Wald chi-square on
 the treatment-by-subgroup coefficients, taken from that robust variance.
-Integer (frequency) weights leave the variance model-based, so they keep the
-likelihood-ratio test.
+Whether \code{\link[survival]{coxph}()} attaches a robust variance turns on
+whether the weights are integral, not on what they mean, so integer-valued
+weights take the likelihood-ratio branch. That suits frequency weights, which is
+what whole-numbered weights usually are; sampling weights that happen to be
+integral would be tested as though they were counts, so pass those unrounded.
+A robust Wald test is also anticonservative when there are few clusters -- treat
+an interaction p-value from a fit with only a handful of them as approximate.
 
 The per-level hazard ratio is estimated by refitting on that level alone, so
 each level carries its own baseline hazard and, in an adjusted model, its own
 covariate coefficients. It is the estimate a reader reproduces by running
-\code{\link[survival]{coxph}()} on that subset by hand. Some tools instead
+\code{\link[survival]{coxph}()} on that subset by hand, with the same weights
+and tie handling. Some tools instead
 read the within-level effects off a single treatment-by-subgroup interaction
 model fitted to everyone, which pools the baseline hazard across levels; the
 two agree closely in large balanced strata and can differ appreciably in small

--- a/man/ggforest_subgroup.Rd
+++ b/man/ggforest_subgroup.Rd
@@ -105,6 +105,15 @@ fit on the observations complete for both. As with any subgroup analysis the
 interaction test is the inference; the individual per-level hazard ratios are
 descriptive and subject to multiplicity (see Wang et al., 2007).
 
+The refits reproduce the fit the user supplied: the case weights and the tie
+handling of \code{model} are carried into every subset fit, so a subgroup
+hazard ratio is the weighted one whenever the model is weighted. The two
+models compared by the interaction test are fit without a robust variance,
+which \code{\link[survival]{coxph}()} otherwise attaches to a weighted fit:
+the likelihood-ratio test compares log-likelihoods, which the variance
+estimator does not change, and \code{\link[stats]{anova}()} declines a fit
+that carries one.
+
 The plot is composed of three aligned panels (labels, forest, statistics), so
 the text columns keep a fixed width and do not collide with the forest at any
 figure size.

--- a/tests/testthat/test-ggforest_subgroup.R
+++ b/tests/testthat/test-ggforest_subgroup.R
@@ -184,3 +184,121 @@ test_that("conf.level is validated and the CI column header tracks it", {
   expect_true(any(grepl("HR (80% CI)", L, fixed = TRUE)))
   expect_false(any(grepl("HR (95% CI)", L, fixed = TRUE)))
 })
+
+test_that("subgroup hazard ratios come from the model the user fitted", {
+  # every row is a refit on a subset; dropping the model's weights reported an
+  # unweighted hazard ratio under a weighted model, wrong by 15% here and in
+  # opposite directions for the two subgroups
+  cc <- survival::colon[survival::colon$etype == 2 &
+                          survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx  <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("Female", "Male"))
+  set.seed(9)
+  cc$w <- runif(nrow(cc), 0.2, 3)
+  m <- survival::coxph(survival::Surv(time, status) ~ rx, data = cc, weights = w)
+
+  tab <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                            conf.level = 0.95, show.overall = TRUE)
+  est <- tab[tab$type != "header", ]
+  expect_gt(nrow(est), 0)
+
+  for (i in seq_len(nrow(est))) {
+    lab <- est$label[i]
+    ref <- if (lab == "Overall") {
+      exp(stats::coef(m))[[1]]
+    } else {
+      sub <- cc[cc$sex == lab, ]
+      exp(stats::coef(survival::coxph(survival::Surv(time, status) ~ rx,
+                                      data = sub, weights = w)))[[1]]
+    }
+    expect_equal(est$hr[i], ref, tolerance = 1e-8, info = lab)
+  }
+})
+
+test_that("the tie handling of the fit is carried into the refits too", {
+  cc <- survival::colon[survival::colon$etype == 2 &
+                          survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx  <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("Female", "Male"))
+  m <- survival::coxph(survival::Surv(time, status) ~ rx, data = cc,
+                       ties = "breslow")
+  tab <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                            conf.level = 0.95, show.overall = TRUE)
+  ov <- tab$hr[tab$label == "Overall"]
+  expect_equal(ov, exp(stats::coef(m))[[1]], tolerance = 1e-8)
+  # and it is genuinely breslow, not efron
+  expect_false(isTRUE(all.equal(
+    ov, exp(stats::coef(survival::coxph(survival::Surv(time, status) ~ rx,
+                                        data = cc, ties = "efron")))[[1]])))
+})
+
+test_that("an unweighted model is unaffected", {
+  cc <- survival::colon[survival::colon$etype == 2 &
+                          survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx  <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("Female", "Male"))
+  m <- survival::coxph(survival::Surv(time, status) ~ rx, data = cc)
+  tab <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                            conf.level = 0.95, show.overall = TRUE)
+  expect_equal(tab$hr[tab$label == "Overall"], exp(stats::coef(m))[[1]],
+               tolerance = 1e-8)
+})
+
+test_that("a model covariate named like the carried weights is not clobbered", {
+  skip_if_not_installed("survival")
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("F", "M"))
+  set.seed(9)
+  cc$w <- stats::runif(nrow(cc), 0.2, 3)
+  cc$.ggf_weights <- cc$age          # a real covariate carrying the internal name
+  m <- survival::coxph(
+    survival::Surv(time, status) ~ rx + .ggf_weights, data = cc, weights = w
+  )
+  tab <- .subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                conf.level = 0.95, show.overall = TRUE)
+
+  got <- tab$hr[tab$label == "Overall"]
+  expect_length(got, 1L)
+  expect_equal(got, unname(exp(stats::coef(m))[["rxLev+5FU"]]), tolerance = 1e-10)
+
+  # each subgroup must still refit on age, not on the weights
+  for (lv in c("F", "M")) {
+    sub <- cc[cc$sex == lv, ]
+    ref <- survival::coxph(
+      survival::Surv(time, status) ~ rx + .ggf_weights, data = sub, weights = w
+    )
+    shown <- tab$hr[tab$label == lv]
+    expect_length(shown, 1L)
+    expect_equal(shown, unname(exp(stats::coef(ref))[["rxLev+5FU"]]), tolerance = 1e-10)
+  }
+})
+
+test_that("the interaction p-value is computed on the weighted fit too", {
+  cc <- survival::colon[survival::colon$etype == 2 &
+                          survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx  <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("Female", "Male"))
+  set.seed(9)
+  cc$w <- runif(nrow(cc), 0.2, 3)
+  m <- survival::coxph(survival::Surv(time, status) ~ rx, data = cc, weights = w)
+  tab <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                            conf.level = 0.95, show.overall = TRUE)
+  got <- tab$pint[tab$type == "header" & !is.na(tab$pint)][1]
+
+  # the likelihood-ratio test does not use the variance estimator, so the
+  # comparison fits are made without the robust variance coxph() adds to a
+  # weighted fit (which anova() refuses outright)
+  a <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc,
+                       weights = w, robust = FALSE)
+  i <- survival::coxph(survival::Surv(time, status) ~ rx + sex + rx:sex, data = cc,
+                       weights = w, robust = FALSE)
+  ref <- stats::anova(a, i)[["Pr(>|Chi|)"]][2]
+  expect_false(is.na(got))
+  expect_equal(got, ref, tolerance = 1e-8)
+  # and it is not the unweighted value
+  au <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc)
+  iu <- survival::coxph(survival::Surv(time, status) ~ rx + sex + rx:sex, data = cc)
+  expect_false(isTRUE(all.equal(got, stats::anova(au, iu)[["Pr(>|Chi|)"]][2])))
+})

--- a/tests/testthat/test-ggforest_subgroup.R
+++ b/tests/testthat/test-ggforest_subgroup.R
@@ -435,20 +435,27 @@ test_that("the tie handling carried is the model's own, not a same-named object 
   cc$rx <- droplevels(cc$rx)
   cc$sex <- factor(cc$sex, labels = c("F", "M"))
 
-  # `tie.method` exists only inside the wrapper: master looked it up in the
-  # calling frame and errored; it must resolve from the model's own environment
-  wrapper <- function(d, tie.method = "breslow") {
-    m <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = d,
-                         ties = tie.method)
-    survminer:::.subgroup_forest_table(m, d, "rx", c(Sex = "sex"),
-                                       conf.level = 0.95, show.overall = TRUE)
+  # the model is built inside a wrapper, so `tie.method` exists only in that
+  # wrapper's frame; the plot is then requested from HERE, where it does not.
+  # Resolving `ties` from the caller's frame would fail or find something else --
+  # it has to come from the model's own environment.
+  mk <- function(d, tie.method = "breslow") {
+    survival::coxph(survival::Surv(time, status) ~ rx + sex, data = d, ties = tie.method)
   }
-  tab <- wrapper(cc)
-  ref <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc,
-                         ties = "breslow")
+  m <- mk(cc)
+  tie.method <- "efron"          # a decoy visible from this frame
+  tab <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                            conf.level = 0.95, show.overall = TRUE)
   got <- tab$hr[tab$label == "Overall"]
   expect_length(got, 1L)
-  expect_equal(got, unname(exp(stats::coef(ref))[["rxLev+5FU"]]), tolerance = 1e-10)
+
+  br <- unname(exp(stats::coef(survival::coxph(
+    survival::Surv(time, status) ~ rx + sex, data = cc, ties = "breslow")))[["rxLev+5FU"]])
+  ef <- unname(exp(stats::coef(survival::coxph(
+    survival::Surv(time, status) ~ rx + sex, data = cc, ties = "efron")))[["rxLev+5FU"]])
+  expect_false(isTRUE(all.equal(br, ef, tolerance = 1e-9)))   # the two must differ
+  expect_equal(got, br, tolerance = 1e-10)
+  expect_false(isTRUE(all.equal(got, ef, tolerance = 1e-9)))
 })
 
 test_that("integer weights reproduce the same fit as replicating each row", {
@@ -479,4 +486,176 @@ test_that("integer weights reproduce the same fit as replicating each row", {
     expect_length(got, 1L)
     expect_equal(got, unname(exp(stats::coef(ref))[["rxLev+5FU"]]), tolerance = 1e-7)
   }
+})
+
+test_that("the Wald interaction test uses the right degrees of freedom", {
+  skip_if_not_installed("survival")
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc <- cc[!is.na(cc$differ), ]
+  cc$differ3 <- factor(cc$differ, labels = c("well", "mod", "poor"))
+  set.seed(9)
+  cc$w <- stats::runif(nrow(cc), 0.2, 3)          # non-integer -> robust variance
+
+  m <- survival::coxph(survival::Surv(time, status) ~ rx, data = cc, weights = w)
+  tab <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Diff = "differ3"),
+                                            conf.level = 0.95, show.overall = FALSE)
+  got <- tab$pint[tab$type == "header"]
+  got <- got[!is.na(got)]
+  expect_length(got, 1L)
+
+  i <- survival::coxph(survival::Surv(time, status) ~ rx + differ3 + rx:differ3,
+                       data = cc, weights = w)
+  k <- grep(":", names(stats::coef(i)), fixed = TRUE)
+  expect_equal(length(k), 2L)                     # a 3-level subgroup gives 2 df
+  b <- stats::coef(i)[k]
+  V <- stats::vcov(i)[k, k, drop = FALSE]
+  chi <- drop(t(b) %*% solve(V, b))
+  expect_equal(got, stats::pchisq(chi, df = 2, lower.tail = FALSE), tolerance = 1e-10)
+  # a df of 1 would be a different, smaller p-value
+  expect_false(isTRUE(all.equal(got, stats::pchisq(chi, df = 1, lower.tail = FALSE),
+                                tolerance = 1e-6)))
+})
+
+test_that("an unestimable interaction coefficient does not discard the whole test", {
+  skip_if_not_installed("survival")
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc <- cc[!is.na(cc$differ), ]
+  set.seed(9)
+  cc$w <- stats::runif(nrow(cc), 0.2, 3)
+  # a declared level with no rows leaves an aliased interaction coefficient
+  cc$dif4 <- factor(c("well", "mod", "poor")[cc$differ],
+                    levels = c("well", "mod", "poor", "EMPTY"))
+  cc$dif3 <- droplevels(cc$dif4)
+
+  m <- survival::coxph(survival::Surv(time, status) ~ rx, data = cc, weights = w)
+  t4 <- suppressWarnings(
+    survminer:::.subgroup_forest_table(m, cc, "rx", c(Diff = "dif4"),
+                                       conf.level = 0.95, show.overall = FALSE))
+  t3 <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Diff = "dif3"),
+                                           conf.level = 0.95, show.overall = FALSE)
+  g4 <- t4$pint[t4$type == "header"]; g4 <- g4[!is.na(g4)]
+  g3 <- t3$pint[t3$type == "header"]; g3 <- g3[!is.na(g3)]
+  expect_length(g4, 1L)                       # not NA, so the column survives
+  expect_length(g3, 1L)
+  expect_equal(g4, g3, tolerance = 1e-10)     # and equals the droplevels answer
+})
+
+test_that("weights survive rows the model dropped for missing covariates", {
+  skip_if_not_installed("survival")
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("F", "M"))
+  set.seed(9)
+  cc$w <- stats::runif(nrow(cc), 0.2, 3)
+  cc$nodes[1:12] <- NA                     # coxph drops these 12 rows
+  m <- survival::coxph(survival::Surv(time, status) ~ rx + nodes, data = cc, weights = w)
+  expect_lt(m$n, nrow(cc))                 # the fit really is short
+
+  # the weights must be put back on the right rows of the full frame
+  tab <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                            conf.level = 0.95, show.overall = TRUE)
+  got <- tab$hr[tab$label == "Overall"]
+  expect_length(got, 1L)
+  expect_equal(got, unname(exp(stats::coef(m))[["rxLev+5FU"]]), tolerance = 1e-10)
+})
+
+test_that("clustering that cannot be matched to data is an error", {
+  skip_if_not_installed("survival")
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("F", "M"))
+  m <- survival::coxph(survival::Surv(time, status) ~ rx + sex + cluster(id), data = cc)
+  expect_error(
+    survminer:::.subgroup_forest_table(m, cc[1:600, ], "rx", c(Sex = "sex"),
+                                       conf.level = 0.95, show.overall = TRUE),
+    "cluster"
+  )
+})
+
+test_that("an id-clustered model gets id-clustered intervals", {
+  skip_if_not_installed("survival")
+  set.seed(3)
+  ng <- 150
+  d <- data.frame(id = rep(seq_len(ng), each = 3))
+  d$rx  <- factor(rep(stats::rbinom(ng, 1, 0.5), each = 3), labels = c("Obs", "Trt"))
+  d$sex <- factor(rep(stats::rbinom(ng, 1, 0.5), each = 3), labels = c("F", "M"))
+  u <- rep(stats::rnorm(ng, 0, 0.8), each = 3)
+  d$t1 <- rep(c(0, 5, 10), ng)
+  d$t2 <- d$t1 + stats::rexp(nrow(d), exp(0.4 * (d$rx == "Trt") + u))
+  d$status <- 1L
+  m <- survival::coxph(survival::Surv(t1, t2, status) ~ rx + sex, data = d, id = id)
+
+  tab <- survminer:::.subgroup_forest_table(m, d, "rx", c(Sex = "sex"),
+                                            conf.level = 0.95, show.overall = TRUE)
+  ov <- tab[tab$label == "Overall", ]
+  expect_equal(nrow(ov), 1L)
+  expect_false(is.na(ov$hr))                       # rows must be estimable at all
+  ci <- exp(stats::confint(m))["rxTrt", ]
+  expect_equal(ov$lower, unname(ci[1]), tolerance = 1e-10)
+  expect_equal(ov$upper, unname(ci[2]), tolerance = 1e-10)
+  # and not the naive interval
+  naive <- exp(stats::coef(m)[["rxTrt"]] +
+               c(-1, 1) * stats::qnorm(0.975) * sqrt(diag(m$naive.var))[1])
+  expect_false(isTRUE(all.equal(ov$lower, naive[1], tolerance = 1e-8)))
+})
+
+test_that("a data frame reordered only within tied responses is caught by row count", {
+  skip_if_not_installed("survival")
+  # documented limit: the guard compares responses, so a swap between rows with
+  # identical time and status cannot be seen. This locks the documented scope.
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("F", "M"))
+  set.seed(9)
+  cc$w <- stats::runif(nrow(cc), 0.2, 3)
+  m <- survival::coxph(survival::Surv(time, status) ~ rx, data = cc, weights = w)
+  # a wholesale reorder IS caught
+  set.seed(1)
+  expect_error(
+    survminer:::.subgroup_forest_table(m, cc[sample(nrow(cc)), ], "rx", c(Sex = "sex"),
+                                       conf.level = 0.95, show.overall = TRUE),
+    "case weights"
+  )
+  # near-tied times must not trigger a false alarm (coxph's timefix snaps them)
+  d <- cc
+  d$time[2] <- d$time[1] + 1e-9
+  m2 <- survival::coxph(survival::Surv(time, status) ~ rx, data = d, weights = w)
+  expect_silent(
+    survminer:::.subgroup_forest_table(m2, d, "rx", c(Sex = "sex"),
+                                       conf.level = 0.95, show.overall = TRUE)
+  )
+})
+
+test_that("a model with no stored response cannot smuggle mismatched weights through", {
+  skip_if_not_installed("survival")
+  # y = FALSE means there is no response to check `data` against, so the weights
+  # cannot be shown to belong to these rows. That must be refused, not assumed.
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("F", "M"))
+  set.seed(9)
+  cc$w <- stats::runif(nrow(cc), 0.2, 3)
+  m <- survival::coxph(survival::Surv(time, status) ~ rx, data = cc,
+                       weights = w, y = FALSE)
+  expect_null(m$y)
+  set.seed(3)
+  expect_error(
+    survminer:::.subgroup_forest_table(m, cc[sample(nrow(cc)), ], "rx", c(Sex = "sex"),
+                                       conf.level = 0.95, show.overall = TRUE),
+    "case weights"
+  )
+  # and the in-order frame is refused too, since it still cannot be verified
+  expect_error(
+    survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                       conf.level = 0.95, show.overall = TRUE),
+    "case weights"
+  )
 })

--- a/tests/testthat/test-ggforest_subgroup.R
+++ b/tests/testthat/test-ggforest_subgroup.R
@@ -450,3 +450,33 @@ test_that("the tie handling carried is the model's own, not a same-named object 
   expect_length(got, 1L)
   expect_equal(got, unname(exp(stats::coef(ref))[["rxLev+5FU"]]), tolerance = 1e-10)
 })
+
+test_that("integer weights reproduce the same fit as replicating each row", {
+  skip_if_not_installed("survival")
+  # A frequency weight of w is, by definition, w copies of that row. This checks
+  # the weighted subgroup estimates against replication, which needs no second
+  # implementation to be believed.
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("F", "M"))
+  set.seed(9)
+  cc$iw <- sample(1:3, nrow(cc), replace = TRUE)
+
+  # breslow: replication manufactures tied event times, which efron handles
+  # differently from a weight (a known coxph difference, not one of ours)
+  m <- survival::coxph(survival::Surv(time, status) ~ rx + age, data = cc,
+                       weights = iw, ties = "breslow")
+  tab <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                            conf.level = 0.95, show.overall = TRUE)
+
+  for (lv in c("Overall", "F", "M")) {
+    d  <- if (lv == "Overall") cc else cc[cc$sex == lv, ]
+    ex <- d[rep(seq_len(nrow(d)), d$iw), ]
+    ref <- survival::coxph(survival::Surv(time, status) ~ rx + age, data = ex,
+                           ties = "breslow")
+    got <- tab$hr[tab$label == lv]
+    expect_length(got, 1L)
+    expect_equal(got, unname(exp(stats::coef(ref))[["rxLev+5FU"]]), tolerance = 1e-7)
+  }
+})

--- a/tests/testthat/test-ggforest_subgroup.R
+++ b/tests/testthat/test-ggforest_subgroup.R
@@ -351,51 +351,58 @@ test_that("the clustering of the model is carried into the refits", {
   expect_false(isTRUE(all.equal(ov$lower, naive[1], tolerance = 1e-8)))
 })
 
-test_that("a robust fit gets a Wald interaction test, an integer-weighted one keeps the LRT", {
+test_that("any weighted fit gets a Wald interaction test on a robust variance", {
   skip_if_not_installed("survival")
   cc <- survival::colon[survival::colon$etype == 2 &
                         survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
   cc$rx <- droplevels(cc$rx)
   cc$sex <- factor(cc$sex, labels = c("F", "M"))
   set.seed(9)
-  cc$w  <- stats::runif(nrow(cc), 0.2, 3)     # non-integer -> robust variance
-  cc$iw <- sample(1:3, nrow(cc), replace = TRUE)
+  cc$w  <- stats::runif(nrow(cc), 0.2, 3)         # non-integer
+  cc$iw <- sample(1:3, nrow(cc), replace = TRUE)  # integral
 
-  # --- robust (weighted) fit: Wald chi-square on the interaction coefficients
+  wald <- function(fit) {
+    k <- grep(":", names(stats::coef(fit)), fixed = TRUE)
+    k <- k[!is.na(stats::coef(fit)[k])]
+    b <- stats::coef(fit)[k]; V <- stats::vcov(fit)[k, k, drop = FALSE]
+    stats::pchisq(drop(t(b) %*% solve(V, b)), df = length(k), lower.tail = FALSE)
+  }
+  pint <- function(m) {
+    tb <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                            conf.level = 0.95, show.overall = TRUE)
+    g <- tb$pint[tb$type == "header"]
+    g[!is.na(g)]
+  }
+
+  # non-integer weights: coxph attaches the robust variance itself
   mw <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc, weights = w)
-  tw <- survminer:::.subgroup_forest_table(mw, cc, "rx", c(Sex = "sex"),
-                                           conf.level = 0.95, show.overall = TRUE)
-  got <- tw$pint[tw$type == "header"]
-  got <- got[!is.na(got)]
-  expect_length(got, 1L)
+  gw <- pint(mw)
+  expect_length(gw, 1L)
+  expect_equal(gw, wald(survival::coxph(
+    survival::Surv(time, status) ~ rx + sex + rx:sex, data = cc, weights = w)),
+    tolerance = 1e-10)
 
-  iw <- survival::coxph(survival::Surv(time, status) ~ rx + sex + rx:sex,
-                        data = cc, weights = w)
-  k <- grep(":", names(stats::coef(iw)), fixed = TRUE)
-  b <- stats::coef(iw)[k]
-  V <- stats::vcov(iw)[k, k, drop = FALSE]
-  ref <- stats::pchisq(drop(t(b) %*% solve(V, b)), df = length(k), lower.tail = FALSE)
-  expect_equal(got, ref, tolerance = 1e-10)
-
-  # it must NOT be the likelihood-ratio value, which is anticonservative here
-  a0 <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc,
-                        weights = w, robust = FALSE)
-  i0 <- survival::coxph(survival::Surv(time, status) ~ rx + sex + rx:sex, data = cc,
-                        weights = w, robust = FALSE)
-  lrt <- stats::anova(a0, i0)[["Pr(>|Chi|)"]][2]
-  expect_false(isTRUE(all.equal(got, lrt, tolerance = 1e-6)))
-
-  # --- integer (frequency) weights: variance stays model-based, LRT retained
+  # integral weights leave it model-based, but coxph cannot tell a count from a
+  # whole-numbered sampling weight, so the test must still be the robust Wald
   mi <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc, weights = iw)
-  ti <- survminer:::.subgroup_forest_table(mi, cc, "rx", c(Sex = "sex"),
-                                           conf.level = 0.95, show.overall = TRUE)
-  goti <- ti$pint[ti$type == "header"]
-  goti <- goti[!is.na(goti)]
-  expect_length(goti, 1L)
+  expect_null(mi$naive.var)
+  gi <- pint(mi)
+  expect_length(gi, 1L)
+  expect_equal(gi, wald(survival::coxph(
+    survival::Surv(time, status) ~ rx + sex + rx:sex, data = cc, weights = iw,
+    robust = TRUE)), tolerance = 1e-10)
+  # and NOT the likelihood-ratio value, which is only valid for true counts
   ai <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc, weights = iw)
   ii <- survival::coxph(survival::Surv(time, status) ~ rx + sex + rx:sex, data = cc,
                         weights = iw)
-  expect_equal(goti, stats::anova(ai, ii)[["Pr(>|Chi|)"]][2], tolerance = 1e-10)
+  expect_false(isTRUE(all.equal(gi, stats::anova(ai, ii)[["Pr(>|Chi|)"]][2],
+                                tolerance = 1e-6)))
+
+  # an unweighted fit keeps the likelihood-ratio test
+  mu <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc)
+  au <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc)
+  iu <- survival::coxph(survival::Surv(time, status) ~ rx + sex + rx:sex, data = cc)
+  expect_equal(pint(mu), stats::anova(au, iu)[["Pr(>|Chi|)"]][2], tolerance = 1e-10)
 })
 
 test_that("weights that cannot be matched to the rows of data are an error", {
@@ -657,5 +664,117 @@ test_that("a model with no stored response cannot smuggle mismatched weights thr
     survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
                                        conf.level = 0.95, show.overall = TRUE),
     "case weights"
+  )
+})
+
+test_that("the tie handling is carried whichever way the user spelled it", {
+  skip_if_not_installed("survival")
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("F", "M"))
+  cc$time <- round(cc$time / 365.25) * 365.25      # heavy ties, so it matters
+
+  br <- unname(exp(stats::coef(survival::coxph(
+    survival::Surv(time, status) ~ rx + sex, data = cc, ties = "breslow")))[["rxLev+5FU"]])
+  ef <- unname(exp(stats::coef(survival::coxph(
+    survival::Surv(time, status) ~ rx + sex, data = cc, ties = "efron")))[["rxLev+5FU"]])
+  expect_false(isTRUE(all.equal(br, ef, tolerance = 1e-6)))
+
+  # `method` is coxph's own alias for `ties`, recorded in the call under its own
+  # name -- reading the call would miss it entirely
+  for (m in list(survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc,
+                                 ties = "breslow"),
+                 survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc,
+                                 method = "breslow"))) {
+    tab <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                              conf.level = 0.95, show.overall = TRUE)
+    got <- tab$hr[tab$label == "Overall"]
+    expect_length(got, 1L)
+    expect_equal(got, br, tolerance = 1e-10)
+    expect_false(isTRUE(all.equal(got, ef, tolerance = 1e-6)))
+  }
+})
+
+test_that("a reconstruction that lost a fit setting is reported, not plotted quietly", {
+  skip_if_not_installed("survival")
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("F", "M"))
+
+  # `subset` is not carried, so refitting on all of `data` cannot reproduce the
+  # model -- that disagreement must reach the user
+  m <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc,
+                       subset = age < 60)
+  expect_warning(
+    survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                       conf.level = 0.95, show.overall = TRUE),
+    "treatment coefficient"
+  )
+  # a model with nothing lost must not warn
+  m2 <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc)
+  expect_silent(
+    survminer:::.subgroup_forest_table(m2, cc, "rx", c(Sex = "sex"),
+                                       conf.level = 0.95, show.overall = TRUE)
+  )
+})
+
+test_that("a wide time range does not make the guard reject the fitted data", {
+  skip_if_not_installed("survival")
+  # aeqSurv snaps near-tied times on an absolute budget of sqrt(eps) * the time
+  # range. Judged relatively, that snap is large next to a SMALL time in a widely
+  # spread dataset, so a relative tolerance rejects the very frame the model was
+  # fitted on. The comparison has to be made on the times' own scale.
+  n <- 400
+  set.seed(11)
+  d <- data.frame(
+    time   = c(1, 1 + 1e-6, seq(2, 5000, length.out = n - 2)),
+    status = stats::rbinom(n, 1, 0.7),
+    rx     = factor(rep(c("a", "b"), length.out = n)),
+    sex    = factor(rep(c("F", "M"), each = n / 2)),
+    w      = stats::runif(n, 0.5, 2)
+  )
+  m <- survival::coxph(survival::Surv(time, status) ~ rx, data = d, weights = w)
+  # the snap really did happen, and a relative comparison really does reject it
+  yd <- eval(stats::formula(m)[[2]], envir = d)
+  expect_false(isTRUE(all.equal(unclass(yd), unclass(m$y), check.attributes = FALSE)))
+  # yet this is the frame the model was fitted on, so it must be accepted
+  expect_true(survminer:::.data_is_fit_data(m, d))
+  expect_silent(
+    survminer:::.subgroup_forest_table(m, d, "rx", c(Sex = "sex"),
+                                       conf.level = 0.95, show.overall = TRUE)
+  )
+  # and a genuine reorder is still caught on the same data
+  set.seed(2)
+  expect_false(survminer:::.data_is_fit_data(m, d[sample(nrow(d)), ]))
+})
+
+test_that("too few clusters is flagged at run time", {
+  skip_if_not_installed("survival")
+  set.seed(5)
+  ng <- 12                                   # far below the fifty-cluster mark
+  d <- data.frame(ctr = factor(rep(seq_len(ng), each = 40)))
+  d$rx  <- factor(stats::rbinom(nrow(d), 1, 0.5), labels = c("Obs", "Trt"))
+  d$sex <- factor(stats::rbinom(nrow(d), 1, 0.5), labels = c("F", "M"))
+  u <- rep(stats::rnorm(ng, 0, 0.7), each = 40)
+  d$time <- stats::rexp(nrow(d), exp(0.4 * (d$rx == "Trt") + u))
+  d$status <- stats::rbinom(nrow(d), 1, 0.8)
+  m <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = d, cluster = ctr)
+  expect_warning(
+    survminer:::.subgroup_forest_table(m, d, "rx", c(Sex = "sex"),
+                                       conf.level = 0.95, show.overall = TRUE),
+    "12 clusters"
+  )
+  # a model with plenty of clusters must not warn
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("F", "M"))
+  m2 <- survival::coxph(survival::Surv(time, status) ~ rx + cluster(id), data = cc)
+  expect_gt(length(unique(cc$id)), 50L)
+  expect_silent(
+    survminer:::.subgroup_forest_table(m2, cc, "rx", c(Sex = "sex"),
+                                       conf.level = 0.95, show.overall = TRUE)
   )
 })

--- a/tests/testthat/test-ggforest_subgroup.R
+++ b/tests/testthat/test-ggforest_subgroup.R
@@ -256,7 +256,7 @@ test_that("a model covariate named like the carried weights is not clobbered", {
   m <- survival::coxph(
     survival::Surv(time, status) ~ rx + .ggf_weights, data = cc, weights = w
   )
-  tab <- .subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+  tab <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
                                 conf.level = 0.95, show.overall = TRUE)
 
   got <- tab$hr[tab$label == "Overall"]
@@ -275,7 +275,7 @@ test_that("a model covariate named like the carried weights is not clobbered", {
   }
 })
 
-test_that("the interaction p-value is computed on the weighted fit too", {
+test_that("the interaction p-value is computed on the weighted fit, not an unweighted one", {
   cc <- survival::colon[survival::colon$etype == 2 &
                           survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
   cc$rx  <- droplevels(cc$rx)
@@ -286,19 +286,167 @@ test_that("the interaction p-value is computed on the weighted fit too", {
   tab <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
                                             conf.level = 0.95, show.overall = TRUE)
   got <- tab$pint[tab$type == "header" & !is.na(tab$pint)][1]
-
-  # the likelihood-ratio test does not use the variance estimator, so the
-  # comparison fits are made without the robust variance coxph() adds to a
-  # weighted fit (which anova() refuses outright)
-  a <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc,
-                       weights = w, robust = FALSE)
-  i <- survival::coxph(survival::Surv(time, status) ~ rx + sex + rx:sex, data = cc,
-                       weights = w, robust = FALSE)
-  ref <- stats::anova(a, i)[["Pr(>|Chi|)"]][2]
   expect_false(is.na(got))
-  expect_equal(got, ref, tolerance = 1e-8)
+
+  # the weighted fit carries a robust variance, so the test is a Wald
+  # chi-square on the interaction coefficients taken from it
+  i <- survival::coxph(survival::Surv(time, status) ~ rx + sex + rx:sex, data = cc,
+                       weights = w)
+  k <- grep(":", names(stats::coef(i)), fixed = TRUE)
+  b <- stats::coef(i)[k]
+  V <- stats::vcov(i)[k, k, drop = FALSE]
+  ref <- stats::pchisq(drop(t(b) %*% solve(V, b)), df = length(k), lower.tail = FALSE)
+  expect_equal(got, ref, tolerance = 1e-10)
+
   # and it is not the unweighted value
   au <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc)
   iu <- survival::coxph(survival::Surv(time, status) ~ rx + sex + rx:sex, data = cc)
   expect_false(isTRUE(all.equal(got, stats::anova(au, iu)[["Pr(>|Chi|)"]][2])))
+})
+
+test_that("a robust = TRUE model gets robust intervals in every row", {
+  skip_if_not_installed("survival")
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("F", "M"))
+  m <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc,
+                       robust = TRUE)
+  tab <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                            conf.level = 0.95, show.overall = TRUE)
+  ci <- exp(stats::confint(m))["rxLev+5FU", ]
+  ov <- tab[tab$label == "Overall", ]
+  expect_equal(nrow(ov), 1L)
+  expect_equal(ov$lower, unname(ci[1]), tolerance = 1e-10)
+  expect_equal(ov$upper, unname(ci[2]), tolerance = 1e-10)
+
+  for (lv in c("F", "M")) {
+    ref <- survival::coxph(survival::Surv(time, status) ~ rx, data = cc[cc$sex == lv, ],
+                           robust = TRUE)
+    rci <- exp(stats::confint(ref))["rxLev+5FU", ]
+    row <- tab[tab$label == lv, ]
+    expect_equal(nrow(row), 1L)
+    expect_equal(row$lower, unname(rci[1]), tolerance = 1e-10)
+    expect_equal(row$upper, unname(rci[2]), tolerance = 1e-10)
+  }
+})
+
+test_that("the clustering of the model is carried into the refits", {
+  skip_if_not_installed("survival")
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("F", "M"))
+  m <- survival::coxph(survival::Surv(time, status) ~ rx + sex + cluster(id), data = cc)
+  tab <- survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                            conf.level = 0.95, show.overall = TRUE)
+  ci <- exp(stats::confint(m))["rxLev+5FU", ]
+  ov <- tab[tab$label == "Overall", ]
+  expect_equal(nrow(ov), 1L)
+  # cluster-robust, not the naive interval
+  expect_equal(ov$lower, unname(ci[1]), tolerance = 1e-10)
+  expect_equal(ov$upper, unname(ci[2]), tolerance = 1e-10)
+  naive <- exp(stats::coef(m)[["rxLev+5FU"]] +
+               c(-1, 1) * stats::qnorm(0.975) * sqrt(diag(m$naive.var))[1])
+  expect_false(isTRUE(all.equal(ov$lower, naive[1], tolerance = 1e-8)))
+})
+
+test_that("a robust fit gets a Wald interaction test, an integer-weighted one keeps the LRT", {
+  skip_if_not_installed("survival")
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("F", "M"))
+  set.seed(9)
+  cc$w  <- stats::runif(nrow(cc), 0.2, 3)     # non-integer -> robust variance
+  cc$iw <- sample(1:3, nrow(cc), replace = TRUE)
+
+  # --- robust (weighted) fit: Wald chi-square on the interaction coefficients
+  mw <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc, weights = w)
+  tw <- survminer:::.subgroup_forest_table(mw, cc, "rx", c(Sex = "sex"),
+                                           conf.level = 0.95, show.overall = TRUE)
+  got <- tw$pint[tw$type == "header"]
+  got <- got[!is.na(got)]
+  expect_length(got, 1L)
+
+  iw <- survival::coxph(survival::Surv(time, status) ~ rx + sex + rx:sex,
+                        data = cc, weights = w)
+  k <- grep(":", names(stats::coef(iw)), fixed = TRUE)
+  b <- stats::coef(iw)[k]
+  V <- stats::vcov(iw)[k, k, drop = FALSE]
+  ref <- stats::pchisq(drop(t(b) %*% solve(V, b)), df = length(k), lower.tail = FALSE)
+  expect_equal(got, ref, tolerance = 1e-10)
+
+  # it must NOT be the likelihood-ratio value, which is anticonservative here
+  a0 <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc,
+                        weights = w, robust = FALSE)
+  i0 <- survival::coxph(survival::Surv(time, status) ~ rx + sex + rx:sex, data = cc,
+                        weights = w, robust = FALSE)
+  lrt <- stats::anova(a0, i0)[["Pr(>|Chi|)"]][2]
+  expect_false(isTRUE(all.equal(got, lrt, tolerance = 1e-6)))
+
+  # --- integer (frequency) weights: variance stays model-based, LRT retained
+  mi <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc, weights = iw)
+  ti <- survminer:::.subgroup_forest_table(mi, cc, "rx", c(Sex = "sex"),
+                                           conf.level = 0.95, show.overall = TRUE)
+  goti <- ti$pint[ti$type == "header"]
+  goti <- goti[!is.na(goti)]
+  expect_length(goti, 1L)
+  ai <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc, weights = iw)
+  ii <- survival::coxph(survival::Surv(time, status) ~ rx + sex + rx:sex, data = cc,
+                        weights = iw)
+  expect_equal(goti, stats::anova(ai, ii)[["Pr(>|Chi|)"]][2], tolerance = 1e-10)
+})
+
+test_that("weights that cannot be matched to the rows of data are an error", {
+  skip_if_not_installed("survival")
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("F", "M"))
+  set.seed(9)
+  cc$w <- stats::runif(nrow(cc), 0.2, 3)
+  m <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc, weights = w)
+
+  # a reordered data frame would attach each weight to the wrong subject
+  set.seed(1)
+  expect_error(
+    survminer:::.subgroup_forest_table(m, cc[sample(nrow(cc)), ], "rx", c(Sex = "sex"),
+                                       conf.level = 0.95, show.overall = TRUE),
+    "case weights"
+  )
+  # so would a different number of rows
+  expect_error(
+    survminer:::.subgroup_forest_table(m, cc[1:600, ], "rx", c(Sex = "sex"),
+                                       conf.level = 0.95, show.overall = TRUE),
+    "case weights"
+  )
+  # the matching data frame is fine
+  expect_silent(
+    survminer:::.subgroup_forest_table(m, cc, "rx", c(Sex = "sex"),
+                                       conf.level = 0.95, show.overall = TRUE)
+  )
+})
+
+test_that("the tie handling carried is the model's own, not a same-named object in scope", {
+  skip_if_not_installed("survival")
+  cc <- survival::colon[survival::colon$etype == 2 &
+                        survival::colon$rx %in% c("Obs", "Lev+5FU"), ]
+  cc$rx <- droplevels(cc$rx)
+  cc$sex <- factor(cc$sex, labels = c("F", "M"))
+
+  # `tie.method` exists only inside the wrapper: master looked it up in the
+  # calling frame and errored; it must resolve from the model's own environment
+  wrapper <- function(d, tie.method = "breslow") {
+    m <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = d,
+                         ties = tie.method)
+    survminer:::.subgroup_forest_table(m, d, "rx", c(Sex = "sex"),
+                                       conf.level = 0.95, show.overall = TRUE)
+  }
+  tab <- wrapper(cc)
+  ref <- survival::coxph(survival::Surv(time, status) ~ rx + sex, data = cc,
+                         ties = "breslow")
+  got <- tab$hr[tab$label == "Overall"]
+  expect_length(got, 1L)
+  expect_equal(got, unname(exp(stats::coef(ref))[["rxLev+5FU"]]), tolerance = 1e-10)
 })


### PR DESCRIPTION
`ggforest_subgroup()` gets each subgroup hazard ratio by refitting the Cox model on
that subset, but the refit was a plain `coxph()`: the case weights, tie handling and
clustering of the supplied model were dropped. A weighted model reported unweighted
subgroup estimates, and a clustered model drew intervals from the naive variance.

Those settings are now carried into every refit. Weights and clustering ride along as
data columns so subsetting the data subsets them too, and both are read from the fitted
object rather than re-evaluated from its call.

The interaction test is affected the same way, and it cannot simply be refit weighted:
`coxph()` attaches a robust variance to any non-integer weighted fit, and `anova()`
declines to compare likelihoods for such a fit because their differences are no longer
chi-square. A fit carrying a robust variance now gets a Wald chi-square on the
treatment-by-subgroup coefficients instead; everything else, integer weights included,
keeps the likelihood-ratio test.

A `data` whose rows cannot be matched to the fit is now refused when weights or
clustering have to be carried across.

```r
library(survminer)
library(survival)

cc <- colon[colon$etype == 2 & colon$rx %in% c("Obs", "Lev+5FU"), ]
cc$rx    <- droplevels(cc$rx)
cc$sex   <- factor(cc$sex, labels = c("Female", "Male"))
cc$node4 <- factor(cc$node4, labels = c("<= 4 nodes", "> 4 nodes"))

set.seed(9)
cc$w <- runif(nrow(cc), 0.2, 3)          # inverse-probability weights

m <- coxph(Surv(time, status) ~ rx + age, data = cc, weights = w)

ggforest_subgroup(m, data = cc, treatment = "rx",
                  subgroups = c(Sex = "sex", Nodes = "node4"))
```

Before — the refits ignore the weights:

![Subgroup forest plot with overall HR 0.69 and Female 0.87 (0.63-1.19)](https://i.imgur.com/8WlVoNG.png)

After — the overall row reproduces `exp(coef(m))["rxLev+5FU"]` = 0.70, and the female
subgroup moves from an apparent 13% reduction to exactly no effect:

![The same plot with overall HR 0.70 and Female 1.00 (0.70-1.44)](https://i.imgur.com/ye54IOm.png)

Models specifying none of weights, ties, robust or clustering are unchanged.
